### PR TITLE
[CDAP-21166] Force cleaning up location cache periodically.

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -67,6 +67,7 @@ public final class Constants {
   // Directory path for caching remove location content
   public static final String LOCATION_CACHE_PATH = "location.cache.path";
   public static final String LOCATION_CACHE_EXPIRATION_MS = "location.cache.expiration.ms";
+  public static final String LOCATION_CACHE_FORCE_CLEANUP_MS = "location.cache.force.cleanup.ms";
 
   public static final String CLUSTER_NAME = "cluster.name";
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/guice/DFSLocationModule.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/guice/DFSLocationModule.java
@@ -95,8 +95,10 @@ public class DFSLocationModule extends PrivateModule {
 
       Path cachePath = Paths.get(locationCachePath).toAbsolutePath();
       long expiry = cConf.getLong(Constants.LOCATION_CACHE_EXPIRATION_MS);
+      long forceCleanupInterval = cConf.getLong(Constants.LOCATION_CACHE_FORCE_CLEANUP_MS);
       return new CachingLocationFactory(lf,
-          new DefaultCachingPathProvider(cachePath, expiry, TimeUnit.MILLISECONDS));
+          new DefaultCachingPathProvider(cachePath, expiry, TimeUnit.MILLISECONDS,
+              forceCleanupInterval));
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
@@ -23,6 +23,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.hash.Hashing;
 import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.internal.io.ASMDatumWriterFactory.CacheKey;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,7 +32,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +52,10 @@ public class DefaultCachingPathProvider implements CachingPathProvider {
 
   private final LoadingCache<CacheKey, Path> cache;
   private final Path cacheDir;
+  private final ScheduledExecutorService cleanupExecutor;
 
-  public DefaultCachingPathProvider(Path cacheDir, long cacheExpiry, TimeUnit cacheExpiryUnit) {
+  public DefaultCachingPathProvider(Path cacheDir, long cacheExpiry, TimeUnit cacheExpiryUnit,
+      long forceCleanupIntervalMillis) {
     this.cacheDir = cacheDir;
     this.cache = CacheBuilder.newBuilder()
         .expireAfterAccess(cacheExpiry, cacheExpiryUnit)
@@ -81,6 +87,20 @@ public class DefaultCachingPathProvider implements CachingPathProvider {
         });
 
     populateCache(cacheDir, cache);
+    // Cache is not automatically cleaned up and for low throughput caches this needs to be
+    // maintained: https://github.com/google/guava/wiki/CachesExplained#when-does-cleanup-happen
+    if (forceCleanupIntervalMillis > 0) {
+      // A non-positive value indicates that the cache should not be periodically cleaned up.
+      cleanupExecutor = Executors.newSingleThreadScheduledExecutor(
+          Threads.createDaemonThreadFactory("location-cache-cleanup"));
+      cleanupExecutor.scheduleAtFixedRate(() -> {
+        LOG.trace("Cleaning up location cache");
+        cache.cleanUp();
+      }, 0, forceCleanupIntervalMillis, TimeUnit.MILLISECONDS);
+    } else {
+      // If cleanup interval is <= 0 the executor is not initialized.
+      cleanupExecutor = null;
+    }
   }
 
   @Override

--- a/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
@@ -23,7 +23,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.hash.Hashing;
 import io.cdap.cdap.common.utils.DirUtils;
-import io.cdap.cdap.internal.io.ASMDatumWriterFactory.CacheKey;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -214,6 +214,15 @@
   </property>
 
   <property>
+    <name>location.cache.force.cleanup.ms</name>
+    <value>3600000</value>
+    <description>
+      Time duration after which the location cache is forced cleaned up. A
+      non-positive value indicates that the cache is never forced cleaned up.
+    </description>
+  </property>
+
+  <property>
     <name>thrift.max.read.buffer</name>
     <value>16777216</value>
     <description>

--- a/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
@@ -90,8 +90,10 @@ public class CachingLocationTest {
     Path cachePath = TEMP_FOLDER.newFolder().toPath();
     String message = "Testing message";
 
-    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS);
-    LocationFactory lf = new CachingLocationFactory(new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
+    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1,
+        TimeUnit.HOURS, 0);
+    LocationFactory lf = new CachingLocationFactory(
+        new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
 
     // Write out a location
     Location location = lf.create("test");
@@ -144,12 +146,53 @@ public class CachingLocationTest {
   }
 
   @Test
+  public void testForceCacheCleanup() throws IOException, InterruptedException {
+    Path cachePath = TEMP_FOLDER.newFolder().toPath();
+    String message = "Testing message force cleanup";
+
+    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1,
+        TimeUnit.SECONDS, 100);
+    LocationFactory lf = new CachingLocationFactory(
+        new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
+
+    // Write out a location
+    Location location = lf.create("test-cleanup");
+    try (OutputStream os = location.getOutputStream()) {
+      os.write(message.getBytes(StandardCharsets.UTF_8));
+    }
+    try (InputStream is = location.getInputStream()) {
+      Assert.assertEquals(message, new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+    }
+
+    // Check if the cache file is there
+    long oldLastModified = location.lastModified();
+    Path cachedFile = cacheProvider.getCachePath(cacheProvider.getCacheName(location),
+        oldLastModified);
+    Assert.assertTrue(Files.exists(cachedFile));
+    try (InputStream is = Files.newInputStream(cachedFile)) {
+      Assert.assertEquals(message, new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
+    }
+
+    // Sleep 3 seconds to force expiry of cache(1 second) and force cleanup of cache(100ms) with
+    // some buffer for operations.
+    TimeUnit.SECONDS.sleep(3);
+
+    Path cacheFileDir = cacheProvider.getCachePath(cacheProvider.getCacheName(location),
+        location.lastModified()).getParent();
+    Assert.assertFalse(Files.exists(cacheFileDir));
+    // Entries should be cleaned up automatically.
+    Assert.assertEquals(0, cacheProvider.getCacheEntries().size());
+  }
+
+  @Test
   public void testCachePopulate() throws IOException {
     Path cachePath = TEMP_FOLDER.newFolder().toPath();
     String message = "Testing message";
 
-    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS);
-    LocationFactory lf = new CachingLocationFactory(new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
+    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1,
+        TimeUnit.HOURS, 0);
+    LocationFactory lf = new CachingLocationFactory(
+        new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
 
     // Write out a location
     Location location = lf.create("test");
@@ -163,7 +206,8 @@ public class CachingLocationTest {
 
     // Create a new preview cache provider from the same directory, it should
     // populate the cache.
-    Collection<Path> cacheEntries = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS).getCacheEntries();
+    Collection<Path> cacheEntries = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS,
+        0).getCacheEntries();
     Assert.assertTrue(cacheEntries.contains(cacheProvider.getCachePath(cacheProvider.getCacheName(location),
         location.lastModified())));
   }
@@ -175,7 +219,8 @@ public class CachingLocationTest {
 
     // Create a new cache provider from the same directory, it should
     // populate the cache.
-    DefaultCachingPathProvider cachingPathProvider = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS);
+    DefaultCachingPathProvider cachingPathProvider = new DefaultCachingPathProvider(cachePath, 1,
+        TimeUnit.HOURS, 0);
     LocationFactory lf = new CachingLocationFactory(
       new LocalLocationFactory(TEMP_FOLDER.newFolder()), cachingPathProvider);
 
@@ -220,8 +265,10 @@ public class CachingLocationTest {
     Path cachePath = TEMP_FOLDER.newFolder().toPath();
     String message = "Testing message";
 
-    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS);
-    LocationFactory lf = new CachingLocationFactory(new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
+    DefaultCachingPathProvider cacheProvider = new DefaultCachingPathProvider(cachePath, 1,
+        TimeUnit.HOURS, 0);
+    LocationFactory lf = new CachingLocationFactory(
+        new LocalLocationFactory(TEMP_FOLDER.newFolder()), cacheProvider);
 
     // Write out a location
     Location location = lf.create("test");


### PR DESCRIPTION
Location cache is not cleaned up because of how `CacheBuilder` works and the cache having low read/write throughput.
Details: https://github.com/google/guava/wiki/CachesExplained#when-does-cleanup-happen

### Solution
As suggested in the link above created a ScheduledExecutor to periorically clean up the cache and remove stale entries. This will trigger the removal listner to clean up PD files.

### Testing
Tested in autopush by enabling TRACE logs and changing the TTL to 3 minutes.