### PR TITLE
[CVE-2021-39144] Fix vulnerability for xstream in cdap builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1730,6 +1730,13 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.20</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
A [critical vulnerability (CVE-2021-39144)](https://nvd.nist.gov/vuln/detail/cve-2021-39144) has been identified in the com.thoughtworks.xstream:xstream library, which is patched in version 1.4.18 and subsequent releases. 

In a previous change (#15946), the 1.4.20 XStream dependency was updated in two locations, but one instance was missed.  This PR resolves that remaining update.