### PR TITLE
[CDAP-21172] Implement CRUD Operations for Metadata Tables

### DIFF
--- a/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/FormattedMetadata.java
+++ b/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/FormattedMetadata.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata.spanner;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.SchemaWalker;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.spi.metadata.Metadata;
+import io.cdap.cdap.spi.metadata.MetadataConstants;
+import io.cdap.cdap.spi.metadata.ScopedName;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A helper class to process and prepare metadata fields for optimized storage.
+ * This class encapsulates the logic for flattening text fields, parsing schemas,
+ * and extracting specific properties for relational storage.
+ */
+public class FormattedMetadata {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FormattedMetadata.class);
+
+  // Fields directly mapped to metadata table columns
+  private final String namespace;
+  private final String type;
+  private final String name;
+  private final Long created;
+  private final String userText;
+  private final String systemText;
+  private final Set<Property> metadataProps;
+
+  /**
+   * Creates an instance of FormattedMetadata from a MetadataEntity and Metadata.
+   * This is the public entry point for creating formatted metadata.
+   *
+   * @param entity   the metadata entity being processed.
+   * @param metadata the metadata to be associated with the entity.
+   * @return a new instance of FormattedMetadata.
+   * @throws IOException if schema parsing fails.
+   */
+  public static FormattedMetadata from(MetadataEntity entity, Metadata metadata) throws IOException {
+    return new FormattedMetadata(entity, metadata);
+  }
+
+  private FormattedMetadata(MetadataEntity entity, Metadata metadata) throws IOException {
+    this.namespace = entity.getValue("namespace");
+    this.type = entity.getType().toLowerCase();
+    this.name = Objects.requireNonNull(entity.getValue(entity.getType())).toLowerCase();
+
+    Map<ScopedName, String> properties = metadata.getProperties();
+    String schemaJson = properties.get(new ScopedName(MetadataScope.SYSTEM, MetadataConstants.SCHEMA_KEY));
+    Map<String, Set<Property>> schemaProperty = reformatSchemaProperty(schemaJson);
+    Map<String, Set<Property>> reformatedProperties = reformatProperties(properties);
+    Set<Property> reformatedPropertiesWithValue = reformatedProperties
+      .getOrDefault("extractedProperties", Collections.emptySet());
+    reformatedPropertiesWithValue.addAll(schemaProperty.getOrDefault("schemaAndFieldNames",
+                                                                     Collections.emptySet()));
+    Set<ScopedName> tags = metadata.getTags();
+    Set<Property> reformatedTags = reformatTags(tags);
+
+    this.metadataProps = new HashSet<>();
+    this.metadataProps.addAll(reformatedPropertiesWithValue);
+    this.metadataProps.addAll(reformatedTags);
+    this.metadataProps.add(new Property(MetadataScope.SYSTEM.name(), this.type, this.name));
+    this.systemText = buildText(reformatedPropertiesWithValue, tags, MetadataScope.SYSTEM) + " " + type;
+    this.metadataProps.addAll(reformatedProperties.getOrDefault("propertyNames", Collections.emptySet()));
+    this.metadataProps.addAll(schemaProperty.getOrDefault("fieldProperties", Collections.emptySet()));
+    this.userText = buildText(reformatedPropertiesWithValue, tags, MetadataScope.USER);
+    this.created = parseCreationTime(reformatedPropertiesWithValue).orElse(null);
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Optional<Long> getCreated() {
+    return Optional.ofNullable(created);
+  }
+
+  public String getUserText() {
+    return userText;
+  }
+
+  public String getSystemText() {
+    return systemText;
+  }
+
+  public Set<Property> getMetadataProps() {
+    return metadataProps;
+  }
+
+  /**
+   * Processes properties and extract property names into a Set.
+   *
+   * @param properties The original properties from the metadata object.
+   * @return A Set containing Property objects.
+   */
+  private Map<String, Set<Property>> reformatProperties(Map<ScopedName, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Set<Property> extracted = new HashSet<>(properties.size());
+    Set<String> propertyNames = new HashSet<>();
+    for (Map.Entry<ScopedName, String> entry : properties.entrySet()) {
+      ScopedName key = entry.getKey();
+      String name = key.getName().toLowerCase();
+      String scope = key.getScope().name();
+      String value = entry.getValue().toLowerCase();
+
+      // If it's a schema key, reformat it.
+      if (MetadataConstants.SCHEMA_KEY.equals(name)) {
+        continue;
+      }
+
+      extracted.add(new Property(scope, name, value));
+      propertyNames.add(name);
+    }
+
+    String allPropertiesValue = String.join(" ", propertyNames);
+    Set<Property> propertyValue = new HashSet<>();
+    propertyValue.add(new Property(MetadataScope.SYSTEM.name(),
+                                          MetadataConstants.PROPERTIES_KEY, allPropertiesValue));
+
+    Map<String, Set<Property>> result = new HashMap<>();
+    result.put("extractedProperties", extracted);
+    result.put("propertyNames", propertyValue);
+
+    return result;
+
+  }
+
+  /**
+   * Extracts tags into the set format.
+   */
+  private Set<Property> reformatTags(Set<ScopedName> tags) {
+    return tags.stream()
+      .map(tag -> new Property(tag.getScope().name(), MetadataConstants.TAGS_KEY, tag.getName()))
+      .collect(Collectors.toSet());
+  }
+
+  /**
+   * Builds a single, space-delimited string of text from properties and tags
+   * for a given scope.
+   */
+  private String buildText(Set<Property> properties, Set<ScopedName> tags, MetadataScope scope) {
+    String scopeProperties = properties.stream()
+      .filter(property -> Objects.equals(property.getScope(), scope.toString()))
+      .map(property -> property.getValue().toLowerCase())
+      .collect(Collectors.joining(" "));
+
+    String scopeTags = tags.stream()
+      .filter(tag -> tag.getScope() == scope)
+      .map(tag -> tag.getName().toLowerCase())
+      .collect(Collectors.joining(" "));
+
+    return Stream.of(scopeProperties, scopeTags)
+      .filter(s -> !s.isEmpty())
+      .collect(Collectors.joining(" "));
+  }
+
+  /**
+   * Finds and parses the creation time from the processed properties.
+   */
+  private Optional<Long> parseCreationTime(Set<Property> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String expectedScope = MetadataScope.SYSTEM.name();
+    String expectedName = MetadataConstants.CREATION_TIME_KEY;
+    for (Property property : properties) {
+      if (expectedScope.equalsIgnoreCase(property.getScope()) && expectedName.equalsIgnoreCase(property.getName())) {
+        try {
+          return Optional.of(Long.parseLong(property.getValue()));
+        } catch (NumberFormatException e) {
+          LOG.warn("Unable to parse property value '{}' as a long for the creation time key. Skipping.",
+                   property.getValue(), e);
+          return Optional.empty();
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  /**
+   * Parses a schema JSON string into a concise, human-readable format.
+   *
+   * @param schemaStr The raw JSON string representing the schema.
+   * @return A formatted string (e.g., "schemaname:TYPE field1:TYPE1 field2:TYPE2").
+   * @throws IOException if the schema string cannot be parsed.
+   */
+  private Map<String, Set<Property>> reformatSchemaProperty(String schemaStr) throws IOException {
+    if (schemaStr == null) {
+      return Collections.emptyMap();
+    }
+
+    Set<Property> fieldProperties = new HashSet<>();
+    Set<Property> schemaAndFieldNames = new HashSet<>();
+    Schema schema = Schema.parseJson(schemaStr);
+
+    List<String> formattedFields = new ArrayList<>();
+    SchemaWalker.walk(schema, (fieldName, fieldSchema) -> {
+      if (fieldName != null) {
+        Schema nonNullableSchema = fieldSchema.isNullable() ? fieldSchema.getNonNullable() : fieldSchema;
+        String typeName = nonNullableSchema.getType().toString().toLowerCase();
+        fieldProperties.add(new Property(
+          MetadataScope.SYSTEM.name(),
+          fieldName.toLowerCase(),
+          typeName));
+        formattedFields.add(fieldName.toLowerCase() + ":" + typeName.toLowerCase());
+      }
+    });
+
+    String schemaProperties = formattedFields.isEmpty() ? "" : String.join(" ", formattedFields);
+    schemaAndFieldNames.add(new Property(
+      MetadataScope.SYSTEM.name(),
+      "schema",
+      schemaProperties));
+
+    Map<String, Set<Property>> result = new HashMap<>();
+    result.put("fieldProperties", fieldProperties);
+    result.put("schemaAndFieldNames", schemaAndFieldNames);
+
+    return result;
+  }
+
+  /**
+   * Represents a property for the Spanner metadata_props table.
+   */
+  static class Property {
+    private final String scope;
+    private final String name;
+    private final String value;
+
+    Property(String scope, String name, String value) {
+      this.scope = scope;
+      this.name = name;
+      this.value = value;
+    }
+
+    public String getScope() {
+      return scope;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    /**
+     * Checks if this Property is equal to another object.
+     */
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Property property = (Property) o;
+      return Objects.equals(scope, property.scope)
+        && Objects.equals(name, property.name)
+        && Objects.equals(value, property.value);
+    }
+
+    public int hashCode() {
+      return Objects.hash(scope, name, value);
+    }
+
+    public String toString() {
+      return scope + ':' + name + ':' + value;
+    }
+  }
+}
+

--- a/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/MetadataMutator.java
+++ b/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/MetadataMutator.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata.spanner;
+
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.GSON;
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.METADATA_PROPS_TABLE;
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.METADATA_TABLE;
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.filterMetadata;
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.toMetadataId;
+
+import com.google.cloud.spanner.Key;
+import com.google.cloud.spanner.KeyRange;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Mutation;
+import com.google.common.collect.Sets;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.spi.metadata.Metadata;
+import io.cdap.cdap.spi.metadata.MetadataChange;
+import io.cdap.cdap.spi.metadata.MetadataDirective;
+import io.cdap.cdap.spi.metadata.MetadataMutation;
+import io.cdap.cdap.spi.metadata.ScopedName;
+import io.cdap.cdap.spi.metadata.ScopedNameOfKind;
+import io.cdap.cdap.spi.metadata.VersionedMetadata;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Generates Spanner mutations from metadata changes.
+ */
+public class MetadataMutator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataMutator.class);
+
+  /**
+   * Creates a Spanner request that corresponds to the given mutation, along with the change
+   * effected by this mutation. The request must be executed by the caller.
+   *
+   * @param before   the metadata for the mutation's entity before the change
+   * @param mutation the mutation to apply
+   * @return a Spanner request to be executed, and the change caused by the mutation.
+   */
+  public static ChangeRequest applyMutation(VersionedMetadata before, MetadataMutation mutation)
+    throws IOException {
+    LOG.trace("Applying mutation {} to entity {} with metadata {}",
+              mutation, mutation.getEntity(), before.getMetadata());
+    switch (mutation.getType()) {
+      case CREATE:
+        return create(before, (MetadataMutation.Create) mutation);
+      case DROP:
+        return drop(mutation.getEntity(), before);
+      case UPDATE:
+        return update(mutation.getEntity(), before, ((MetadataMutation.Update) mutation).getUpdates());
+      case REMOVE:
+        return remove(before, (MetadataMutation.Remove) mutation);
+      default:
+        throw new IllegalArgumentException(String.format("Unknown mutation type '%s' for %s", mutation.getType(),
+                                                         mutation));
+    }
+  }
+
+  /**
+   * Creates the Spanner request for an entity replacement. See {@link
+   * MetadataMutation.Create} for detailed semantics.
+   *
+   * @param before the metadata for the mutation's entity before the change.
+   * @param create the mutation to apply
+   * @return the list of mutation to be executed, and the change caused by the mutation
+   */
+  private static ChangeRequest create(VersionedMetadata before, MetadataMutation.Create create) throws IOException {
+    // if the entity did not exist before, none of the directives apply and this is equivalent to update()
+    if (!before.existing()) {
+      return update(create.getEntity(), before, create.getMetadata());
+    }
+
+    Metadata newMetadata = create.getMetadata();
+    Metadata existingMetadata = before.getMetadata();
+    Map<ScopedNameOfKind, MetadataDirective> directives = create.getDirectives();
+    Set<MetadataScope> affectedScopes = determineAffectedScopes(newMetadata);
+    Set<ScopedName> finalTags = new HashSet<>();
+    Map<ScopedName, String> finalProperties = new HashMap<>();
+
+    // 1. Process all tags and properties in scopes NOT affected by this mutation.
+    Sets.difference(MetadataScope.ALL, affectedScopes).forEach(scope -> {
+      existingMetadata.getTags().stream()
+        .filter(tag -> tag.getScope().equals(scope))
+        .forEach(finalTags::add);
+      existingMetadata.getProperties().entrySet().stream()
+        .filter(entry -> entry.getKey().getScope().equals(scope))
+        .forEach(entry -> finalProperties.put(entry.getKey(), entry.getValue()));
+    });
+
+    // 2. Process all directives for affected scopes.
+    directives.entrySet().stream()
+      .filter(entry -> affectedScopes.contains(entry.getKey().getScope()))
+      .forEach(entry -> {
+        ScopedNameOfKind key = entry.getKey();
+        MetadataDirective directive = entry.getValue();
+        ScopedName scopedName = new ScopedName(key.getScope(), key.getName());
+        switch (key.getKind()) {
+          case TAG:
+            if (directive != MetadataDirective.PRESERVE && directive != MetadataDirective.KEEP) {
+              break;
+            }
+
+            // Check if the tag existed before but was removed in the new metadata.
+            boolean presentInExisting = existingMetadata.getTags().contains(scopedName);
+            boolean absentInNew = !newMetadata.getTags().contains(scopedName);
+            if (presentInExisting && absentInNew) {
+              finalTags.add(scopedName);
+            }
+            break;
+
+          case PROPERTY:
+            String existingValue = existingMetadata.getProperties().get(scopedName);
+            String newValue = newMetadata.getProperties().get(scopedName);
+
+            // Skip if there was no existing value to preserve or keep.
+            if (existingValue == null) {
+              break;
+            }
+
+            // These variables describe the property's state change.
+            boolean propertyWasChanged = !existingValue.equals(newValue);
+            boolean propertyWasRemoved = newValue == null;
+            if ((directive == MetadataDirective.PRESERVE && propertyWasChanged)
+              || (directive == MetadataDirective.KEEP && propertyWasRemoved)) {
+              finalProperties.put(scopedName, existingValue);
+            }
+            break;
+
+          default:
+            throw new IllegalArgumentException("Unknown or unhandled MetadataKind: " + key.getKind());
+        }
+      });
+
+    Metadata after = new Metadata(finalTags, finalProperties);
+    MetadataChange metadataChange = new MetadataChange(create.getEntity(), before.getMetadata(), after);
+    List<Mutation> mutations = bufferWrites(create.getEntity(), before.getVersion(), after);
+    return new ChangeRequest(mutations, metadataChange);
+  }
+
+  /**
+   * Determines the set of scopes that this mutation applies to.
+   * Scopes that do not occur in the new metadata are not changed.
+   *
+   * @param metadata the metadata for the mutation's entity after the change
+   * @return a set of MetadataScope objects
+   */
+  private static Set<MetadataScope> determineAffectedScopes(Metadata metadata) {
+    return Stream.concat(metadata.getTags().stream(),
+                         metadata.getProperties().keySet().stream())
+      .map(ScopedName::getScope)
+      .collect(Collectors.toSet());
+  }
+
+  /**
+   * Creates the Spanner delete request for an entity deletion. This drops the corresponding
+   * metadata document from the index.
+   *
+   * @param before the metadata for the mutation's entity before the change
+   * @return the Change Request which contains the list of mutation,
+   *        and the change caused by the mutation.
+   */
+  private static ChangeRequest drop(MetadataEntity entity, VersionedMetadata before) {
+    List<Mutation> mutations = new ArrayList<>();
+    String metadataId = toMetadataId(entity);
+    if (before.getVersion() == null) {
+      throw new IllegalArgumentException("existingVersion cannot be null when deleting a "
+                                           + "specific version of a metadata entity.");
+    }
+    mutations.add(Mutation.delete(METADATA_TABLE, Key.of(metadataId)));
+    return new ChangeRequest(mutations, new MetadataChange(entity, before.getMetadata(), Metadata.EMPTY));
+  }
+
+  /**
+   * Creates the Spanner request for updating the metadata of an entity. This updates or
+   * adds the new metadata.
+   *
+   * @param before the metadata for the mutation's entity before the change, and its version
+   * @return the list of mutation to be executed, and the change caused by the mutation
+   */
+  private static ChangeRequest update(MetadataEntity entity, VersionedMetadata before, Metadata updates)
+    throws IOException {
+    Set<ScopedName> tags = new HashSet<>(before.getMetadata().getTags());
+    tags.addAll(updates.getTags());
+    Map<ScopedName, String> properties = new HashMap<>(before.getMetadata().getProperties());
+    properties.putAll(updates.getProperties());
+    Metadata after = new Metadata(tags, properties);
+    return new ChangeRequest(bufferWrites(entity, before.getVersion(), after),
+                             new MetadataChange(entity, before.getMetadata(), after));
+  }
+
+  /**
+   * Creates Spanner mutations to remove specified tags and properties from an entity.
+   *
+   * <p>This operation does not delete the entity's row from the table. To completely
+   * delete the entity, use {@link MetadataMutation.Drop}.
+   *
+   * @param before the metadata for the mutation's entity before the change
+   * @return the list of mutations to execute and the change caused by the mutation
+   */
+  private static ChangeRequest remove(VersionedMetadata before, MetadataMutation.Remove remove) throws IOException {
+    Metadata after = filterMetadata(before.getMetadata(), false,
+                                    remove.getKinds(), remove.getScopes(), remove.getRemovals());
+    return new ChangeRequest(bufferWrites(remove.getEntity(), before.getVersion(), after),
+                             new MetadataChange(remove.getEntity(), before.getMetadata(), after));
+  }
+
+  /**
+   * Creates Spanner Mutations for adding or updating the metadata for an entity.
+   * The mutations must be executed by the caller within a transaction.
+   *
+   * @param entity        The metadata entity.
+   * @param expectVersion The expected version for optimistic locking, or null for creation.
+   * @param metadata      The metadata to write.
+   * @return A list of Spanner mutations.
+   */
+  private static List<Mutation> bufferWrites(MetadataEntity entity, @Nullable Long expectVersion, Metadata metadata)
+    throws IOException {
+    List<Mutation> mutations = new ArrayList<>();
+    FormattedMetadata formattedMetadata = FormattedMetadata.from(entity, metadata);
+    mutations.add(createMetadataTableMutation(entity, metadata, formattedMetadata, expectVersion));
+    mutations.addAll(createMetadataPropsTableMutations(entity, formattedMetadata));
+    return mutations;
+  }
+
+  /**
+   * Creates the Mutation for the main metadata table.
+   * This method takes the pre-processed data from the SpannerMetadataBuilder.
+   */
+  private static Mutation createMetadataTableMutation(MetadataEntity entity, Metadata metadata,
+                                                      FormattedMetadata formattedMetadata,
+                                                      @Nullable Long expectVersion) {
+    Mutation.WriteBuilder writeBuilder = Mutation.newInsertOrUpdateBuilder(METADATA_TABLE)
+      .set(Tables.Metadata.METADATA_ID_FIELD).to(toMetadataId(entity))
+      .set(Tables.Metadata.NAMESPACE_FIELD).to(formattedMetadata.getNamespace())
+      .set(Tables.Metadata.TYPE_FIELD).to(formattedMetadata.getType())
+      .set(Tables.Metadata.NAME_FIELD).to(formattedMetadata.getName())
+      .set(Tables.Metadata.USER_FIELD).to(formattedMetadata.getUserText())
+      .set(Tables.Metadata.SYSTEM_FIELD).to(formattedMetadata.getSystemText())
+      .set(Tables.Metadata.METADATA_COLUMN_FIELD).to(GSON.toJson(metadata))
+      .set(Tables.Metadata.VERSION).to(expectVersion == null ? 1L : expectVersion + 1);
+    formattedMetadata.getCreated().ifPresent(c -> writeBuilder
+      .set(Tables.Metadata.CREATED_FIELD).to(c));
+    return writeBuilder.build();
+  }
+
+  /**
+   * Creates Mutations for the metadata_props table.
+   * This includes a delete mutation for existing properties followed by inserts.
+   */
+  private static List<Mutation> createMetadataPropsTableMutations(MetadataEntity entity,
+                                                                  FormattedMetadata formattedMetadata) {
+    List<Mutation> propMutations = new ArrayList<>();
+    String entityId = toMetadataId(entity);
+
+    // Crucial: Delete existing properties first to ensure updates are clean.
+    // This is necessary because we are doing "insert or update" for properties,
+    // but existing properties that are no longer present in the new metadata
+    // need to be explicitly removed.
+    propMutations.add(Mutation.delete(METADATA_PROPS_TABLE, KeySet.range(KeyRange.prefix(Key.of(entityId)))));
+
+    for (FormattedMetadata.Property prop : formattedMetadata.getMetadataProps()) {
+      propMutations.add(Mutation.newInsertOrUpdateBuilder(METADATA_PROPS_TABLE)
+                          .set(Tables.MetadataProps.METADATA_ID_FIELD).to(entityId)
+                          .set(Tables.MetadataProps.NAMESPACE_FIELD).to(formattedMetadata.getNamespace())
+                          .set(Tables.MetadataProps.TYPE_FIELD).to(formattedMetadata.getType())
+                          .set(Tables.MetadataProps.NESTED_SCOPE_FIELD).to(prop.getScope())
+                          .set(Tables.MetadataProps.NESTED_NAME_FIELD).to(prop.getName())
+                          .set(Tables.MetadataProps.NESTED_VALUE_FIELD).to(prop.getValue())
+                          .build());
+    }
+    return propMutations;
+  }
+}
+

--- a/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorage.java
+++ b/cdap-metadata-ext-spanner/src/main/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorage.java
@@ -24,6 +24,7 @@ import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.ReadContext;
+import com.google.cloud.spanner.ReadOnlyTransaction;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerException;
@@ -35,20 +36,25 @@ import com.google.cloud.spanner.TransactionRunner;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.common.metadata.MetadataUtil;
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataChange;
+import io.cdap.cdap.spi.metadata.MetadataKind;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.spi.metadata.MetadataStorageContext;
 import io.cdap.cdap.spi.metadata.MutationOptions;
 import io.cdap.cdap.spi.metadata.Read;
 import io.cdap.cdap.spi.metadata.ScopedName;
+import io.cdap.cdap.spi.metadata.ScopedNameOfKind;
 import io.cdap.cdap.spi.metadata.ScopedNameTypeAdapter;
 import io.cdap.cdap.spi.metadata.SearchRequest;
 import io.cdap.cdap.spi.metadata.SearchResponse;
@@ -84,8 +90,8 @@ public class SpannerMetadataStorage implements MetadataStorage {
     )));
 
   // Metadata table names
