### PR TITLE
OSSRH to central sonatype repo migration.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/src/main/resources/archetype-resources/pom.xml
@@ -40,11 +40,11 @@
   <repositories>
     <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
     </repository>
   </repositories>
 

--- a/cdap-docs/admin-manual/source/appendices/hbase-ddl-executor.rst
+++ b/cdap-docs/admin-manual/source/appendices/hbase-ddl-executor.rst
@@ -348,7 +348,7 @@ Corresponding ``pom.xml``. Configure the property ``hbase-client`` (currently ``
     <repositories>
       <repository>
         <id>sonatype</id>
-        <url>https://oss.sonatype.org/content/groups/public</url>
+        <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
       </repository>
       <repository>
         <id>apache.snapshots</id>

--- a/cdap-docs/developer-manual/source/conf.py
+++ b/cdap-docs/developer-manual/source/conf.py
@@ -25,7 +25,7 @@ snapshot_version = release.endswith('SNAPSHOT')
 archetype_version = "-DarchetypeVersion=%s" % release
 
 if snapshot_version:
-    archetype_repository = '-DarchetypeRepository=https://oss.sonatype.org/content/repositories/snapshots/'
+    archetype_repository = '-DarchetypeRepository=https://central.sonatype.com/repositories/snapshots/'
     archetype_repository_version = "%s %s" % (archetype_repository, archetype_version)
 else:
     # For releases, repo is not required, but included here to simplify the code as replacements can't be empty

--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -72,11 +72,11 @@
   <distributionManagement>
     <repository>
       <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
       <id>sonatype.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
     </snapshotRepository>
     <site>
       <id>cask</id>
@@ -136,11 +136,11 @@
   <repositories>
     <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/groups/public</url>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
     </repository>
   </repositories>
 
@@ -843,7 +843,7 @@
             <version>1.6.14</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org</nexusUrl>
+              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
               <serverId>sonatype.release</serverId>
             </configuration>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     </repository>
     <repository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://central.sonatype.com/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -99,11 +99,11 @@
   <distributionManagement>
     <repository>
       <id>sonatype.release</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
     </repository>
     <snapshotRepository>
       <id>sonatype.snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repositories/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -1687,7 +1687,7 @@
           <version>1.6.14</version>
           <extensions>true</extensions>
           <configuration>
-            <nexusUrl>https://oss.sonatype.org</nexusUrl>
+            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
             <serverId>sonatype.release</serverId>
           </configuration>
         </plugin>


### PR DESCRIPTION
* Updating the releases and snapshot urls. This will allow us to use existing plugins and push to the new central repository.