### PR TITLE
[CDAP-21172]Added cdap-metadata-ext-spanner Module with ExtensionLoader

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2114,9 +2114,13 @@ public final class Constants {
     public static final String STORAGE_PROVIDER_IMPLEMENTATION = "metadata.storage.implementation";
     public static final String STORAGE_PROVIDER_NOSQL = "nosql";
     public static final String STORAGE_PROVIDER_ELASTICSEARCH = "elastic";
+    public static final String STORAGE_PROVIDER_SPANNER = "gcp-spanner";
 
     public static final String METADATA_WRITER_SUBSCRIBER = "metadata.writer";
     public static final String METADATA_CONSUMER_WRITER_SUBSCRIBER = "metadata.consumer.writer";
+
+    // Metadata configs
+    public static final String METADATA_STORAGE_EXT_DIR = "metadata.storage.extensions.dir";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2845,6 +2845,11 @@
     <value>/opt/cdap/master/ext/log-publisher</value>
   </property>
 
+  <property>
+    <name>metadata.storage.extensions.dir</name>
+    <value>/opt/cdap/master/ext/metadata-storage</value>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data/runtime/DataSetsModules.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data/runtime/DataSetsModules.java
@@ -45,6 +45,7 @@ import io.cdap.cdap.data2.registry.UsageRegistry;
 import io.cdap.cdap.data2.registry.UsageWriter;
 import io.cdap.cdap.metadata.elastic.ElasticsearchMetadataStorage;
 import io.cdap.cdap.security.impersonation.OwnerStore;
+import io.cdap.cdap.spi.metadata.DelegatingMetadataStorage;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.spi.metadata.dataset.DatasetMetadataStorage;
 import io.cdap.cdap.spi.metadata.noop.NoopMetadataStorage;
@@ -178,11 +179,21 @@ class MetadataStorageProvider implements Provider<MetadataStorage> {
     if (Constants.Metadata.STORAGE_PROVIDER_NOSQL.equalsIgnoreCase(config)) {
       return injector.getInstance(DatasetMetadataStorage.class);
     }
+
+    // TODO (CDAP-21173): Load elastic search implementation using DelegatingMetadataStorage
     if (Constants.Metadata.STORAGE_PROVIDER_ELASTICSEARCH.equalsIgnoreCase(config)) {
       return injector.getInstance(ElasticsearchMetadataStorage.class);
     }
-    throw new IllegalArgumentException("Unsupported MetadataStorage '" + config + "'. Only '"
-        + Constants.Metadata.STORAGE_PROVIDER_NOSQL + "' and '"
-        + Constants.Metadata.STORAGE_PROVIDER_ELASTICSEARCH + "' are allowed.");
+    if (Constants.Metadata.STORAGE_PROVIDER_SPANNER.equalsIgnoreCase(config)) {
+      return injector.getInstance(DelegatingMetadataStorage.class);
+    }
+    String errorMessage = String.format(
+      "Unsupported MetadataStorage '%s'. Only '%s', '%s' and '%s' are allowed.",
+      config,
+      Constants.Metadata.STORAGE_PROVIDER_NOSQL,
+      Constants.Metadata.STORAGE_PROVIDER_SPANNER,
+      Constants.Metadata.STORAGE_PROVIDER_ELASTICSEARCH
+    );
+    throw new IllegalArgumentException(errorMessage);
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/AuditMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/AuditMetadataStorage.java
@@ -84,6 +84,11 @@ public class AuditMetadataStorage implements MetadataStorage {
   }
 
   @Override
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
   public void createIndex() throws IOException {
     try {
       storage.createIndex();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/DefaultMetadataStorageContext.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/DefaultMetadataStorageContext.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+/**
+ * Default implementation of the {@link MetadataStorageContext}.
+ * TODO(CDAP-21174): Generalize the context for metadata storage
+ */
+public class DefaultMetadataStorageContext implements MetadataStorageContext {
+
+  private final Map<String, String> properties;
+
+  DefaultMetadataStorageContext(CConfiguration cConf, @Nullable String prefix) {
+    if (prefix != null) {
+      this.properties = Collections.unmodifiableMap(cConf.getPropsWithPrefix(prefix));
+    } else {
+      this.properties = Collections.emptyMap();
+    }
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}
+

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/DelegatingMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/DelegatingMetadataStorage.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Delegates {@link MetadataStorage} based on configured extension.
+ */
+public class DelegatingMetadataStorage implements MetadataStorage {
+  private final CConfiguration cConf;
+  private final MetadataStorage delegate;
+  private static String prefix;
+  private static final String SPANNER_METADATA_STORAGE = "gcp-spanner";
+
+  @Inject
+  DelegatingMetadataStorage(CConfiguration cConf, MetadataStorageExtensionLoader extensionLoader) throws Exception {
+    this.cConf = cConf;
+    this.delegate = extensionLoader.get(getName());
+
+    if (this.delegate == null) {
+      throw new IllegalArgumentException("Unsupported MetadataProvider type: " + getName());
+    }
+    // TODO(CDAP-21174): Generalize the context for metadata storage
+    if (getName().equals(SPANNER_METADATA_STORAGE)) {
+      this.prefix = String.format("%s%s.", Constants.Dataset.STORAGE_EXTENSION_PROPERTY_PREFIX,
+                                  SPANNER_METADATA_STORAGE);
+    } else {
+      this.prefix = null;
+    }
+
+    this.delegate.initialize(new DefaultMetadataStorageContext(cConf, prefix));
+  }
+
+  @Override
+  public void createIndex() throws IOException {
+    delegate.createIndex();
+  }
+
+  @Override
+  public void close() {
+    if (delegate != null) {
+      delegate.close();
+    }
+  }
+
+  @Override
+  public String getName() {
+    return cConf.get(Constants.Metadata.STORAGE_PROVIDER_IMPLEMENTATION);
+  }
+
+  @Override
+  public void dropIndex() throws IOException {
+    delegate.dropIndex();
+  }
+
+  @Override
+  public MetadataChange apply(MetadataMutation mutation, MutationOptions options) throws IOException {
+    return delegate.apply(mutation, options);
+  }
+
+  @Override
+  public List<MetadataChange> batch(List<? extends MetadataMutation> mutations, MutationOptions options)
+    throws IOException {
+    return delegate.batch(mutations, options);
+  }
+
+  @Override
+  public Metadata read(Read read) throws IOException {
+    return delegate.read(read);
+  }
+
+  @Override
+  public SearchResponse search(SearchRequest request) throws IOException {
+    return delegate.search(request);
+  }
+}
+

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorageExtensionLoader.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorageExtensionLoader.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.lang.ClassPathResources;
+import io.cdap.cdap.common.lang.FilterClassLoader;
+import io.cdap.cdap.extension.AbstractExtensionLoader;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Extension loader for {@link MetadataStorage} implementations.
+ */
+public class MetadataStorageExtensionLoader extends AbstractExtensionLoader<String, MetadataStorage> {
+
+  private static final Set<String> ALLOWED_RESOURCES = createAllowedResources();
+  private static final Set<String> ALLOWED_PACKAGES = createPackageSets(ALLOWED_RESOURCES);
+
+  @Inject
+  public MetadataStorageExtensionLoader(CConfiguration cConf) {
+    super(cConf.get(Constants.Metadata.METADATA_STORAGE_EXT_DIR));
+  }
+
+  private static Set<String> createAllowedResources() {
+    try {
+      return ClassPathResources.getResourcesWithDependencies(MetadataStorage.class.getClassLoader(),
+                                                             MetadataStorage.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to trace dependencies for MetadataStorage extension.", e);
+    }
+  }
+
+  @Override
+  protected Set<String> getSupportedTypesForProvider(MetadataStorage metadataStorage) {
+    return Collections.singleton(metadataStorage.getName());
+  }
+
+  @Override
+  protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
+    return new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return ALLOWED_RESOURCES.contains(resource);
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return ALLOWED_PACKAGES.contains(packageName);
+      }
+    };
+  }
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/dataset/DatasetMetadataStorage.java
@@ -75,6 +75,11 @@ public class DatasetMetadataStorage extends SearchHelper implements MetadataStor
   }
 
   @Override
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
   public void createIndex() throws IOException {
     createDatasets();
   }

--- a/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -218,6 +218,11 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
   }
 
   @Override
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
   public void close() {
     Closeables.closeQuietly(client);
   }

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -114,6 +114,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-metadata-ext-spanner</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tephra</groupId>
       <artifactId>tephra-api</artifactId>
     </dependency>
@@ -251,6 +256,7 @@
         <stage.authenticators.ext.dir>${stage.opt.dir}/ext/authenticators</stage.authenticators.ext.dir>
         <stage.credential.provider.extensions.dir>${stage.opt.dir}/ext/credentialproviders</stage.credential.provider.extensions.dir>
         <stage.messaging.ext.dir>${stage.opt.dir}/ext/messagingproviders</stage.messaging.ext.dir>
+        <stage.metadata.ext.dir>${stage.opt.dir}/ext/metadatastorage</stage.metadata.ext.dir>
         <stage.metricswriters.ext.dir>${stage.opt.dir}/ext/metricswriters/google_cloud_monitoring_writer
         </stage.metricswriters.ext.dir>
         <stage.eventwriters.ext.dir>${stage.opt.dir}/ext/eventwriters/google_cloud_pubsub_writer
@@ -724,6 +730,28 @@
                     <resource>
                       <directory>
                         ${project.parent.basedir}/cdap-messaging-ext-spanner/target/libexec/
+                      </directory>
+                      <includes>
+                        <include>*.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+
+              <!-- Copy metadata extensions -->
+              <execution>
+                <id>copy-metadata-ext-spanner</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.metadata.ext.dir}/spanner</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-metadata-ext-spanner/target/libexec/
                       </directory>
                       <includes>
                         <include>*.jar</include>

--- a/cdap-metadata-ext-spanner/pom.xml
+++ b/cdap-metadata-ext-spanner/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2025 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.cdap.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>6.12.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-metadata-ext-spanner</artifactId>
+
+  <properties>
+    <guava.version>33.4.0-jre</guava.version>
+    <spanner.version>6.87.0</spanner.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>26.55.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-metadata-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-spanner</artifactId>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <configuration combine.self="override">
+                  <includeScope>runtime</includeScope>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <overWriteIfNewer>true</overWriteIfNewer>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>false</overWriteSnapshots>
+                  <prependGroupId>true</prependGroupId>
+                  <silent>true</silent>
+                </configuration>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+              </execution>
+            </executions>
+            <groupId>org.apache.maven.plugins</groupId>
+            <version>2.8</version>
+          </plugin>
+          <plugin>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <configuration combine.self="override">
+                  <finalName>${project.groupId}.${project.build.finalName}</finalName>
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <id>jar</id>
+                <phase>prepare-package</phase>
+              </execution>
+            </executions>
+            <groupId>org.apache.maven.plugins</groupId>
+            <version>2.4</version>
+          </plugin>
+        </plugins>
+      </build>
+      <id>dist</id>
+    </profile>
+  </profiles>
+</project>

--- a/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorage.java
+++ b/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2025 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,65 +14,68 @@
  * the License.
  */
 
-package io.cdap.cdap.spi.metadata.noop;
+package io.cdap.cdap.metadata.spanner;
 
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataChange;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
+import io.cdap.cdap.spi.metadata.MetadataStorageContext;
 import io.cdap.cdap.spi.metadata.MutationOptions;
 import io.cdap.cdap.spi.metadata.Read;
 import io.cdap.cdap.spi.metadata.SearchRequest;
 import io.cdap.cdap.spi.metadata.SearchResponse;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
- * Metadata storage provider that does nothing.
+ * A metadata storage provider that delegates to Spanner.
  */
-public class NoopMetadataStorage implements MetadataStorage {
+public class SpannerMetadataStorage implements MetadataStorage {
 
   @Override
-  public String getName() {
-    return getClass().getSimpleName();
-  }
-
-  @Override
-  public void createIndex() throws IOException {
-    // no-op
-  }
-
-  @Override
-  public void dropIndex() throws IOException {
-    // no-op
-  }
-
-  @Override
-  public MetadataChange apply(MetadataMutation mutation, MutationOptions options) {
-    return new MetadataChange(mutation.getEntity(), Metadata.EMPTY, Metadata.EMPTY);
-  }
-
-  @Override
-  public List<MetadataChange> batch(List<? extends MetadataMutation> mutations,
-      MutationOptions options) {
-    return mutations.stream().map(mutation -> apply(mutation, options))
-        .collect(Collectors.toList());
-  }
-
-  @Override
-  public Metadata read(Read read) {
-    return Metadata.EMPTY;
-  }
-
-  @Override
-  public SearchResponse search(SearchRequest request) {
-    return new SearchResponse(request, null, 0, 0, 0, Collections.emptyList());
+  public void initialize(MetadataStorageContext context) throws Exception {
+    throw new IOException("NOT IMPLEMENTED");
   }
 
   @Override
   public void close() {
-    // no-op
+  }
+
+  @Override
+  public void createIndex() throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public String getName() {
+    return "gcp-spanner";
+  }
+
+  @Override
+  public void dropIndex() throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public MetadataChange apply(MetadataMutation mutation, MutationOptions options) throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public List<MetadataChange> batch(List<? extends MetadataMutation> mutations, MutationOptions options)
+    throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public Metadata read(Read read) throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public SearchResponse search(SearchRequest request) throws IOException {
+    throw new IOException("NOT IMPLEMENTED");
   }
 }
+

--- a/cdap-metadata-ext-spanner/src/main/resources/META-INF/services/io.cdap.cdap.spi.metadata.MetadataStorage
+++ b/cdap-metadata-ext-spanner/src/main/resources/META-INF/services/io.cdap.cdap.spi.metadata.MetadataStorage
@@ -1,0 +1,17 @@
+#
+# Copyright © 2025 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.metadata.spanner.SpannerMetadataStorage

--- a/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorage.java
+++ b/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorage.java
@@ -28,6 +28,23 @@ import java.util.List;
 public interface MetadataStorage extends Closeable {
 
   /**
+   * Initialization of the metadata storage. This method will be called after the constructor and
+   * before any method is being called.
+   *
+   * @param context a context object providing interaction with the CDAP platform.
+   * @throws Exception if the metadata storage failed to initialize itself
+   */
+  default void initialize(MetadataStorageContext context) throws Exception {
+    // no-op
+  }
+
+  /**
+   * Returns the name of this MetadataStorage. The name needs to match with the configuration
+   * provided through {@code metadata.storage.implementation}.
+   */
+  String getName();
+
+  /**
    * Create all tables or indexes required for operations.
    */
   void createIndex() throws IOException;

--- a/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorageContext.java
+++ b/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataStorageContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.metadata;
+
+import java.util.Map;
+
+/**
+ * The context for {@link MetadataStorage} to interact with the CDAP platform.
+ */
+public interface MetadataStorageContext {
+
+  /**
+   * System properties are derived from the CDAP configuration. Anything in the CDAP configuration
+   * will be added as an entry in the system properties.
+   *
+   * @return unmodifiable system properties for the metadata storage.
+   */
+  Map<String, String> getProperties();
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -2601,6 +2601,7 @@
         <module>cdap-security-spi</module>
         <module>cdap-security</module>
         <module>cdap-metadata-spi</module>
+        <module>cdap-metadata-ext-spanner</module>
         <module>cdap-storage-ext-spanner</module>
         <module>cdap-storage-spi</module>
         <module>cdap-system-app-api</module>


### PR DESCRIPTION
### **Description:**

This PR introduces the `SpannerMetadataStorage `and it is being loaded at runtime using the `MetadataStorageExtensionLoader`. Key changes include:

- **SpannerMetadataStorage**: A new class that extends `MetadataStorage`  that handles the pipeline metadata and stores it in spanner tables. It delegates the operations (such as createIndex, apply, and search) to the spanner tables in the spanner instance.

- **DelegatingMetadataStorage**: This class acts as a wrapper around `SpannerMetadataStorage`, enabling the use of `SpannerMetadataStorage` within the `MetadataStorage` framework. It ensures that the SpannerMetadataStorage is properly initialized.

### **Testing:**

-  **Local Testing**:Tested these changes using a Distributed docker image.