### PR TITLE
[CDAP-21184] Support java 11 : Move log lines to Java process only to unblock UI config read

### DIFF
--- a/cdap-common/bin/functions.sh
+++ b/cdap-common/bin/functions.sh
@@ -347,7 +347,6 @@ cdap_set_java () {
   fi
   __java_version_raw=$("${__java}" -version 2>&1 | awk -F '"' '/version/ {print $2}')
   __java_version=$(echo "$__java_version_raw" | awk -F. '{if ($1 == "1") print $2; else print $1}')
-  echo "$(date) Major Java version: $__java_version"
   if [[ -z ${__java_version} ]]; then
     die "Could not detect Java version. Aborting..."
   fi
@@ -740,6 +739,7 @@ cdap_run_class() {
   cdap_create_local_dir || die "Could not create local directory : ${LOCAL_DIR}"
   # Replace the <LOG_DIR> with local directory if present in JVM OPTS.
   OPTS="${OPTS//<LOG_DIR>/$LOCAL_DIR}"
+  echo "$(date) Major Java version: $JAVA_VERSION"
   if [[ -n ${__args} ]] && [[ ${__args} != '' ]]; then
     echo "$(date) Running class ${__class} with arguments: ${__args} and JVM OPTS : ${OPTS}"
   else
@@ -771,6 +771,7 @@ cdap_exec_class() {
   cdap_create_local_dir || die "Could not create local directory : ${LOCAL_DIR}"
   # Replace the <LOG_DIR> with local directory if present in JVM OPTS.
   OPTS="${OPTS//<LOG_DIR>/$LOCAL_DIR}"
+  echo "$(date) Major Java version: $JAVA_VERSION"
   if [[ -n ${__args} ]] && [[ ${__args} != '' ]]; then
     echo "$(date) Running class ${__class} with arguments: ${__args} and JVM OPTS : ${OPTS}"
   else


### PR DESCRIPTION
The UI code reads the config emitted from stdout of the script `cdap-common/bin/functions.sh` . 

Had added log lines to print current java version in https://github.com/cdapio/cdap/pull/15991 

This was not parsed by config reader and was causing issues in UI pod. 

Moved the log lines to print only before any Java process is being run. 


But the approach to read config by UI process should be modified to handle configs in a proper manner.

Testing : 

- Tested with these changes, all pods are up and running. and able to access ui and perform any ops