### PR TITLE
[CDAP-21180] Instead of instantiation of Class,we can figure out the Configtype by only Class object

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/Artifacts.java
@@ -43,9 +43,12 @@ public final class Artifacts {
    * @return the resolved config type
    * @throws IllegalArgumentException if the config type is not a valid type
    */
-  public static Type getConfigType(Class<? extends Application> appClass) {
+  public static Type getConfigType(Class<?> appClass) {
+    // Class has to be a child of Application
+    Preconditions.checkArgument(Application.class.isAssignableFrom(appClass), "The given class : " + appClass
+      + " is not supported. Type must be a child class of Application");
     TypeToken<?> configType = TypeToken.of(appClass)
-        .resolveType(Application.class.getTypeParameters()[0]);
+      .resolveType(Application.class.getTypeParameters()[0]);
     if (Reflections.isResolved(configType.getType())) {
       // Default the type to Config.class if the resolved type is not subclass of Config.
       // It normally won't happen, unless someone generate the bytecode directly.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
@@ -241,13 +241,19 @@ final class DefaultArtifactInspector implements ArtifactInspector {
         return builder;
       }
 
-      Application app = (Application) mainClass.newInstance();
+      //If it's application assignable class, then ensure it has a public no-arg constructor
+      try {
+        mainClass.getConstructor();
+      } catch (NoSuchMethodException e) {
+        throw new InvalidArtifactException(String.format(
+          "Application class %s in artifact %s must have a public no-arg constructor.", mainClassName, artifactId));
+      }
 
       java.lang.reflect.Type configType;
       // if the user parameterized their application, like 'xyz extends Application<T>',
       // we can deserialize the config into that object. Otherwise it'll just be a Config
       try {
-        configType = Artifacts.getConfigType(app.getClass());
+        configType = Artifacts.getConfigType(mainClass);
       } catch (Exception e) {
         throw new InvalidArtifactException(String.format(
             "Could not resolve config type for Application class %s in artifact %s. "
@@ -258,7 +264,7 @@ final class DefaultArtifactInspector implements ArtifactInspector {
       Schema configSchema =
           configType == Config.class ? null : schemaGenerator.generate(configType);
       builder.addApp(new ApplicationClass(mainClassName, "", configSchema,
-          getArtifactRequirements(app.getClass())));
+          getArtifactRequirements(mainClass)));
     } catch (ClassNotFoundException e) {
       throw new InvalidArtifactException(String.format(
           "Could not find Application main class %s in artifact %s.", mainClassName, artifactId));
@@ -267,10 +273,6 @@ final class DefaultArtifactInspector implements ArtifactInspector {
           "Config for Application %s in artifact %s has an unsupported schema. "
               + "The type must extend Config and cannot be parameterized.", mainClassName,
           artifactId));
-    } catch (InstantiationException | IllegalAccessException e) {
-      throw new InvalidArtifactException(String.format(
-          "Could not instantiate Application class %s in artifact %s.", mainClassName, artifactId),
-          e);
     }
 
     return builder;


### PR DESCRIPTION
Context : https://cdap.atlassian.net/browse/CDAP-21180

Compared the values between the Old method and new method. And the values matches exactly. i.e.

`mainClass` is same as `app.getClass()`
and Value of `configType` is same : 

![Screenshot 2025-06-22 at 1 43 00 PM](https://github.com/user-attachments/assets/598520be-0a68-4691-b05e-e42447005787)

Tested above with Wrangler Service app ( dataprep ) 