-  private static final String METADATA_TABLE = "metadata";
-  private static final String METADATA_PROPS_TABLE = "metadata_props";
+  public static final String METADATA_TABLE = "metadata";
+  public static final String METADATA_PROPS_TABLE = "metadata_props";
 
   private String instanceId;
   private String projectId;
@@ -164,23 +170,23 @@ public class SpannerMetadataStorage implements MetadataStorage {
    */
   private String getCreateMetadataTableDDLStatement() {
     return String.format(
-      "CREATE TABLE IF NOT EXISTS %s (" + // metadata
-        "%s STRING(MAX) NOT NULL," +  // metadata_id
-        "%s STRING(MAX) NOT NULL," + // namespace
-        "%s STRING(MAX) NOT NULL," + // entity_type
-        "%s STRING(MAX) NOT NULL," + // name
-        "%s INT64," + // create_time
-        "%s STRING(MAX)," + // user
-        "%s STRING(MAX)," + // system
-        "%s JSON," + // metadata_column
-        "%s INT64 NOT NULL," + // version
-        "user_tokens TOKENLIST AS " + // user_tokens list
-        "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN," +
-        "system_tokens TOKENLIST AS " + // system_tokens list
-        "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN," +
-        "text_tokens TOKENLIST AS " + // text_tokens list
-        "(TOKENLIST_CONCAT([User_Tokens, System_Tokens])) HIDDEN," +
-        ") PRIMARY KEY (%s) ", // metadata_id
+      "CREATE TABLE IF NOT EXISTS %s (" // metadata
+        + "%s STRING(MAX) NOT NULL,"   // metadata_id
+        + "%s STRING(MAX) NOT NULL," // namespace
+        + "%s STRING(MAX) NOT NULL,"  // entity_type
+        + "%s STRING(MAX) NOT NULL,"  // name
+        + "%s INT64,"  // create_time
+        + "%s STRING(MAX),"  // user
+        + "%s STRING(MAX),"  // system
+        + "%s JSON,"  // metadata_column
+        + "%s INT64 NOT NULL,"  // version
+        + "user_tokens TOKENLIST AS "  // user_tokens list
+        + "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN,"
+        + "system_tokens TOKENLIST AS "  // system_tokens list
+        + "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN,"
+        + "text_tokens TOKENLIST AS "  // text_tokens list
+        + "(TOKENLIST_CONCAT([User_Tokens, System_Tokens])) HIDDEN,"
+        + ") PRIMARY KEY (%s) ", // metadata_id
       METADATA_TABLE,
       Tables.Metadata.METADATA_ID_FIELD,
       Tables.Metadata.NAMESPACE_FIELD,
@@ -223,17 +229,17 @@ public class SpannerMetadataStorage implements MetadataStorage {
    */
   private String getCreateMetadataPropsTableDDLStatement() {
     return String.format(
-      "CREATE TABLE IF NOT EXISTS %s (" +
-        "%s STRING(MAX) NOT NULL," +  // metadata_id
-        "%s STRING(MAX) NOT NULL," + // namespace
-        "%s STRING(MAX) NOT NULL," + // entity_type
-        "%s STRING(MAX) NOT NULL," + // name
-        "%s STRING(MAX)," + // scope
-        "%s STRING(MAX)," + // value
-        "value_tokens TOKENLIST AS " + // value_tokens list
-        "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN," +
-        ") PRIMARY KEY (%s, %s, %s) ," + // metadata_id, name, scope
-        "INTERLEAVE IN PARENT %s ON DELETE CASCADE",
+      "CREATE TABLE IF NOT EXISTS %s ("
+        + "%s STRING(MAX) NOT NULL,"  // metadata_id
+        + "%s STRING(MAX) NOT NULL," // namespace
+        + "%s STRING(MAX) NOT NULL," // entity_type
+        + "%s STRING(MAX) NOT NULL," // name
+        + "%s STRING(MAX)," // scope
+        + "%s STRING(MAX)," // value
+        + "value_tokens TOKENLIST AS " // value_tokens list
+        + "(TOKENIZE_SUBSTRING(%s, support_relative_search=>TRUE)) HIDDEN,"
+        + ") PRIMARY KEY (%s, %s, %s) ," // metadata_id, name, scope
+        + "INTERLEAVE IN PARENT %s ON DELETE CASCADE",
       METADATA_PROPS_TABLE,
       Tables.MetadataProps.METADATA_ID_FIELD,
       Tables.MetadataProps.NAMESPACE_FIELD,
@@ -303,6 +309,17 @@ public class SpannerMetadataStorage implements MetadataStorage {
     LOG.info("Metadata Tables dropped successfully.");
   }
 
+  @Override
+  public Metadata read(Read read) throws IOException {
+    try (ReadOnlyTransaction transaction = dbClient.readOnlyTransaction()) {
+      Metadata metadata = readVersionedMetadata(read.getEntity(), transaction).getMetadata();
+      return filterMetadata(metadata, true, read.getKinds(),
+                            read.getScopes(), read.getSelection());
+    } catch (SpannerException e) {
+      throw new IOException("Error reading from Spanner", e);
+    }
+  }
+
   /**
    * Applies a single metadata mutation atomically.
    *
@@ -311,6 +328,7 @@ public class SpannerMetadataStorage implements MetadataStorage {
    * @return The {@link MetadataChange} that occurred.
    * @throws IOException If a non-retryable Spanner error occurs.
    */
+  @Override
   public MetadataChange apply(MetadataMutation mutation, MutationOptions options) throws IOException {
     try {
       TransactionRunner runner = dbClient.readWriteTransaction();
@@ -333,7 +351,7 @@ public class SpannerMetadataStorage implements MetadataStorage {
     VersionedMetadata before = readVersionedMetadata(entity, transaction);
     Preconditions.checkArgument(before != null,
                                 "Metadata entity %s not found for mutation", entity);
-    ChangeRequest intermediary = applyMutation(before, mutation);
+    ChangeRequest intermediary = MetadataMutator.applyMutation(before, mutation);
     bufferMutations(transaction, intermediary.getMutation());
     return intermediary.getChange();
   }
@@ -359,18 +377,6 @@ public class SpannerMetadataStorage implements MetadataStorage {
     if (!SUPPORTED_MUTATION_OPS.contains(operation)) {
       throw new IllegalArgumentException("Unsupported Spanner Mutation operation: " + operation);
     }
-  }
-
-  /**
-   * Creates a Spanner request that corresponds to the given mutation, along with the change
-   * effected by this mutation. The request must be executed by the caller.
-   *
-   * @param before   the metadata for the mutation's entity before the change
-   * @param mutation the mutation to apply
-   * @return a Spanner request to be executed, and the change caused by the mutation.
-   */
-  private ChangeRequest applyMutation(VersionedMetadata before, MetadataMutation mutation) throws IOException {
-    throw new IOException("NOT IMPLEMENTED");
   }
 
   /**
@@ -443,9 +449,33 @@ public class SpannerMetadataStorage implements MetadataStorage {
   }
 
   /**
+   * Filter the metadata based on the given scopes, kinds, and selection. Based on the value of
+   * {@param keep}, this can be used to keep or to discard the matching tags and properties.
+   *
+   * @param keep if true, only matching metadata elements are kept; otherwise only non-matching
+   *             elements are kept.
+   */
+  public static Metadata filterMetadata(Metadata metadata, boolean keep, Set<MetadataKind> kinds,
+                                  Set<MetadataScope> scopes, Set<ScopedNameOfKind> selection) {
+    if (selection != null) {
+      return new Metadata(
+        Sets.filter(metadata.getTags(), tag -> keep == selection.contains(
+          new ScopedNameOfKind(MetadataKind.TAG, tag.getScope(), tag.getName()))),
+        Maps.filterKeys(metadata.getProperties(), key ->
+          keep == selection.contains(new ScopedNameOfKind(MetadataKind.PROPERTY, key.getScope(), key.getName())))
+      );
+    }
+    return new Metadata(
+      Sets.filter(metadata.getTags(), tag ->
+        keep == (kinds.contains(MetadataKind.TAG) && scopes.contains(tag.getScope()))),
+      Maps.filterKeys(metadata.getProperties(), key ->
+        keep == (kinds.contains(MetadataKind.PROPERTY) && scopes.contains(key.getScope()))));
+  }
+
+  /**
    * Translate a metadata entity into a metadata_id in the table.
    */
-  protected String toMetadataId(MetadataEntity entity) {
+  public static String toMetadataId(MetadataEntity entity) {
     final boolean isEntityTypeVersioned = MetadataUtil.isVersionedEntityType(entity.getType());
 
     String keyValuePairs = StreamSupport.stream(entity.spliterator(), false)
@@ -454,11 +484,6 @@ public class SpannerMetadataStorage implements MetadataStorage {
       .collect(Collectors.joining(","));
 
     return keyValuePairs.isEmpty() ? entity.getType() : entity.getType() + ":" + keyValuePairs;
-  }
-
-  @Override
-  public Metadata read(Read read) throws IOException {
-    throw new IOException("NOT IMPLEMENTED");
   }
 
   @Override

--- a/cdap-metadata-ext-spanner/src/test/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorageTest.java
+++ b/cdap-metadata-ext-spanner/src/test/java/io/cdap/cdap/metadata/spanner/SpannerMetadataStorageTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.metadata.spanner;
 
+import static io.cdap.cdap.metadata.spanner.SpannerMetadataStorage.toMetadataId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -214,7 +215,7 @@ public class SpannerMetadataStorageTest {
         String metadataJson = SpannerMetadataStorage.GSON.toJson(metadata);
 
         Mutation mutation = Mutation.newInsertOrUpdateBuilder(METADATA_TABLE)
-          .set(Tables.Metadata.METADATA_ID_FIELD).to(spannerMetadataStorage.toMetadataId(entity))
+          .set(Tables.Metadata.METADATA_ID_FIELD).to(toMetadataId(entity))
           .set(Tables.Metadata.NAMESPACE_FIELD).to(entity.getValue(MetadataEntity.NAMESPACE))
           .set(Tables.Metadata.TYPE_FIELD).to(entity.getType())
           .set(Tables.Metadata.NAME_FIELD).to(entity.getValue(entity.getType()))


### PR DESCRIPTION
### **Description:**
This PR is the follow-up for #15978 and here we are temporarily building this module separately as a workaround for a dependency issue that breaks the unified build.Unit tests will be added in a follow-up PR, as they depend on methods to be introduced at that time. Its key changes are listed below:

- **MetadataFormatter**:   A helper class to process and prepare metadata fields for optimized storage.
-  **MetadataMutator**: A helper class which is used by the base class(`SpannerMetadataStorage`) for performing CRUD operations.

### **Testing:**

-  **Local Testing**:Tested these changes using a Distributed docker image.   

### **CRUD Operations**
Consider the following Example 
```
system:description = "Initial raw data"
system:creation_time = "1000"
user:validated = (a tag)
```

- **CREATE**: Applying a Create to the SYSTEM scope with a new description and schema (and a PRESERVE directive for creation_time) results in:
```
system:description = "Processed data" (Replaced)
system:creation_time = "1000" (Preserved)
system:schema = "id:INT" (Added)
user:validated (tag) (Untouched)
```
- **UPDATE**: Applying an Update with system:quality_score = "98.7" results in:
```
system:description = "Initial raw data"
system:creation_time = "1000"
user:validated (tag)
system:quality_score = "98.7" (Added)
```
- **REMOVE**: Applying a Remove for the user:validated tag results in:
```
system:description = "Initial raw data"
system:creation_time = "1000"
user:validated (Removed)
```
- **DROP**: Applying a Drop results in:
```
Metadata.EMPTY (all properties and tags are gone).
```