### PR TITLE
[CDAP-21170] Enable Auto rotation of KMS keys used for secure keys

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5021,6 +5021,26 @@
   </property>
 
   <property>
+    <name>security.store.system.properties.gcp-cloudkms.key.rotation.enabled</name>
+    <value>true</value>
+    <description>
+      Enable key rotation for KMS keys used to encrypt and decrypt secure keys.
+      When true, it will enable rotation for newly created keys as well as
+      existing keys (after upgrade).
+    </description>
+  </property>
+
+  <property>
+    <name>security.store.system.properties.gcp-cloudkms.key.rotation.period.days</name>
+    <value>90</value>
+    <description>
+      Specifies the rotation period applied to KMS keys when
+      security.store.system.properties.gcp-cloudkms.key.rotation.enabled is true.
+      The rotation period must be at least 1 day.
+    </description>
+  </property>
+
+  <property>
     <name>security.token.digest.algorithm</name>
     <value>HmacSHA256</value>
     <description>

--- a/cdap-securestore-ext-cloudkms/pom.xml
+++ b/cdap-securestore-ext-cloudkms/pom.xml
@@ -77,6 +77,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-securestore-ext-cloudkms/src/main/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudKMSClient.java
+++ b/cdap-securestore-ext-cloudkms/src/main/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudKMSClient.java
@@ -30,6 +30,8 @@ import com.google.api.services.cloudkms.v1.model.DecryptResponse;
 import com.google.api.services.cloudkms.v1.model.EncryptRequest;
 import com.google.api.services.cloudkms.v1.model.EncryptResponse;
 import com.google.api.services.cloudkms.v1.model.KeyRing;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.io.CharStreams;
 import java.io.Closeable;
 import java.io.File;
