### PR TITLE
Adding fetcher for plugin to pipeline mapping.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/ApplicationPluginMapping.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/ApplicationPluginMapping.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.upgrade;
+
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.PluginId;
+import java.util.Objects;
+
+/**
+ * Mapping for the latest application version and its plugin.
+ */
+public class ApplicationPluginMapping {
+
+  // Version less application Id.
+  private final ApplicationId applicationId;
+  private final PluginId pluginId;
+
+  public ApplicationPluginMapping(ApplicationId applicationId, PluginId pluginId) {
+    this.applicationId = applicationId;
+    this.pluginId = pluginId;
+  }
+
+  public ApplicationId getApplicationId() {
+    return applicationId;
+  }
+
+  public PluginId getPluginId() {
+    return pluginId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ApplicationPluginMapping)) {
+      return false;
+    }
+    ApplicationPluginMapping that = (ApplicationPluginMapping) o;
+    return Objects.equals(applicationId, that.applicationId) && Objects.equals(
+        pluginId, that.pluginId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(applicationId, pluginId);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/ApplicationPluginMappingFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/ApplicationPluginMappingFetcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.upgrade;
+
+import io.cdap.cdap.proto.id.NamespaceId;
+import java.util.List;
+
+/**
+ * Fetcher for application to plugin mapping.
+ */
+public interface ApplicationPluginMappingFetcher {
+
+  /**
+   * Fetches application to plugin mapping for a namespace.
+   *
+   * @param namespace the namespace for which mapping will be fetched.
+   * @return a list of type {@link ApplicationPluginMapping}. An empty list will be returned if no
+   *     applications are found.
+   * @throws Exception the exception during fetching of application plugin mapping.
+   */
+  List<ApplicationPluginMapping> fetchApplicationPluginMapping(NamespaceId namespace)
+      throws Exception;
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/MetadataApplicationPluginMappingFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/upgrade/MetadataApplicationPluginMappingFetcher.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.upgrade;
+
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.metadata.MetadataAdmin;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.PluginId;
+import io.cdap.cdap.spi.metadata.MetadataRecord;
+import io.cdap.cdap.spi.metadata.SearchRequest;
+import io.cdap.cdap.spi.metadata.SearchResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+
+/**
+ * Fetcher for application to plugin mapping from the stored metadata.
+ */
+public class MetadataApplicationPluginMappingFetcher implements ApplicationPluginMappingFetcher {
+
+  private static final String CONNECTOR_PROPERTY = "connector";
+  private static final String PROPERTY_SEPARATOR = ":";
+
+  private final MetadataAdmin metadataAdmin;
+
+  @Inject
+  public MetadataApplicationPluginMappingFetcher(MetadataAdmin metadataAdmin) {
+    this.metadataAdmin = metadataAdmin;
+  }
+
+  @Override
+  public List<ApplicationPluginMapping> fetchApplicationPluginMapping(NamespaceId namespaceId)
+      throws Exception {
+    String namespace = namespaceId.getNamespace();
+    List<ApplicationPluginMapping> results = new ArrayList<>();
+    results.addAll(fromSearchResponse(
+        metadataAdmin.search(buildSearchRequest(MetadataScope.USER, namespaceId)),
+        namespace));
+    results.addAll(
+        fromSearchResponse(
+            metadataAdmin.search(buildSearchRequest(MetadataScope.SYSTEM, namespaceId)),
+            namespace));
+    return results;
+  }
+
+  private List<ApplicationPluginMapping> fromSearchResponse(SearchResponse response,
+      String namespace) {
+    List<ApplicationPluginMapping> results = new ArrayList<>();
+    for (MetadataRecord result : response.getResults()) {
+      MetadataEntity pluginEntity = result.getEntity();
+      if (!MetadataEntity.PLUGIN.equalsIgnoreCase(pluginEntity.getType())) {
+        continue;
+      }
+      PluginId pluginDetail = toPluginId(pluginEntity);
+      String namespacePrefix = namespace + PROPERTY_SEPARATOR;
+      // Pipelines are present as part of system scope.
+      Map<String, String> pluginProperties = result.getMetadata()
+          .getProperties(MetadataScope.SYSTEM);
+      for (String propertyKey : pluginProperties.keySet()) {
+        if (CONNECTOR_PROPERTY.equalsIgnoreCase(propertyKey) || !propertyKey
+            .startsWith(namespacePrefix)) {
+          continue;
+        }
+        String[] split = propertyKey.split(PROPERTY_SEPARATOR);
+        results.add(
+            new ApplicationPluginMapping(new ApplicationId(split[0], split[1]), pluginDetail));
+      }
+    }
+    return results;
+  }
+
+  private PluginId toPluginId(MetadataEntity pluginEntity) {
+    return new PluginId(pluginEntity.getValue(MetadataEntity.NAMESPACE),
+        pluginEntity.getValue(MetadataEntity.ARTIFACT),
+        pluginEntity.getValue(MetadataEntity.VERSION),
+        pluginEntity.getValue(MetadataEntity.PLUGIN),
+        pluginEntity.getValue(MetadataEntity.TYPE));
+  }
+
+  private SearchRequest buildSearchRequest(MetadataScope scope, NamespaceId namespaceId) {
+    SearchRequest.Builder builder = SearchRequest.of("*").
+        addType(MetadataEntity.PLUGIN);
+    if (MetadataScope.SYSTEM == scope) {
+      builder.addNamespace(scope.toString().toLowerCase());
+    } else {
+      builder.addNamespace(namespaceId.getNamespace());
+    }
+    return builder.build();
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/upgrade/MetadataApplicationPluginMappingFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/upgrade/MetadataApplicationPluginMappingFetcherTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.upgrade;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.metadata.MetadataAdmin;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.PluginId;
+import io.cdap.cdap.spi.metadata.Metadata;
+import io.cdap.cdap.spi.metadata.MetadataRecord;
+import io.cdap.cdap.spi.metadata.SearchRequest;
+import io.cdap.cdap.spi.metadata.SearchResponse;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Parameterized tests for {@link MetadataApplicationPluginMappingFetcher} using a parameter class.
+ */
+@RunWith(Parameterized.class)
+public class MetadataApplicationPluginMappingFetcherTest {
+
+  // A static inner class to hold the parameters for each test case
+  static class TestCaseParams {
+
+    final String name;
+    final SearchResponse userResponse;
+    final SearchResponse systemResponse;
+    final List<ApplicationPluginMapping> expectedMappings;
+
+    TestCaseParams(String name, SearchResponse userResponse, SearchResponse systemResponse,
+        List<ApplicationPluginMapping> expectedMappings) {
+      this.name = name;
+      this.userResponse = userResponse;
+      this.systemResponse = systemResponse;
+      this.expectedMappings = expectedMappings;
+    }
+  }
+
+  @Parameters(name = "{index}: {0}")
+  public static Collection<Object[]> data() {
+    SearchResponse emptyResponse = new SearchResponse(SearchRequest.of("*").build(), null, 0,
+        Integer.MAX_VALUE, 0, Collections.emptyList());
+
+    SearchResponse userPluginResponse = new SearchResponse(SearchRequest.of("*").build(), null, 0,
+        Integer.MAX_VALUE, 0, ImmutableList.of(new MetadataRecord(
+        MetadataEntity.builder().append("namespace", "default")
+            .append("artifact", "trash-plugin")
+            .append("version", "1.2.0")
+            .append(MetadataEntity.TYPE, "batchsink")
+            .appendAsType(MetadataEntity.PLUGIN, "trash")
+            .build(),
+        new Metadata(
+            MetadataScope.SYSTEM, ImmutableMap.of("default:pipeline_1", "1")))));
+
+    SearchResponse systemPluginResponse = new SearchResponse(SearchRequest.of("*").build(), null, 0,
+        Integer.MAX_VALUE, 0, ImmutableList.of(new MetadataRecord(
+        MetadataEntity.builder().append("namespace", "system")
+            .append("artifact", "google-cloud")
+            .append("version", "0.24.0")
+            .append(MetadataEntity.TYPE, "batchsource")
+            .appendAsType(MetadataEntity.PLUGIN, "GCS")
+            .build(),
+        new Metadata(
+            MetadataScope.SYSTEM, ImmutableMap.of("default:pipeline_1", "1")))));
+
+    ApplicationPluginMapping applicationSystemPluginMapping =
+        new ApplicationPluginMapping(new ApplicationId("default", "pipeline_1"),
+            new PluginId("system", "google-cloud", "0.24.0", "GCS", "batchsource"));
+    ApplicationPluginMapping applicationUserPluginMapping =
+        new ApplicationPluginMapping(new ApplicationId("default", "pipeline_1"),
+            new PluginId("default", "trash-plugin", "1.2.0", "trash", "batchsink"));
+
+    return Arrays.asList(new Object[][]{
+        {new TestCaseParams("No Plugin Mappings", emptyResponse, emptyResponse,
+            Collections.emptyList())},
+        {new TestCaseParams("Only System Plugin Mappings", emptyResponse, systemPluginResponse,
+            ImmutableList.of(applicationSystemPluginMapping))},
+        {new TestCaseParams("Only User Plugin Mappings", userPluginResponse, emptyResponse,
+            ImmutableList.of(applicationUserPluginMapping))},
+        {new TestCaseParams("Both Plugin Mappings present", userPluginResponse,
+            systemPluginResponse,
+            ImmutableList.of(applicationUserPluginMapping, applicationSystemPluginMapping))}
+    });
+  }
+
+  @Mock
+  private MetadataAdmin metadataAdmin;
+
+  private MetadataApplicationPluginMappingFetcher mappingFetcher;
+
+  private final TestCaseParams params;
+
+  public MetadataApplicationPluginMappingFetcherTest(TestCaseParams params) {
+    this.params = params;
+  }
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    mappingFetcher = new MetadataApplicationPluginMappingFetcher(metadataAdmin);
+  }
+
+  @Test
+  public void testFetchApplicationPluginMapping() throws Exception {
+    // Arrange
+    SearchRequest userPluginRequest = SearchRequest.of("*").addType("plugin")
+        .addNamespace(NamespaceId.DEFAULT.getNamespace())
+        .build();
+    SearchRequest systemPluginRequest = SearchRequest.of("*").addType("plugin")
+        .addNamespace(NamespaceId.SYSTEM.getNamespace()).build();
+
+    when(metadataAdmin.search(eq(userPluginRequest))).thenReturn(params.userResponse);
+    when(metadataAdmin.search(eq(systemPluginRequest))).thenReturn(params.systemResponse);
+
+    // Act
+    List<ApplicationPluginMapping> actual = mappingFetcher.fetchApplicationPluginMapping(
+        NamespaceId.DEFAULT);
+
+    // Assert
+    Assert.assertEquals(String.format("Test case '%s' failed.", params.name),
+        params.expectedMappings, actual);
+    verify(metadataAdmin, times(1)).search(userPluginRequest);
+    verify(metadataAdmin, times(1)).search(systemPluginRequest);
+  }
+}


### PR DESCRIPTION
* Added a metadata fetcher to fetch mapping from CDAP metadata.

Sample response from metadata API for a user plugin `Trash` and the pipeline `DataFusionQuickstart`
```
{
  "sort": "io.cdap.cdap.data2.metadata.dataset.SortInfo@74a24bc1",
  "offset": 0,
  "limit": 2147483647,
  "numCursors": 0,
  "total": 1,
  "results": [
    {
      "metadataEntity": {
        "details": {
          "namespace": "default",
          "artifact": "trash-plugin",
          "version": "1.2.0",
          "type": "batchsink",
          "plugin": "Trash"
        },
        "type": "plugin"
      },
      "metadata": {
        "SYSTEM": {
          "properties": {
            "default:DataFusionQuickstart": "1"
          },
          "tags": []
        }
      }
    }
  ],
  "cursors": [],
  "showHidden": false,
  "entityScope": [
    "USER"
  ]
}
```