### PR TITLE
Fixing unit test failures.

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -1676,6 +1676,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     deleteArtifact(ns1ArtifactId, 200);
     deleteArtifact(pluginArtifact, 200);
+    deleteApp(appId, 200);
   }
 
   @Test
@@ -1728,6 +1729,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     deleteArtifact(latestAppArtifact, 200);
     deleteArtifact(pluginArtifact, 200);
     deleteArtifact(latestPluginArtifact, 200);
+    deleteApp(appId, 200);
   }
 
   private Artifact deployPluginArtifact(Namespace namespace, Artifact artifact, Class<?> claszz,


### PR DESCRIPTION
* New applications added for upgrades test were not being deleted leading to higher count being returned for list apps.