@@ -40,7 +42,10 @@ import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -59,12 +64,17 @@ class CloudKMSClient implements Closeable {
   private static final String CLOUD_KMS = "cloudkms";
   private static final String PROJECT_ID = "project.id";
   private static final String SERVICE_ACCOUNT_FILE = "service.account.file";
+  private static final String ENABLE_KEY_ROTATION = "key.rotation.enabled";
+  private static final String KEY_ROTATION_PERIOD_DAYS = "key.rotation.period.days";
   private static final String METADATA_SERVER_API = "metadata.server.api";
   private static final String DEFAULT_METADATA_SERVER_API =
       "http://metadata.google.internal/computeMetadata"
           + "/v1/project/project-id";
   private static final String KEYRING_ID = "keyring.id";
   private static final String DEFAULT_KEYRING_ID = "cdap";
+  private static final String KEY_RING_FORMAT = "projects/%s/locations/%s/keyRings/%s";
+  private static final String CRYPTO_KEY_FORMAT = KEY_RING_FORMAT + "/cryptoKeys/%s";
+  private static final String DEFAULT_KEY_ROTATION_PERIOD_DAYS = "90";
 
 
   private final CloudKMS cloudKMS;
@@ -72,6 +82,8 @@ class CloudKMSClient implements Closeable {
   private final String keyringId;
   // In-memory cache to hold created crypto keys, this is to avoid checking if a given crypto key exists.
   private final Set<String> knownCryptoKeys;
+  private final Boolean enableKeyRotation;
+  private final Long keyRotationPeriod;
 
   /**
    * Constructs Cloud KMS client.
@@ -87,6 +99,22 @@ class CloudKMSClient implements Closeable {
     this.cloudKMS = createCloudKMS(serviceAccountFile);
     this.keyringId = properties.getOrDefault(KEYRING_ID, DEFAULT_KEYRING_ID);
     this.knownCryptoKeys = new HashSet<>();
+    this.enableKeyRotation = Boolean.parseBoolean(
+        properties.get(ENABLE_KEY_ROTATION));
+    this.keyRotationPeriod = initializeKeyRotationPeriod(properties);
+  }
+
+  private long initializeKeyRotationPeriod(Map<String, String> properties) {
+    long rotationPeriod = Long.parseLong(
+        properties.getOrDefault(KEY_ROTATION_PERIOD_DAYS, DEFAULT_KEY_ROTATION_PERIOD_DAYS));
+    if (rotationPeriod < 1) {
+      LOG.warn(
+          "Configured value for '{}' is {} which is less than minimum requirement of "
+              + "1 day. Falling back to the default of {} days.",
+          KEY_ROTATION_PERIOD_DAYS, rotationPeriod, DEFAULT_KEY_ROTATION_PERIOD_DAYS);
+      rotationPeriod = Long.parseLong(DEFAULT_KEY_ROTATION_PERIOD_DAYS);
+    }
+    return rotationPeriod;
   }
 
   /**
@@ -115,7 +143,8 @@ class CloudKMSClient implements Closeable {
    * @return an authorized CloudKMS client
    * @throws IOException if credentials can not be created in current environment
    */
-  private CloudKMS createCloudKMS(String serviceAccountFile) throws IOException {
+   @VisibleForTesting
+   CloudKMS createCloudKMS(String serviceAccountFile) throws IOException {
     HttpTransport transport = new NetHttpTransport();
     JsonFactory jsonFactory = new JacksonFactory();
     GoogleCredential credential;
@@ -163,6 +192,56 @@ class CloudKMSClient implements Closeable {
     }
   }
 
+   void enableKeyRotationIfNeeded() throws IOException {
+    if (!this.enableKeyRotation) {
+      return;
+    }
+
+    String keyRingName = String.format(KEY_RING_FORMAT, projectId, LOCATION_ID, keyringId);
+    try {
+      List<CryptoKey> cryptoKeys = cloudKMS.projects().locations().keyRings().cryptoKeys()
+          .list(keyRingName).execute().getCryptoKeys();
+      if (cryptoKeys == null || cryptoKeys.isEmpty()) {
+        LOG.info("No existing crypto keys found in keyring {}.", keyringId);
+        return;
+      }
+
+      for (CryptoKey cryptoKey : cryptoKeys) {
+        String cryptoKeyName = cryptoKey.getName();
+        String cryptoKeyId = cryptoKeyName.substring(
+            cryptoKeyName.lastIndexOf('/') + 1);
+
+        if (Strings.isNullOrEmpty(cryptoKey.getRotationPeriod())) {
+          CryptoKey updateRequest = new CryptoKey();
+          // Setting rotation period to 90 days for KMS keys.
+          long rotationInSeconds = Duration.ofDays(this.keyRotationPeriod).getSeconds();
+          updateRequest.setRotationPeriod(rotationInSeconds + "s");
+          // Setting nextRotationTime to 1 day after the key is updated.
+          Instant nextRotationTime = Instant.now().plus(Duration.ofDays(1));
+          updateRequest.setNextRotationTime(nextRotationTime.toString());
+
+          String resourceName = String.format(CRYPTO_KEY_FORMAT, projectId, LOCATION_ID, keyringId, cryptoKeyId);
+          try {
+            cloudKMS.projects().locations().keyRings().cryptoKeys()
+                .patch(resourceName, updateRequest)
+                .setUpdateMask(
+                    "rotation_period,next_rotation_time")
+                .execute();
+            LOG.info("Successfully updated rotation period for crypto key {}.", cryptoKeyId);
+          } catch (GoogleJsonResponseException e) {
+            throw new IOException(
+                String.format("Failed to update rotation period for crypto key %s", cryptoKeyId),
+                e);
+          }
+        }
+      }
+    } catch (GoogleJsonResponseException e) {
+      throw new IOException(
+          String.format("Exception occurred while listing crypto keys in keyring %s", keyringId),
+          e);
+    }
+  }
+
   /**
    * Creates a new crypto key on google cloud kms with the given id.
    *
@@ -175,14 +254,20 @@ class CloudKMSClient implements Closeable {
       return;
     }
 
-    String parent = String.format("projects/%s/locations/%s/keyRings/%s", projectId, LOCATION_ID,
-        keyringId);
-
     CryptoKey cryptoKey = new CryptoKey();
     // This will allow the API access to the key for symmetric encryption and decryption.
     cryptoKey.setPurpose(ENCRYPT_DECRYPT);
 
+    if (this.enableKeyRotation) {
+      long rotationInSeconds = Duration.ofDays(this.keyRotationPeriod).getSeconds();
+      cryptoKey.setRotationPeriod(rotationInSeconds + "s");
+
+      Instant nextRotationTime = Instant.now().plus(Duration.ofDays(1));
+      cryptoKey.setNextRotationTime(nextRotationTime.toString());
+    }
+
     try {
+      String parent = String.format(KEY_RING_FORMAT, projectId, LOCATION_ID, keyringId);
       cloudKMS.projects().locations().keyRings().cryptoKeys()
           .create(parent, cryptoKey)
           .setCryptoKeyId(cryptoKeyId)
@@ -210,8 +295,7 @@ class CloudKMSClient implements Closeable {
    * @throws IOException there's an error in encrypting secret
    */
   byte[] encrypt(String cryptoKeyId, byte[] secret) throws IOException {
-    String resourceName = String.format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, LOCATION_ID,
+    String resourceName = String.format(CRYPTO_KEY_FORMAT, projectId, LOCATION_ID,
         keyringId, cryptoKeyId);
     // secret must not be longer than 64KiB.
     EncryptRequest request = new EncryptRequest().encodePlaintext(secret);
@@ -236,8 +320,8 @@ class CloudKMSClient implements Closeable {
    * @throws IOException there's an error in decrypting secret
    */
   byte[] decrypt(String cryptoKeyId, byte[] encryptedSecret) throws IOException {
-    String resourceName = String.format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
-        projectId, LOCATION_ID, keyringId, cryptoKeyId);
+    String resourceName = String.format(CRYPTO_KEY_FORMAT, projectId, LOCATION_ID, keyringId,
+        cryptoKeyId);
 
     DecryptRequest request = new DecryptRequest().encodeCiphertext(encryptedSecret);
     DecryptResponse response = cloudKMS.projects().locations().keyRings().cryptoKeys()

--- a/cdap-securestore-ext-cloudkms/src/main/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudSecretManager.java
+++ b/cdap-securestore-ext-cloudkms/src/main/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudSecretManager.java
@@ -55,6 +55,7 @@ public class CloudSecretManager implements SecretManager {
     this.store = context.getSecretStore();
     this.client = new CloudKMSClient(context.getProperties());
     this.client.createKeyRingIfNotExists();
+    this.client.enableKeyRotationIfNeeded();
   }
 
   @Override

--- a/cdap-securestore-ext-cloudkms/src/test/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudKMSClientTest.java
+++ b/cdap-securestore-ext-cloudkms/src/test/java/io/cdap/cdap/securestore/gcp/cloudkms/CloudKMSClientTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudkms;
+
+import com.google.api.services.cloudkms.v1.CloudKMS;
+import com.google.api.services.cloudkms.v1.model.CryptoKey;
+import com.google.api.services.cloudkms.v1.model.ListCryptoKeysResponse;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloudKMSClientTest {
+
+  private static final String TEST_PROJECT_ID = "test-project";
+  private static final String TEST_KEYRING_ID = "test-instance";
+  private static final String LOCATION_ID = "global";
+
+  @Mock
+  private CloudKMS mockKMS;
+  @Mock
+  private CloudKMS.Projects mockProjects;
+  @Mock
+  private CloudKMS.Projects.Locations mockLocations;
+  @Mock
+  private CloudKMS.Projects.Locations.KeyRings mockKeyRings;
+  @Mock
+  private CloudKMS.Projects.Locations.KeyRings.CryptoKeys mockCryptoKeys;
+  @Mock
+  private CloudKMS.Projects.Locations.KeyRings.CryptoKeys.Create mockCreate;
+  @Mock
+  private CloudKMS.Projects.Locations.KeyRings.CryptoKeys.Patch mockPatch;
+  @Mock
+  private CloudKMS.Projects.Locations.KeyRings.CryptoKeys.List mockList;
+
+  @Captor
+  private ArgumentCaptor<CryptoKey> cryptoKeyCaptor;
+  @Captor
+  private ArgumentCaptor<String> resourceNameCaptor;
+  @Captor
+  private ArgumentCaptor<String> updateMaskCaptor;
+
+  @Before
+  public void setUp() throws Exception {
+    when(mockKMS.projects()).thenReturn(mockProjects);
+    when(mockProjects.locations()).thenReturn(mockLocations);
+    when(mockLocations.keyRings()).thenReturn(mockKeyRings);
+    when(mockKeyRings.cryptoKeys()).thenReturn(mockCryptoKeys);
+    when(mockCryptoKeys.create(anyString(), any(CryptoKey.class))).thenReturn(mockCreate);
+    when(mockCreate.setCryptoKeyId(anyString())).thenReturn(mockCreate);
+    when(mockCryptoKeys.patch(anyString(), any(CryptoKey.class))).thenReturn(mockPatch);
+    when(mockPatch.setUpdateMask(anyString())).thenReturn(mockPatch);
+    when(mockCryptoKeys.list(anyString())).thenReturn(mockList);
+  }
+
+  private CloudKMSClient initializeClient(boolean rotationEnabled) throws IOException {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("project.id", TEST_PROJECT_ID);
+    properties.put("keyring.id", TEST_KEYRING_ID);
+    properties.put("key.rotation.period.days", "90");
+    properties.put("key.rotation.enabled", String.valueOf(rotationEnabled));
+    return new CloudKMSClient(properties) {
+      @Override
+      CloudKMS createCloudKMS(String serviceAccountFile) {
+        return mockKMS;
+      }
+    };
+  }
+
+  @Test
+  public void testCreateCryptoKeyIfNotExists_setsRotationPeriodDetails() throws IOException {
+    CloudKMSClient cloudKMSclient = initializeClient(true);
+    String cryptoKeyId = "new-test-key";
+    Instant testStartTime = Instant.now();
+    cloudKMSclient.createCryptoKeyIfNotExists(cryptoKeyId);
+
+    verify(mockCryptoKeys).create(anyString(), cryptoKeyCaptor.capture());
+    CryptoKey capturedKey = cryptoKeyCaptor.getValue();
+
+    assertNotNull(capturedKey.getNextRotationTime());
+    Instant nextRotation = Instant.parse(capturedKey.getNextRotationTime());
+    assertTrue(nextRotation.isAfter(testStartTime));
+
+    long expectedSeconds = Duration.ofDays(90).getSeconds();
+    assertEquals(expectedSeconds + "s", capturedKey.getRotationPeriod());
+  }
+
+  @Test
+  public void testCreateCryptoKeyIfNotExists_doesNotSetRotationWhenDisabled() throws IOException {
+    CloudKMSClient cloudKMSclient = initializeClient(false);
+    String cryptoKeyId = "new-key-no-rotation";
+    cloudKMSclient.createCryptoKeyIfNotExists(cryptoKeyId);
+
+    verify(mockCryptoKeys).create(anyString(), cryptoKeyCaptor.capture());
+    CryptoKey capturedKey = cryptoKeyCaptor.getValue();
+
+    assertNull(capturedKey.getNextRotationTime());
+    assertNull(capturedKey.getRotationPeriod());
+  }
+
+  @Test
+  public void testEnableRotationForExistingKeys_updatesKeyWithoutRotation() throws IOException {
+    CloudKMSClient cloudKMSclient = initializeClient(true);
+    String keyToUpdateId = "key-without-rotation";
+    String keyToUpdateFullName = String.format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
+        TEST_PROJECT_ID, LOCATION_ID, TEST_KEYRING_ID, keyToUpdateId);
+
+    String keyToSkipId = "key-with-rotation";
+    String keyToSkipFullName = String.format("projects/%s/locations/%s/keyRings/%s/cryptoKeys/%s",
+        TEST_PROJECT_ID, LOCATION_ID, TEST_KEYRING_ID, keyToSkipId);
+
+    CryptoKey keyToUpdate = new CryptoKey().setName(keyToUpdateFullName);
+    CryptoKey keyToSkip = new CryptoKey().setName(keyToSkipFullName).setRotationPeriod("7776000s");
+
+    ListCryptoKeysResponse response = new ListCryptoKeysResponse().setCryptoKeys(
+        Arrays.asList(keyToUpdate, keyToSkip));
+    when(mockList.execute()).thenReturn(response);
+
+    cloudKMSclient.enableKeyRotationIfNeeded();
+
+    verify(mockPatch, times(1)).execute();
+    verify(mockCryptoKeys).patch(resourceNameCaptor.capture(), cryptoKeyCaptor.capture());
+    verify(mockPatch).setUpdateMask(updateMaskCaptor.capture());
+
+    assertEquals(keyToUpdateFullName, resourceNameCaptor.getValue());
+
+    long expectedSeconds = Duration.ofDays(90).getSeconds();
+    assertEquals(expectedSeconds + "s", cryptoKeyCaptor.getValue().getRotationPeriod());
+    assertEquals("rotation_period,next_rotation_time", updateMaskCaptor.getValue());
+  }
+}


### PR DESCRIPTION
To resolve a vulnerability, we need to enable auto rotation, for at most 90 days, of KMS keys which are used to encrypt/decrypt secure keys.

Changes made - 
- Key rotation is enabled by default for all new keys in the keyring.
- Key rotation is enabled for existing keys in the keyring if not already enabled. This scenario will executed during upgrade.

Testing -
- Created an instance with the modified image and newly created kms keys had rotation enabled.
- Created an image with KMS keys not having rotation enabled. Upgrade the image to a version which uses modified image and rotation got enabled in existing kms keys.
- Created a MySQL -> Trash pipeline. Inside MySQL source plugin, added macro for secure key value in the password field. Successfully ran the pipeline. Manually rotated the key (the minimum rotation period is 24 hrs). After this, pipeline ran successfully.