### PR TITLE
[Cherrypick][CDAP-21161]Add new API for app count in a namespace.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -729,6 +729,14 @@ public interface Store {
   void deleteAllStates(NamespaceId namespaceId, String appName) throws ApplicationNotFoundException;
 
   /**
+   * Get the count of latest applications in the namespace.
+   *
+   * @param namespaceId NamespaceId of the application.
+   * @return the count of applications in the namespace
+   */
+  long getApplicationCount(NamespaceId namespaceId);
+
+  /**
    * Ensures the given program exists in the given application spec.
    *
    * @throws NotFoundException if the program does not exists.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -496,6 +496,20 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
   }
 
   /**
+   * Gets count for all application the namespace.
+   *
+   * <p>This API returns the count for latest applications only.</>
+   */
+  @GET
+  @Path("/apps/count")
+  public void getAppsCount(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId) throws Exception {
+    NamespaceId namespace = validateNamespace(namespaceId);
+    long count = applicationLifecycleService.getApplicationsCount(namespace);
+    responder.sendString(HttpResponseStatus.OK, String.valueOf(count));
+  }
+
+  /**
    * Updates an existing application.
    * Deprecated : Unused - just another deploy action after introduction of edit versions
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -299,6 +299,22 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
   }
 
+  /**
+   * Get application count of the latest versions in the namespace.
+   *
+   * @param namespace namespace for which count is to be returned.
+   * @return Count of the applications in the namespace.
+   */
+  public long getApplicationsCount(NamespaceId namespace) {
+    if (namespace == null) {
+      throw new IllegalStateException("Application scan request without namespace");
+    }
+    // Get count should have the same permissions as list apps since its used in tandem.
+    accessEnforcer.enforceOnParent(EntityType.APPLICATION, namespace,
+        authenticationContext.getPrincipal(), StandardPermission.LIST);
+    return store.getApplicationCount(namespace);
+  }
+
   private void processApplications(List<Map.Entry<ApplicationId, ApplicationMeta>> list,
       Consumer<ApplicationDetail> consumer) {
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -391,13 +391,29 @@ public class AppMetadataStore {
             Range.Bound.EXCLUSIVE),
         Range.create(fields, Range.Bound.EXCLUSIVE, null,
             Range.Bound.INCLUSIVE));
-    // Count the latest version of app,
-    // we treat latest=["true",null] as latest for backward compatibility.
+    return getApplicationSpecificationTable().count(ranges, createLatestFilterIndex());
+  }
+
+  /**
+   * Returns the number of applications in the given namespace.
+   *
+   * @param namespaceId namespace ID for which to count.
+   * @return the count of application in the namespace.
+   * @throws IOException if the count fails.
+   */
+  public long getNamespaceApplicationCount(NamespaceId namespaceId) throws IOException {
+    Collection<Range> ranges = ImmutableList.of(Range.singleton(
+        ImmutableList.of(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD,
+            namespaceId.getNamespace()))));
+    return getApplicationSpecificationTable().count(ranges, createLatestFilterIndex());
+  }
+
+  private Collection<Field<?>> createLatestFilterIndex() {
+    // We treat latest=["true",null] as latest for backward compatibility.
     // Prior to 6.8, all versions of an application were returned in the list apps api, not just the latest version.
-    Collection<Field<?>> filterIndexes =
-        ImmutableList.of(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null),
-            Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
-    return getApplicationSpecificationTable().count(ranges, filterIndexes);
+    return ImmutableList.of(
+        Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null),
+        Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
   }
 
   @Nullable

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -1179,6 +1179,14 @@ public class DefaultStore implements Store {
     }, ApplicationNotFoundException.class);
   }
 
+  @Override
+  public long getApplicationCount(NamespaceId namespaceId) {
+    return TransactionRunners.run(transactionRunner, context -> {
+          return getAppMetadataStore(context).getNamespaceApplicationCount(namespaceId);
+        }
+    );
+  }
+
   private AppStateTable getAppStateTable(StructuredTableContext context)
       throws TableNotFoundException {
     return new AppStateTable(context);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.Gateway;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.id.Id.Namespace;
 import io.cdap.cdap.common.io.Locations;
@@ -842,6 +843,24 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
             "commitId")
     );
   }
