### PR TITLE
[CDAP-21163] Reduce ApplicationSpecification size when storing in the Cloud Spanner Table

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/ApplicationSpecificationCodec.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/ApplicationSpecificationCodec.java
@@ -40,7 +40,7 @@ import java.util.Map;
 /**
  * TODO: Move to cdap-proto
  */
-final class ApplicationSpecificationCodec extends
+public final class ApplicationSpecificationCodec extends
     AbstractSpecificationCodec<ApplicationSpecification> {
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -40,10 +40,12 @@ import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppMetaStore;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
+import io.cdap.cdap.internal.app.store.adapters.ApplicationMetaAdapter;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.ProgramRunCluster;
 import io.cdap.cdap.proto.ProgramRunClusterStatus;
@@ -163,6 +165,7 @@ public class AppMetadataStore {
       ProgramType.WORKER);
 
   private final StructuredTableContext context;
+  private final boolean appSpecReductionEnabled;
   private StructuredTable applicationSpecificationTable;
   private StructuredTable applicationEditTable;
   private StructuredTable workflowNodeStateTable;
@@ -170,6 +173,8 @@ public class AppMetadataStore {
   private StructuredTable workflowsTable;
   private StructuredTable programCountsTable;
   private StructuredTable subscriberStateTable;
+  private StructuredTable pluginDataTable;
+  private StructuredTable universalPluginDataTable;
 
   /**
    * Static method for creating an instance of {@link AppMetadataStore}.
@@ -180,6 +185,8 @@ public class AppMetadataStore {
 
   private AppMetadataStore(StructuredTableContext context) {
     this.context = context;
+    this.appSpecReductionEnabled = AppMetaStore.APPSPEC_REDUCTION_SUPPORTED_STORAGE_PROVIDERS.contains(
+        context.getStorageProvider());
   }
 
   private StructuredTable getApplicationSpecificationTable() {
@@ -259,6 +266,29 @@ public class AppMetadataStore {
       throw new RuntimeException(e);
     }
     return subscriberStateTable;
+  }
+
+  @VisibleForTesting
+  StructuredTable getPluginDataTable() {
+    try {
+      if (pluginDataTable == null) {
+        pluginDataTable = context.getTable(StoreDefinition.ArtifactStore.PLUGIN_DATA_TABLE);
+      }
+    } catch (TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return pluginDataTable;
+  }
+
+  private StructuredTable getUniversalPluginDataTable() {
+    try {
+      if (universalPluginDataTable == null) {
+        universalPluginDataTable = context.getTable(StoreDefinition.ArtifactStore.UNIV_PLUGIN_DATA_TABLE);
+      }
+    } catch (TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return universalPluginDataTable;
   }
 
   /**
@@ -360,7 +390,8 @@ public class AppMetadataStore {
       boolean keepScanning = true;
       while (iterator.hasNext() && keepScanning && limit > 0) {
         StructuredRow row = iterator.next();
-        AppScanEntry scanEntry = new AppScanEntry(row);
+        AppScanEntry scanEntry = new AppScanEntry(row, getPluginDataTable(),
+            getUniversalPluginDataTable(), appSpecReductionEnabled);
         if (scanEntryPredicate.test(scanEntry)) {
           keepScanning = func.apply(scanEntry);
           limit--;
@@ -734,10 +765,10 @@ public class AppMetadataStore {
   void writeApplication(String namespaceId, String appId, String versionId,
       ApplicationSpecification spec, @Nullable ChangeDetail change,
       @Nullable SourceControlMeta sourceControlMeta, boolean markAsLatest) throws IOException {
+    ApplicationMeta meta = new ApplicationMeta(appId, spec, null, null);
+    String json = ApplicationMetaAdapter.toJson(meta, appSpecReductionEnabled);
     writeApplicationSerialized(namespaceId, appId, versionId,
-        GSON.toJson(
-            new ApplicationMeta(appId, spec, null, null)),
-        change, sourceControlMeta, markAsLatest);
+        json, change, sourceControlMeta, markAsLatest);
     updateApplicationEdit(namespaceId, appId);
   }
 
@@ -814,8 +845,9 @@ public class AppMetadataStore {
     }
     // creation time cannot be null  - will be written to app-spec but won't be added to table
     ApplicationMeta updated = new ApplicationMeta(existing.getId(), spec, null);
+    String json = ApplicationMetaAdapter.toJson(updated, appSpecReductionEnabled);
     updateApplicationSerialized(appId.getNamespace(), appId.getApplication(), appId.getVersion(),
-        GSON.toJson(updated));
+        json);
   }
 
   /**
@@ -2632,6 +2664,7 @@ public class AppMetadataStore {
     deleteTable(getProgramCountsTable(), StoreDefinition.AppMetadataStore.COUNT_TYPE);
     deleteTable(getSubscriberStateTable(), StoreDefinition.AppMetadataStore.SUBSCRIBER_TOPIC);
     deleteTable(getApplicationEditTable(), StoreDefinition.AppMetadataStore.NAMESPACE_FIELD);
+    deleteTable(getPluginDataTable(), StoreDefinition.ArtifactStore.PARENT_NAMESPACE_FIELD);
   }
 
   private void deleteTable(StructuredTable table, String firstKey) throws IOException {
@@ -2816,9 +2849,12 @@ public class AppMetadataStore {
     String changeSummary = row.getString(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD);
     Long creationTimeMillis = row.getLong(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD);
     Boolean latest = row.getBoolean(StoreDefinition.AppMetadataStore.LATEST_FIELD);
-    ApplicationMeta meta = GSON.fromJson(
+    String namespace = row.getString(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD);
+
+    ApplicationMeta meta = ApplicationMetaAdapter.fromJson(
         row.getString(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD),
-        ApplicationMeta.class);
+        ApplicationMeta.class, namespace, appSpecReductionEnabled,
+        getPluginDataTable(), getUniversalPluginDataTable());
     SourceControlMeta sourceControl = GSON.fromJson(
         row.getString(StoreDefinition.AppMetadataStore.SOURCE_CONTROL_META),
         SourceControlMeta.class);
@@ -3085,9 +3121,16 @@ public class AppMetadataStore {
     private final ChangeDetail changeDetail;
     @Nullable
     private final SourceControlMeta sourceControlMeta;
+    private final StructuredTable pluginDataTable;
+    private final StructuredTable universalPluginDataTable;
+    private final boolean appSpecReductionEnabled;
 
-    private AppScanEntry(StructuredRow row) {
+    private AppScanEntry(StructuredRow row, StructuredTable pluginDataTable,
+        StructuredTable universalPluginDataTable, boolean appSpecReductionEnabled) {
       this.appId = getApplicationIdFromRow(row);
+      this.pluginDataTable = pluginDataTable;
+      this.universalPluginDataTable = universalPluginDataTable;
+      this.appSpecReductionEnabled = appSpecReductionEnabled;
       this.rawAppMeta = row.getString(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD);
       String author = row.getString(StoreDefinition.AppMetadataStore.AUTHOR_FIELD);
       String changeSummary = row.getString(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD);
@@ -3116,7 +3159,9 @@ public class AppMetadataStore {
       if (meta != null) {
         return meta;
       }
-      ApplicationMeta tempMeta = GSON.fromJson(rawAppMeta, ApplicationMeta.class);
+      ApplicationMeta tempMeta = ApplicationMetaAdapter.fromJson(
+          rawAppMeta, ApplicationMeta.class, appId.getNamespace(),
+          appSpecReductionEnabled, pluginDataTable, universalPluginDataTable);
       appMeta = meta = new ApplicationMeta(tempMeta.getId(), tempMeta.getSpec(), changeDetail,
           sourceControlMeta);
       return meta;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
@@ -37,8 +37,8 @@ public class ApplicationMeta {
   @Nullable
   private final SourceControlMeta sourceControlMeta;
 
-  public ApplicationMeta(String id, ApplicationSpecification spec,
-      @Nullable ChangeDetail change, @Nullable SourceControlMeta sourceControlMeta) {
+  public ApplicationMeta(String id, ApplicationSpecification spec, @Nullable ChangeDetail change,
+      @Nullable SourceControlMeta sourceControlMeta) {
     this.id = id;
     this.spec = spec;
     this.change = change;
@@ -75,5 +75,25 @@ public class ApplicationMeta {
         .add("change", change)
         .add("sourceControlMeta", sourceControlMeta)
         .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApplicationMeta)) {
+      return false;
+    }
+    ApplicationMeta that = (ApplicationMeta) o;
+    return Objects.equal(id, that.id)
+        && Objects.equal(spec, that.spec)
+        && Objects.equal(change, that.change)
+        && Objects.equal(sourceControlMeta, that.sourceControlMeta);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, spec, change, sourceControlMeta);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContext.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.internal.app.runtime.plugin.PluginNotExistsException;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.store.StoreDefinition.ArtifactStore;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
+
+/**
+ * Provides context for deserializing an {@code ApplicationSpecification}, primarily for resolving
+ * and loading {@link PluginClass} instances. It holds the current namespace, caches loaded plugins,
+ * and allows an outer deserializer to set parent artifact details (name and namespace) used for
+ * plugin resolution.
+ */
+public class AppSpecDeserializationContext {
+
+  private static final Gson GSON = new Gson();
+  private ArtifactId rootArtifact;
+  private final String namespace;
+  private final StructuredTable pluginDataTable;
+  private final StructuredTable universalPluginDataTable;
+  private final LoadingCache<PluginKey, PluginClass> pluginCache;
+
+  /**
+   * Constructs a context for deserializing an Application Specification.
+   *
+   * @param namespace                The current application's namespace.
+   * @param pluginDataTable          Table for loading plugin data.
+   * @param universalPluginDataTable Table for loading universal plugins.
+   */
+  public AppSpecDeserializationContext(String namespace, StructuredTable pluginDataTable,
+      StructuredTable universalPluginDataTable) {
+    this.namespace = namespace;
+    this.pluginDataTable = pluginDataTable;
+    this.universalPluginDataTable = universalPluginDataTable;
+    this.pluginCache = CacheBuilder.newBuilder().maximumSize(10)
+        .build(new CacheLoader<PluginKey, PluginClass>() {
+          @Override
+          @Nonnull
+          public PluginClass load(@Nonnull PluginKey pluginKey) throws PluginNotExistsException {
+            return loadPlugin(pluginKey);
+          }
+        });
+  }
+
+  private PluginClass loadPlugin(PluginKey pluginKey) throws PluginNotExistsException {
+    PluginClass pluginClass = null;
+    Optional<StructuredRow> row = fetchFromPluginDataTable(pluginKey);
+    if (!row.isPresent()) {
+      row = fetchFromUniversalPluginDataTable(pluginKey);
+      if (!row.isPresent()) {
+        throw new PluginNotExistsException(
+            new io.cdap.cdap.proto.id.ArtifactId(pluginKey.getParentNamespace(),
+                pluginKey.getArtifactName(), pluginKey.getArtifactVersion()),
+            pluginKey.getPluginType(), pluginKey.getPluginName());
+      }
+    }
+    String rawPluginData = row.get().getString(ArtifactStore.PLUGIN_DATA_FIELD);
+    if (rawPluginData != null) {
+      JsonObject pluginDataObject = new JsonParser().parse(rawPluginData).getAsJsonObject();
+      if (pluginDataObject.has("pluginClass") && pluginDataObject.get("pluginClass")
+          .isJsonObject()) {
+        pluginClass = GSON.fromJson(pluginDataObject.getAsJsonObject("pluginClass"),
+            PluginClass.class);
+      }
+    }
+    if (pluginClass == null) {
+      throw new RuntimeException("Failed to deserialize PluginClass from data for key: " + pluginKey
+          + ". Raw data might be missing or malformed.");
+    }
+    return pluginClass;
+  }
+
+  private Optional<StructuredRow> fetchFromPluginDataTable(PluginKey pluginKey) {
+    if (pluginKey.getParentName() == null || pluginKey.getParentName().isEmpty()) {
+      // For such scenarios, we need to fetch plugin data from universal plugin data table.
+      return Optional.empty();
+    }
+    Collection<Field<?>> fields = new ArrayList<>();
+    fields.add(
+        Fields.stringField(ArtifactStore.PARENT_NAMESPACE_FIELD, pluginKey.getParentNamespace()));
+    fields.add(Fields.stringField(ArtifactStore.PARENT_NAME_FIELD, pluginKey.getParentName()));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_TYPE_FIELD, pluginKey.getPluginType()));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_NAME_FIELD, pluginKey.getPluginName()));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAMESPACE_FIELD,
+        pluginKey.getArtifactNamespace()));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAME_FIELD, pluginKey.getArtifactName()));
+    fields.add(
+        Fields.stringField(ArtifactStore.ARTIFACT_VER_FIELD, pluginKey.getArtifactVersion()));
+    try {
+      return pluginDataTable.read(fields);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to read from plugin data table for key: " + pluginKey, e);
+    }
+  }
+
+  private Optional<StructuredRow> fetchFromUniversalPluginDataTable(PluginKey pluginKey) {
+    Collection<Field<?>> fields = new ArrayList<>();
+    fields.add(Fields.stringField(ArtifactStore.NAMESPACE_FIELD, namespace));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_TYPE_FIELD, pluginKey.getPluginType()));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_NAME_FIELD, pluginKey.getPluginName()));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAMESPACE_FIELD,
+        pluginKey.getArtifactNamespace()));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAME_FIELD, pluginKey.getArtifactName()));
+    fields.add(
+        Fields.stringField(ArtifactStore.ARTIFACT_VER_FIELD, pluginKey.getArtifactVersion()));
+    try {
+      return universalPluginDataTable.read(fields);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to read from universal plugin data table for key: " + pluginKey, e);
+    }
+  }
+
+  /**
+   * Gets the primary namespace for the current deserialization.
+   *
+   * @return The namespace string.
+   */
+  public String getNamespace() {
+    return namespace;
+  }
+
+  /**
+   * Gets the root artifact, set externally.
+   */
+  public ArtifactId getRootArtifact() {
+    return rootArtifact;
+  }
+
+  /**
+   * Sets the root artifact for plugin resolution context.
+   */
+  public void setRootArtifact(ArtifactId rootArtifact) {
+    this.rootArtifact = rootArtifact;
+  }
+
+  /**
+   * Retrieves the {@link PluginClass} for the given key, using an internal cache.
+   *
+   * @param pluginKey Key identifying the plugin.
+   * @return The resolved {@link PluginClass}.
+   * @throws RuntimeException if the plugin cannot be loaded.
+   */
+  public PluginClass getPlugin(PluginKey pluginKey) throws PluginNotExistsException {
+    try {
+      return this.pluginCache.get(pluginKey);
+    } catch (ExecutionException | UncheckedExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof PluginNotExistsException) {
+        // cache.get() method wraps the PluginNotExistsException with Execution exception.
+        // Hence, we need to explicitly re-throw the PluginNotExistsException here.
+        throw (PluginNotExistsException) cause;
+      }
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new RuntimeException("Failed to load plugin class for " + pluginKey, cause);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContextHolder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContextHolder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds the {@link AppSpecDeserializationContext} for the current thread's deserialization
+ * operation. Ensures context is cleared after use.
+ */
+public final class AppSpecDeserializationContextHolder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      AppSpecDeserializationContextHolder.class);
+  private static final ThreadLocal<AppSpecDeserializationContext> CURRENT_CONTEXT = new ThreadLocal<>();
+
+  private AppSpecDeserializationContextHolder() {
+  }
+
+  /**
+   * Sets the context for the current thread. Should be called before deserialization.
+   */
+  public static void setContext(AppSpecDeserializationContext context) {
+    if (CURRENT_CONTEXT.get() != null) {
+      LOG.warn("Overwriting existing AppSpecDeserializationContext on thread {}. "
+              + "This might indicate a missing clearContext() call from a previous operation.",
+          Thread.currentThread().getName());
+    }
+    CURRENT_CONTEXT.set(context);
+  }
+
+  /**
+   * Gets the context for the current thread.
+   *
+   * @throws IllegalStateException if no context is set.
+   */
+  public static AppSpecDeserializationContext getContext() {
+    AppSpecDeserializationContext context = CURRENT_CONTEXT.get();
+    if (context == null) {
+      throw new IllegalStateException(
+          "AppSpecDeserializationContext has not been set for the current deserialization operation on this thread.");
+    }
+    return context;
+  }
+
+  /**
+   * Clears the context for the current thread. Must be called in a finally block.
+   */
+  public static void clearContext() {
+    CURRENT_CONTEXT.remove();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaAdapter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaAdapter.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.internal.app.ApplicationSpecificationCodec;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
+import io.cdap.cdap.spi.data.StructuredTable;
+import javax.annotation.Nullable;
+
+/**
+ * Manages Gson instances specifically configured for ApplicationMeta serialization and
+ * deserialization, handling application specification reduction. This ensures thread-safe
+ * operations by managing the {@link AppSpecDeserializationContext} lifecycle per operation via
+ * {@link AppSpecDeserializationContextHolder}. It uses a static cache for Gson instances based on
+ * the {@code appSpecReductionEnabled} flag.
+ */
+public final class ApplicationMetaAdapter {
+
+  private static final Gson GSON_INSTANCE_REDUCTION_ENABLED = buildGsonInternal(true);
+  private static final Gson GSON_INSTANCE_REDUCTION_DISABLED = buildGsonInternal(false);
+
+  private ApplicationMetaAdapter() {
+  }
+
+  /**
+   * Deserializes a JSON string to an object of the specified class, managing the
+   * {@link AppSpecDeserializationContext} lifecycle via
+   * {@link AppSpecDeserializationContextHolder}.
+   */
+  public static <T> T fromJson(String jsonString, Class<T> classOfT, String namespace,
+      boolean appSpecReductionEnabled, StructuredTable pluginDataTable,
+      @Nullable StructuredTable universalPluginDataTable) {
+    AppSpecDeserializationContext operationContext = new AppSpecDeserializationContext(namespace,
+        pluginDataTable, universalPluginDataTable);
+    AppSpecDeserializationContextHolder.setContext(operationContext);
+    try {
+      Gson gson = getGson(appSpecReductionEnabled);
+      return gson.fromJson(jsonString, classOfT);
+    } finally {
+      AppSpecDeserializationContextHolder.clearContext();
+    }
+  }
+
+  /**
+   * Serializes an object to its JSON representation.
+   */
+  public static String toJson(Object objectToSerialize, boolean appSpecReductionEnabled) {
+    Gson gson = getGson(appSpecReductionEnabled);
+    // No need to set / get the AppSpecDeserialization context in case of serialization.
+    return gson.toJson(objectToSerialize);
+  }
+
+  private static Gson buildGsonInternal(boolean appSpecReductionEnabled) {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+
+    if (appSpecReductionEnabled) {
+      gsonBuilder.registerTypeAdapter(ApplicationMeta.class, new ApplicationMetaCodec());
+      gsonBuilder.registerTypeAdapter(PluginClass.class, new PluginClassSerializer());
+      gsonBuilder.registerTypeAdapter(Plugin.class, new PluginDeserializer());
+      gsonBuilder.registerTypeHierarchyAdapter(ApplicationSpecification.class,
+          new ApplicationSpecificationCodec());
+    }
+    // This adds other necessary adapters for ApplicationSpecification internals (schemas, etc.)
+    ApplicationSpecificationAdapter.addTypeAdapters(gsonBuilder);
+
+    return gsonBuilder.create();
+  }
+
+  /**
+   * Gets a pre-configured, cached, and thread-safe Gson instance.
+   *
+   * @param conf Configuration map, used to determine if app spec reduction is enabled.
+   * @return A shared Gson instance.
+   */
+  private static Gson getGson(boolean appSpecReductionEnabled) {
+    if (appSpecReductionEnabled) {
+      return GSON_INSTANCE_REDUCTION_ENABLED;
+    }
+    return GSON_INSTANCE_REDUCTION_DISABLED;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaCodec.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaCodec.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
+import java.lang.reflect.Type;
+
+/**
+ * Helper class to encode/decode {@link ApplicationMetaCodec} to/from json.
+ */
+public class ApplicationMetaCodec implements JsonSerializer<ApplicationMeta>,
+    JsonDeserializer<ApplicationMeta> {
+
+  /**
+   * Serializes an {@link ApplicationMeta} object to its JSON representation. Includes the
+   * application ID and its specification.
+   */
+  @Override
+  public JsonElement serialize(ApplicationMeta src, Type typeOfSrc,
+      JsonSerializationContext context) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("id", src.getId());
+
+    JsonElement specJson = context.serialize(src.getSpec());
+    jsonObject.add("spec", specJson);
+
+    return jsonObject;
+  }
+
+  /**
+   * Deserializes a JSON element into an {@link ApplicationMeta} object. It extracts the
+   * application's {@link ArtifactId} from its specification JSON to set the parent name and
+   * namespace in the shared {@link AppSpecDeserializationContext}. This enables correct resolution
+   * of plugins within the application's scope.
+   *
+   * @throws JsonParseException If JSON is malformed or required fields are missing.
+   */
+  @Override
+  public ApplicationMeta deserialize(JsonElement json, Type typeOfT,
+      JsonDeserializationContext context) throws JsonParseException {
+    AppSpecDeserializationContext appSpecDeserializationContext = AppSpecDeserializationContextHolder.getContext();
+    JsonObject jsonObject = json.getAsJsonObject();
+
+    JsonElement idElement = jsonObject.get("id");
+    if (idElement == null || idElement.isJsonNull()) {
+      throw new JsonParseException("ApplicationMeta 'id' field is missing or null");
+    }
+    String id = idElement.getAsString();
+
+    JsonObject specJson = jsonObject.getAsJsonObject("spec");
+    if (specJson == null || specJson.isJsonNull()) {
+      throw new JsonParseException("ApplicationMeta 'spec' field is missing or null for id: " + id);
+    }
+
+    // Set parent context before fully deserializing the AppSpec,
+    // so plugins can be retrieved from DB using this parent information.
+    JsonElement artifactIdJson = specJson.get("artifactId");
+    if (artifactIdJson != null && !artifactIdJson.isJsonNull()) {
+      ArtifactId artifactId = context.deserialize(artifactIdJson, ArtifactId.class);
+      if (artifactId != null) {
+        appSpecDeserializationContext.setRootArtifact(artifactId);
+      } else {
+        throw new JsonParseException(
+            "ArtifactId in ApplicationSpecification was null for app: " + id);
+      }
+    }
+    ApplicationSpecification spec = context.deserialize(specJson, ApplicationSpecification.class);
+    return new ApplicationMeta(id, spec, null, null);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginClassSerializer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginClassSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.cdap.cdap.api.plugin.PluginClass;
+import java.lang.reflect.Type;
+
+/**
+ * Gson serializer for {@link PluginClass}. Serializes only essential identification fields: 'type'
+ * and 'name'.
+ */
+public class PluginClassSerializer implements JsonSerializer<PluginClass> {
+
+  /**
+   * Serializes a {@link PluginClass} to a JSON object. Only 'type' and 'name' fields are included
+   * in the serialized output, excluding other plugin information.
+   */
+  @Override
+  public JsonElement serialize(PluginClass src, Type typeOfSrc, JsonSerializationContext context) {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("type", src.getType());
+    jsonObject.addProperty("name", src.getName());
+    // Exclude other plugin information.
+    return jsonObject;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginDeserializer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginDeserializer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.common.collect.Iterables;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.internal.app.runtime.plugin.PluginNotExistsException;
+import io.cdap.cdap.internal.guava.reflect.TypeParameter;
+import io.cdap.cdap.internal.guava.reflect.TypeToken;
+import io.cdap.cdap.proto.id.NamespaceId;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Gson deserializer for {@link Plugin}s. Uses {@link AppSpecDeserializationContext} to enrich
+ * {@link PluginClass} data if initially minimal.
+ */
+public class PluginDeserializer implements JsonDeserializer<Plugin> {
+
+  /**
+   * Deserializes JSON to {@link Plugin}. If {@link PluginClass#getClassName()} is empty, attempts
+   * to enrich it via {@link #resolvePluginClassData(List, ArtifactId, PluginClass)}.
+   *
+   * @param json    The JSON element to deserialize.
+   * @param typeOfT The type of the object to deserialize to.
+   * @param context The Gson deserialization context.
+   * @return Deserialized {@link Plugin} object.
+   * @throws JsonParseException If JSON is malformed.
+   */
+  @Override
+  public Plugin deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject jsonObject = json.getAsJsonObject();
+    List<ArtifactId> parents = deserializeList(jsonObject.get("parents"), context,
+        ArtifactId.class);
+    ArtifactId artifactId = context.deserialize(jsonObject.get("artifactId"), ArtifactId.class);
+    PluginClass pluginClass = context.deserialize(jsonObject.get("pluginClass"), PluginClass.class);
+
+    // Populate missing PluginClass data which was removed during serialization.
+    // This can be identified if the className field is empty.
+    if (pluginClass != null && (pluginClass.getClassName() == null || pluginClass.getClassName()
+        .isEmpty())) {
+      pluginClass = resolvePluginClassData(parents, artifactId, pluginClass);
+    }
+
+    PluginProperties properties = context.deserialize(jsonObject.get("properties"),
+        PluginProperties.class);
+
+    return new Plugin(parents, artifactId, pluginClass, properties);
+  }
+
+  /**
+   * Attempts to load {@link PluginClass} details from {@link AppSpecDeserializationContext}. Parent
+   * context for lookup defaults to application context; for some plugins, it may be overridden by
+   * artifact in the {@code parents} list if specific conditions are met. Returns the result of
+   * {@code appSpecDeserializationContext.getPlugin(pluginKey)}.
+   *
+   * @param parents     Declared parent {@link ArtifactId}s from JSON.
+   * @param artifactId  The plugin's own {@link ArtifactId}.
+   * @param pluginClass Initial {@link PluginClass}, possibly incomplete.
+   * @return {@link PluginClass} from context, or the outcome of the lookup.
+   */
+  private PluginClass resolvePluginClassData(List<ArtifactId> parents, ArtifactId artifactId,
+      PluginClass pluginClass) {
+    AppSpecDeserializationContext appSpecDeserializationContext = AppSpecDeserializationContextHolder.getContext();
+    String artifactNamespace = resolveNamespaceByScope(artifactId.getScope(),
+        appSpecDeserializationContext.getNamespace());
+
+    Exception exception = null;
+    ArtifactId rootArtifact = appSpecDeserializationContext.getRootArtifact();
+    for (ArtifactId parentId : Iterables.concat(parents, Collections.singleton(rootArtifact))) {
+      String parentName = parentId.getName();
+      String parentNamespace = resolveNamespaceByScope(parentId.getScope(),
+          appSpecDeserializationContext.getNamespace());
+      PluginKey pluginKey = new PluginKey(parentName, parentNamespace, artifactId.getName(),
+          artifactNamespace, artifactId.getVersion().getVersion(), pluginClass.getType(),
+          pluginClass.getName());
+      try {
+        return appSpecDeserializationContext.getPlugin(pluginKey);
+      } catch (PluginNotExistsException e) {
+        exception = e;
+      }
+    }
+    throw new RuntimeException(
+        "No data found in plugin data table OR universal plugin data table for key: " + exception);
+  }
+
+  /**
+   * Deserializes a JSON array into a {@link List} of {@code valueType}. Returns an empty list if
+   * JSON is null, not an array, or if deserialization results in null.
+   */
+  private <V> List<V> deserializeList(JsonElement json, JsonDeserializationContext context,
+      Class<V> valueType) {
+    if (json == null || json.isJsonNull() || !json.isJsonArray()) {
+      return Collections.emptyList();
+    }
+    Type type = new TypeToken<List<V>>() {
+    }.where(new TypeParameter<V>() {
+    }, valueType).getType();
+    List<V> list = context.deserialize(json, type);
+    return list == null ? Collections.emptyList() : list;
+  }
+
+  /**
+   * Resolves namespace string from {@link ArtifactScope}. Uses system namespace for
+   * {@link ArtifactScope#SYSTEM}, otherwise from context.
+   *
+   * @param scope The artifact scope.
+   * @return Corresponding namespace string.
+   */
+  private String resolveNamespaceByScope(ArtifactScope scope, String namespace) {
+    return ArtifactScope.SYSTEM.equals(scope) ? NamespaceId.SYSTEM.getNamespace() : namespace;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginKey.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginKey.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.adapters;
+
+import com.google.common.base.Objects;
+
+/**
+ * Unique key for identifying a plugin. Used for look up and caching.
+ */
+class PluginKey {
+
+  private final String parentName;
+  private final String parentNamespace;
+  private final String artifactName;
+  private final String artifactNamespace;
+  private final String artifactVersion;
+  private final String pluginType;
+  private final String pluginName;
+
+  /**
+   * Creates a {@code PluginKey} with specified plugin identification details.
+   */
+  PluginKey(String parentName, String parentNamespace, String artifactName,
+      String artifactNamespace, String artifactVersion, String pluginType, String pluginName) {
+    this.parentName = parentName;
+    this.parentNamespace = parentNamespace;
+    this.artifactName = artifactName;
+    this.artifactNamespace = artifactNamespace;
+    this.artifactVersion = artifactVersion;
+    this.pluginType = pluginType;
+    this.pluginName = pluginName;
+  }
+
+  /**
+   * Returns the parent name.
+   */
+  public String getParentName() {
+    return parentName;
+  }
+
+  /**
+   * Returns the parent namespace.
+   */
+  public String getParentNamespace() {
+    return parentNamespace;
+  }
+
+  /**
+   * Returns the plugin's artifact name.
+   */
+  public String getArtifactName() {
+    return artifactName;
+  }
+
+  /**
+   * Returns the plugin's artifact namespace.
+   */
+  public String getArtifactNamespace() {
+    return artifactNamespace;
+  }
+
+  /**
+   * Returns the plugin's artifact version.
+   */
+  public String getArtifactVersion() {
+    return artifactVersion;
+  }
+
+  /**
+   * Returns the plugin type.
+   */
+  public String getPluginType() {
+    return pluginType;
+  }
+
+  /**
+   * Returns the plugin name.
+   */
+  public String getPluginName() {
+    return pluginName;
+  }
+
+  /**
+   * Checks equality with another object.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PluginKey)) {
+      return false;
+    }
+    PluginKey pluginKey = (PluginKey) o;
+    return Objects.equal(parentName, pluginKey.parentName)
+        && Objects.equal(parentNamespace, pluginKey.parentNamespace)
+        && Objects.equal(artifactName, pluginKey.artifactName)
+        && Objects.equal(artifactNamespace, pluginKey.artifactNamespace)
+        && Objects.equal(artifactVersion, pluginKey.artifactVersion)
+        && Objects.equal(pluginType, pluginKey.pluginType)
+        && Objects.equal(pluginName, pluginKey.pluginName);
+  }
+
+  /**
+   * Returns a string representation of this key.
+   */
+  @Override
+  public String toString() {
+    return Objects.toStringHelper(this)
+        .add("parentName", parentName)
+        .add("parentNamespace", parentNamespace)
+        .add("artifactName", artifactName)
+        .add("artifactNamespace", artifactNamespace)
+        .add("artifactVersion", artifactVersion)
+        .add("pluginType", pluginType)
+        .add("pluginName", pluginName)
+        .toString();
+  }
+
+  /**
+   * Computes the hash code for this key.
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(parentName, parentNamespace, artifactName, artifactNamespace,
+        artifactVersion, pluginType, pluginName);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -24,6 +24,12 @@ import com.google.gson.GsonBuilder;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.api.schedule.SchedulableProgramType;
+import io.cdap.cdap.api.workflow.ScheduleProgramInfo;
+import io.cdap.cdap.api.workflow.WorkflowActionNode;
+import io.cdap.cdap.api.workflow.WorkflowNode;
+import io.cdap.cdap.api.workflow.WorkflowSpecification;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.utils.ProjectInfo;
@@ -32,6 +38,7 @@ import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.DefaultApplicationSpecification;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.store.plugin.Plugins;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
@@ -1618,6 +1625,37 @@ public abstract class AppMetadataStoreTest {
   }
 
   @Test
+  public void testCreateAndGetApplication() {
+    String appName = "application1";
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    ApplicationReference appRef = new ApplicationReference(NamespaceId.DEFAULT, appName);
+    ApplicationId appId = appRef.app(appName + "_version_" + 1);
+    ApplicationSpecification spec = createDummyAppSpecWithWorkflow(appId, artifactId);
+    ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
+        new ChangeDetail(null, null, null,
+            creationTimeMillis + 1, true));
+
+    // Deploy the first version
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      StructuredTable pluginDataTable = metaStore.getPluginDataTable();
+      Plugins.addWranglerPluginToTable(pluginDataTable);
+      Plugins.addNowDirectivePluginToTable(pluginDataTable);
+      Plugins.addFormatTextPluginToTable(pluginDataTable);
+      metaStore.createLatestApplicationVersion(appId, meta);
+    });
+
+    // Verify latest version
+    final ApplicationMeta[] gotMeta = {null};
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      gotMeta[0] = metaStore.getApplication(appId);
+    });
+
+    Assert.assertEquals(meta.toString(), gotMeta[0].toString());
+  }
+
+  @Test
   public void testDeleteCompletedRunsStartedBefore() throws Exception {
     // Map an iterator to one of 15 different program+workflow permutations. Used to ensure
     // (1) Multiple types of ProgramId exist (2) Multiple runs exist for each ProgramId.
@@ -1755,6 +1793,29 @@ public abstract class AppMetadataStoreTest {
       Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
       Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
       Collections.emptyMap());
+  }
+
+  private ApplicationSpecification createDummyAppSpecWithWorkflow(ApplicationId appId,
+      ArtifactId artifactId) {
+    Map<String, Plugin> plugins = Plugins.createDummyPlugins();
+    ImmutableList<WorkflowNode> nodes = ImmutableList.of(
+        new WorkflowActionNode("mr1",
+            new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE, "mr1")),
+        new WorkflowActionNode("spark1",
+            new ScheduleProgramInfo(SchedulableProgramType.SPARK, "spark1")));
+    WorkflowSpecification wfSpec =
+        new WorkflowSpecification("test", "wf1", "", Collections.emptyMap(),
+            nodes,
+            Collections.emptyMap(), plugins);
+    return new DefaultApplicationSpecification(
+        appId.getApplication(), appId.getVersion(), ProjectInfo.getVersion().toString(), "desc",
+        null, artifactId,
+        Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+        Collections.emptyMap(),
+        ImmutableMap.of(appId.workflow("wf1").getProgram(), wfSpec), Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap());
   }
 
   private void runConcurrentOperation(String name, int numThreads, Runnable runnable) throws Exception {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlAppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlAppMetadataStoreTest.java
@@ -68,6 +68,7 @@ public class SqlAppMetadataStoreTest extends AppMetadataStoreTest {
 
     transactionRunner = injector.getInstance(TransactionRunner.class);
     StoreDefinition.AppMetadataStore.create(injector.getInstance(StructuredTableAdmin.class));
+    StoreDefinition.ArtifactStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/plugin/Plugins.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/plugin/Plugins.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store.plugin;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.api.plugin.Requirements;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.store.StoreDefinition.ArtifactStore;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Util for building plugins for tests.
+ */
+public final class Plugins {
+
+  private Plugins() {
+  }
+
+  /**
+   * Creates dummy plugins.
+   */
+  public static Map<String, Plugin> createDummyPlugins() {
+    Map<String, Plugin> plugins = new HashMap<>();
+
+    Gson gson = new Gson();
+    Map<String, String> childProperties = ImmutableMap.of("child1", "childVal1", "child2",
+        "${secure(acc)}", "child3", "val3");
+    Map<String, String> properties = ImmutableMap.of("key2", gson.toJson(childProperties), "key1",
+        "val1");
+
+    PluginClass wranglerPluginClass = PluginClass.builder()
+        .setClassName("io.cdap.wrangler.Wrangler").setName("Wrangler").setConfigFieldName("config")
+        .setRequirements(Requirements.EMPTY).setType("transform")
+        .setDescription("Wrangler - A interactive tool for data cleansing and transformation.")
+        .add("schema",
+            new PluginPropertyField("schema", "Specifies the schema that has to be output.",
+                "string", true, true)).add("preconditionSQL",
+            new PluginPropertyField("preconditionSQL",
+                "SQL Precondition expression specifying filtering before applying directives (false to filter)",
+                "string", false, true, false)).build();
+    Plugin wranglerPlugin = new Plugin(Collections.emptyList(),
+        NamespaceId.DEFAULT.artifact("wrangler-transform", "1.0").toApiArtifactId(),
+        wranglerPluginClass, PluginProperties.builder().addAll(properties).build());
+    plugins.put("p1", wranglerPlugin);
+
+    PluginClass directivePluginClass = PluginClass.builder()
+        .setClassName("com.google.cloud.datafusion.directives.Now").setName("now")
+        .setRequirements(Requirements.EMPTY).setType("directive")
+        .setDescription("Populates a column with the current date and time").build();
+    ArtifactId parent = NamespaceId.DEFAULT.artifact("Wrangler", "1.0").toApiArtifactId();
+    Plugin directivePlugin = new Plugin(Collections.singleton(parent),
+        NamespaceId.DEFAULT.artifact("wrangler", "1.0").toApiArtifactId(), directivePluginClass,
+        PluginProperties.builder().addAll(properties).build());
+    plugins.put("p2", directivePlugin);
+
+    PluginClass gCloudFormatTextPluginClass = PluginClass.builder()
+        .setClassName("io.cdap.plugin.format.text.input.TextInputFormatProvider").setName("text")
+        .setRequirements(Requirements.EMPTY).setType("validatingInputFormat")
+        .setDescription("Plugin for reading files in text format.").setConfigFieldName("conf")
+        .build();
+    parent = NamespaceId.DEFAULT.artifact("google-cloud", "1.0").toApiArtifactId();
+    Plugin gCloudFormatTextPlugin = new Plugin(Collections.singleton(parent),
+        NamespaceId.DEFAULT.artifact("format-text", "1.0").toApiArtifactId(),
+        gCloudFormatTextPluginClass, PluginProperties.builder().addAll(properties).build());
+    plugins.put("p3", gCloudFormatTextPlugin);
+
+    return plugins;
+  }
+
+  private static void addPluginEntryToTable(StructuredTable pluginDataTable,
+      String parentContextName, String pluginType, String pluginName, String artifactName,
+      String pluginDataJson) throws IOException {
+    Collection<Field<?>> fields = new ArrayList<>();
+    fields.add(Fields.stringField(ArtifactStore.PARENT_NAMESPACE_FIELD, "default"));
+    fields.add(Fields.stringField(ArtifactStore.PARENT_NAME_FIELD, parentContextName));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_TYPE_FIELD, pluginType));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_NAME_FIELD, pluginName));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAMESPACE_FIELD, "default"));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_NAME_FIELD, artifactName));
+    fields.add(Fields.stringField(ArtifactStore.ARTIFACT_VER_FIELD, "1.0"));
+    fields.add(Fields.stringField(ArtifactStore.PLUGIN_DATA_FIELD, pluginDataJson));
+    pluginDataTable.upsert(fields);
+  }
+
+  /**
+   * Initializes a {@link StructuredTable} with a dummy entry for a Wrangler plugin.
+   */
+  public static void addWranglerPluginToTable(StructuredTable pluginDataTable) throws IOException {
+    String wranglerPluginJsonData = "{\"pluginClass\":{\"type\":"
+        + "\"transform\",\"name\":\"Wrangler\",\"description\":\"Wrangler - A interactive tool "
+        + "for data cleansing and transformation.\",\"className\":\"io.cdap.wrangler.Wrangler\","
+        + "\"configFieldName\":\"config\",\"properties\":{\"schema\":{\"name\":\"schema\",\"description"
+        + "\":\"Specifies the schema that has to be output.\",\"type\":\"string\",\"required\":true,"
+        + "\"macroSupported\":true,\"macroEscapingEnabled\":false,\"children\":[]},\"preconditionSQL\""
+        + ":{\"name\":\"preconditionSQL\",\"description\":\"SQL Precondition expression specifying"
+        + " filtering before applying directives (false to filter)\",\"type\":\"string\",\"required"
+        + "\":false,\"macroSupported\":true,\"macroEscapingEnabled\":false,\"children\":[]}},"
+        + "\"requirements\":{\"datasetTypes\":[],\""
+        + "capabilities\":[]}},\"artifactLocationPath\":\"/cdap/namespaces/system/artifacts/wrangler-transform"
+        + "/4.11.0-SNAPSHOT.d26c4ac8-600a-4bf0-8280-0561037036d8.jar\",\"usableBy\":\""
+        + "system:cdap-data-pipeline[6.10.0,7.0.0-SNAPSHOT)\"}"; // Example path/usableBy
+
+    addPluginEntryToTable(pluginDataTable, "testArtifact", "transform", "Wrangler",
+        "wrangler-transform", wranglerPluginJsonData);
+  }
+
+  /**
+   * Initializes a {@link StructuredTable} with a dummy entry for a "now" directive plugin.
+   */
+  public static void addNowDirectivePluginToTable(StructuredTable pluginDataTable)
+      throws IOException {
+
+    ArtifactId parent = NamespaceId.DEFAULT.artifact("Wrangler", "1.0").toApiArtifactId();
+    String nowDirectiveJsonData = "{\"pluginClass\":{\"type\":\"directive\",\"name\":\"now\","
+        + "\"description\":\"Populates a column with the current date and time\","
+        + "\"className\":\"com.google.cloud.datafusion.directives.Now\",\"properties\":{},"
+        + "\"requirements\":{\"datasetTypes\":[],\"capabilities\":[]}},"
+        + "\"artifactLocationPath\":\"/cdap/namespaces/default/artifacts/now-directive/1.0.0-SNAPSHOT.jar\","
+        + "\"usableBy\":\"system:wrangler-transform[4.0.0,5.0.0)\"}";
+
+    addPluginEntryToTable(pluginDataTable, parent.getName(), "directive", "now", "wrangler",
+        nowDirectiveJsonData);
+  }
+
+  /**
+   * Initializes a {@link StructuredTable} with a dummy entry for a "format-text" plugin.
+   */
+  public static void addFormatTextPluginToTable(StructuredTable pluginDataTable)
+      throws IOException {
+
+    String formatTextJsonData =
+        "{\"pluginClass\":{\"type\":\"validatingInputFormat\",\"name\":\"text\","
+            + "\"description\":\"Plugin for reading files in text format.\","
+            + "\"className\":\"io.cdap.plugin.format.text.input.TextInputFormatProvider\","
+            + "\"configFieldName\":\"conf\",\"requirements\":{\"datasetTypes\":[],"
+            + "\"capabilities\":[]}},\"artifactLocationPath\":\"/cdap/namespaces/system/artifacts/format"
+            + "-text/2.14.0-SNAPSHOT.4fed59ac-ef3f-4b76-ac29-d5aa8bc38061.jar\","
+            + "\"usableBy\":\"system:cdap-data-pipeline[6.8.0-SNAPSHOT,7.0.0-SNAPSHOT)\"}";
+
+    addPluginEntryToTable(pluginDataTable, "testArtifact", "validatingInputFormat", "text",
+        "format-text", formatTextJsonData);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -24,7 +24,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Constants used by different systems are all defined here.
@@ -639,6 +642,8 @@ public final class Constants {
   public static final class AppMetaStore {
 
     public static final String TABLE = "app.meta";
+    public static final Set<String> APPSPEC_REDUCTION_SUPPORTED_STORAGE_PROVIDERS = new HashSet<>(
+        Collections.singleton(Dataset.DATA_STORAGE_SPANNER));
   }
 
   /**
@@ -731,6 +736,7 @@ public final class Constants {
     public static final String DATA_STORAGE_IMPLEMENTATION = "data.storage.implementation";
     public static final String DATA_STORAGE_NOSQL = "nosql";
     public static final String DATA_STORAGE_SQL = "postgresql";
+    public static final String DATA_STORAGE_SPANNER = "gcp-spanner";
     public static final String DATA_STORAGE_SQL_DRIVER_EXTERNAL = "data.storage.sql.jdbc.driver.external";
     public static final String DATA_STORAGE_SQL_DRIVER_DIRECTORY = "data.storage.sql.jdbc.driver.directory";
     public static final String DATA_STORAGE_SQL_JDBC_DRIVER_NAME = "data.storage.sql.jdbc.driver.name";

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableContext.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.data.DatasetInstantiationException;
 import io.cdap.cdap.api.dataset.lib.IndexedTable;
 import io.cdap.cdap.api.metrics.MetricsCollector;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.StructuredTableInstantiationException;
@@ -74,5 +75,10 @@ public class NoSqlStructuredTableContext implements StructuredTableContext {
       throw new StructuredTableInstantiationException(
           tableId, String.format("Error instantiating table %s", tableId), e);
     }
+  }
+
+  @Override
+  public String getStorageProvider() {
+    return Constants.Dataset.DATA_STORAGE_NOSQL;
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContext.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.spi.data.sql;
 
 import io.cdap.cdap.api.metrics.MetricsCollector;
+import io.cdap.cdap.common.conf.Constants.Dataset;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableContext;
@@ -58,5 +59,10 @@ public class SqlStructuredTableContext implements StructuredTableContext {
     } catch (IOException e) {
       throw new StructuredTableInstantiationException(tableId, "Failed to get the table schema", e);
     }
+  }
+
+  @Override
+  public String getStorageProvider() {
+    return Dataset.DATA_STORAGE_SQL;
   }
 }

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStorageProvider.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStorageProvider.java
@@ -52,6 +52,7 @@ public class SpannerStorageProvider implements StorageProvider {
   static final String DATABASE = "database";
   static final String CREDENTIALS_PATH = "credentials.path";
   public static final String COMPRESSION_CONFIG = "compression.config";
+  static final String NAME = "gcp-spanner";
 
   private Spanner spanner;
   private SpannerStructuredTableAdmin admin;
@@ -96,7 +97,7 @@ public class SpannerStorageProvider implements StorageProvider {
 
   @Override
   public String getName() {
-    return "gcp-spanner";
+    return NAME;
   }
 
   @Override

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableContext.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner;
+
+import com.google.cloud.spanner.TransactionContext;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.StructuredTableInstantiationException;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+
+/**
+ * The Cloud Spanner context to get the table.
+ */
+public class SpannerStructuredTableContext implements StructuredTableContext {
+
+  private final TransactionContext context;
+  private final SpannerStructuredTableAdmin admin;
+
+  /**
+   * Constructor for SpannerStructuredTableContext.
+   */
+  public SpannerStructuredTableContext(TransactionContext context,
+      SpannerStructuredTableAdmin admin) {
+    this.context = context;
+    this.admin = admin;
+  }
+
+  @Override
+  public StructuredTable getTable(StructuredTableId tableId)
+      throws StructuredTableInstantiationException, TableNotFoundException {
+    return new SpannerStructuredTable(context, admin.getSpannerStructuredTableSchema(tableId));
+  }
+
+  @Override
+  public String getStorageProvider() {
+    return SpannerStorageProvider.NAME;
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
@@ -37,8 +37,7 @@ public class SpannerTransactionRunner implements TransactionRunner {
   public void run(TxRunnable runnable) throws TransactionException {
     try {
       admin.getDatabaseClient().readWriteTransaction().allowNestedTransaction().run(context -> {
-        runnable.run(tableId -> new SpannerStructuredTable(context,
-            admin.getSpannerStructuredTableSchema(tableId)));
+        runnable.run(new SpannerStructuredTableContext(context, admin));
         return null;
       });
     } catch (SpannerException e) {

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableContext.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableContext.java
@@ -32,8 +32,15 @@ public interface StructuredTableContext {
    * @param tableId the table id
    * @return An instance of the specified table, never null
    * @throws StructuredTableInstantiationException if the table cannot be instantiated
-   * @throws TableNotFoundException if the table is not found
+   * @throws TableNotFoundException                if the table is not found
    */
   StructuredTable getTable(StructuredTableId tableId)
       throws StructuredTableInstantiationException, TableNotFoundException;
+
+  /**
+   * Get type of storage provider for the current instance.
+   */
+  default String getStorageProvider() {
+    return "";
+  }
 }


### PR DESCRIPTION
This is a follow up for [CDAP-21144](https://cdap.atlassian.net/browse/CDAP-21144) due to which pipeline json size in CDAP was restricted to 2MB.

The application specification includes significant redundant data, for instance, repeated plugin documentation within a single app spec JSON. Our long-term goal is to remove this unnecessary and duplicated information from the JSON. Ideally, the JSON should only contain the plugin list, a DAG, and configuration details for each node in the DAG.

Removing excessive plugin information is a straightforward way to significantly decrease the app specification size, potentially by approximately 30%. 

To optimize storage, the serialized App Spec in the database will retain only the identifier fields (plugin_type, plugin_name) and the artifactId for each plugin. All other descriptive fields of the PluginClass will be excluded during the database write operation.

During App Spec retrieval, this minimal plugin data (identifier fields and artifactId) will be used to reconstruct the complete Plugin object, potentially by fetching the additional descriptive details from a central plugin registry or a similar mechanism. This ensures that consuming applications receive the full App Spec as originally defined, while the stored representation is significantly reduced in size.

**NOTE : THESE CHANGES ARE LIMITED TO SPANNER STORAGE IMPL**

**Tested:**

_Unit tests:_

- [x] AppSpec during serialization

![image](https://github.com/user-attachments/assets/fba36741-4057-406e-a1cc-0b9b683f94a0)

- [x] AppMeta object during de-serialization forming the plugin class 

![image](https://github.com/user-attachments/assets/3b407c56-1677-4612-a66b-a412fde16b5b)

_CDAP Distributed docker image :_ 

- [x]  Tested pipeline run
- [x]  Pipeline run with user uploaded plugin in Default as well as User namespace
- [x]  Tested with CloudSql integrated CDAP instances - There should be no serialization / deserialization in such scenario.


[CDAP-21144]: https://cdap.atlassian.net/browse/CDAP-21144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