+
+  @Test
+  public void testGetApplicationCount() throws Exception {
+    createNamespace("customNS");
+    deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, "customNS");
+    deploy(ConfigTestApp.class, 200, Gateway.API_VERSION_3_TOKEN, "customNS");
+
+    long count = applicationLifecycleService.getApplicationsCount(new NamespaceId("customNS"));
+
+    Assert.assertEquals(2, count);
+    deleteNamespace("customNS");
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGetApplicationCountNullNamespace() {
+    applicationLifecycleService.getApplicationsCount(null);
+  }
+
 
   private void waitForRuns(int expected, final ProgramId programId, final ProgramRunStatus status) throws Exception {
     Tasks.waitFor(expected, () -> getProgramRuns(Id.Program.fromEntityId(programId), status).size(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -641,6 +641,14 @@ public abstract class AppFabricTestBase {
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
   }
 
+  protected long getAppCount(String namespace) throws Exception {
+    HttpResponse response = doGet(getVersionedApiPath("apps/count",
+        Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return Long.parseLong(response.getResponseBodyAsString());
+  }
+
+
   protected List<JsonObject> getAppListForNegativePaginatedApi(String namespace, int pageSize) throws Exception {
     String uri = "apps/?pageSize=" + pageSize;
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -1594,6 +1594,33 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     deleteArtifact(artifactId, 200);
   }
 
+  @Test
+  public void testGetApplicationCount() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      String ns1AppName = AllProgramsApp.NAME + i;
+      Id.Namespace ns1 = Id.Namespace.from(TEST_NAMESPACE1);
+      Id.Artifact ns1ArtifactId = Id.Artifact.from(ns1, AllProgramsApp.class.getSimpleName(),
+          "1.0.0-SNAPSHOT");
+
+      HttpResponse response = addAppArtifact(ns1ArtifactId, AllProgramsApp.class);
+      Assert.assertEquals(200, response.getResponseCode());
+      Id.Application appId = Id.Application.from(ns1, ns1AppName);
+      response = deploy(appId,
+          new AppRequest<>(ArtifactSummary.from(ns1ArtifactId.toArtifactId())));
+      Assert.assertEquals(200, response.getResponseCode());
+    }
+
+    long result = getAppCount(TEST_NAMESPACE1);
+    Assert.assertEquals(10, result);
+
+    HttpResponse response = doDelete(getVersionedApiPath("apps/",
+        Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1));
+    Assert.assertEquals(200, response.getResponseCode());
+
+    result = getAppCount(TEST_NAMESPACE1);
+    Assert.assertEquals(0, result);
+  }
+
   @After
   public void cleanup() throws Exception {
     setLCMFlag(false);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -1102,6 +1102,49 @@ public abstract class AppMetadataStoreTest {
   }
 
   @Test
+  public void testGetApplicationCount() {
+    ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
+    NamespaceId customNamespace = new NamespaceId("custom");
+    createMultipleApplications(NamespaceId.DEFAULT, "test-default", 20, appSpec);
+    createMultipleApplications(NamespaceId.SYSTEM, "test-system", 5, appSpec);
+    createMultipleApplications(customNamespace, "test-custom", 15, appSpec);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      long count = store.getApplicationCount();
+      // System apps are not included in the count. Default(20) and custom(15) are included.
+      Assert.assertEquals(35, count);
+    });
+
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      // System namespace has 20 applications.
+      long count = store.getNamespaceApplicationCount(NamespaceId.DEFAULT);
+      Assert.assertEquals(20, count);
+      // System namespace has 5 applications.
+      count = store.getNamespaceApplicationCount(NamespaceId.SYSTEM);
+      Assert.assertEquals(5, count);
+      // Custom namespace has 15 applications.
+      count = store.getNamespaceApplicationCount(customNamespace);
+      Assert.assertEquals(15, count);
+    });
+
+  }
+
+  private void createMultipleApplications(NamespaceId namespaceId, String appPrefix, int count,
+      ApplicationSpecification appSpec) {
+    for (int i = 0; i < count; i++) {
+      String appName = appPrefix + i;
+      TransactionRunners.run(transactionRunner, context -> {
+        AppMetadataStore store = AppMetadataStore.create(context);
+        store.writeApplication(namespaceId.getNamespace(), appName, ApplicationId.DEFAULT_VERSION,
+            appSpec,
+            new ChangeDetail(null, null, null, creationTimeMillis), null);
+      });
+    }
+  }
+
+  @Test
   public void testScanApplications() {
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -1446,6 +1446,23 @@ public abstract class DefaultStoreTest {
     Assert.assertEquals(latestAppId.get(), actualApps.get(0));
   }
 
+  @Test
+  public void testGetApplicationCount() throws ConflictException {
+    ApplicationSpecification spec = Specifications.from(new AllProgramsApp());
+    NamespaceId namespaceId = new NamespaceId("custom");
+    ApplicationMeta appMeta = new ApplicationMeta(spec.getName(), spec,
+        new ChangeDetail(null, null, null,
+            System.currentTimeMillis()));
+    for (int i = 0; i < 5; i++) {
+      ApplicationId appId = namespaceId.app("application" + i);
+      store.addLatestApplication(appId, appMeta);
+      Assert.assertNotNull(store.getApplication(appId));
+    }
+    long result = store.getApplicationCount(namespaceId);
+
+    Assert.assertEquals(5, result);
+  }
+
   private void writeStartRecord(ProgramRunId run, ArtifactId artifactId) {
     setStartAndRunning(run, artifactId);
     Assert.assertNotNull(store.getRun(run));


### PR DESCRIPTION
* The new API will be used in the namespace Admin page to display total count of the applications in the namespace.
* This API intentionally currently supports no filter and may be added in the future on need basis.

Cherry pick of PR #15980 .