### PR TITLE
Use central publishing maven plugin

### DIFF
--- a/cdap-app-fabric-tests/pom.xml
+++ b/cdap-app-fabric-tests/pom.xml
@@ -134,11 +134,14 @@ the License.
     <plugins>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/cdap-cli-tests/pom.xml
+++ b/cdap-cli-tests/pom.xml
@@ -140,11 +140,14 @@
     <plugins>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -288,34 +288,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -329,33 +301,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -368,33 +313,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>2.4</version>
-          </plugin>
-
-          <!-- Extra deployment for tgz package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-tgz</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>tar.gz</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -149,11 +149,14 @@ the License.
     <plugins>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -139,11 +139,14 @@
       </plugin>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -127,35 +127,6 @@
               </execution>
             </executions>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>cdap</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/cdap-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
         </plugins>
       </build>
     </profile>
@@ -203,33 +174,6 @@
                     ${package.config.dirs}
                     ${package.dirs}
                   </commandlineArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>cdap</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/cdap_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -838,13 +838,14 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.14</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.8.0</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
-              <serverId>sonatype.release</serverId>
+              <publishingServerId>sonatype.release</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <ignorePublishedComponents>true</ignorePublishedComponents>
             </configuration>
           </plugin>
           <!-- Source JAR -->

--- a/cdap-elastic/pom.xml
+++ b/cdap-elastic/pom.xml
@@ -100,11 +100,14 @@
     <plugins>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
 

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -194,34 +194,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -235,33 +207,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -274,33 +219,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>2.4</version>
-          </plugin>
-
-          <!-- Extra deployment for tgz package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-tgz</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>tar.gz</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -118,34 +118,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.8.1</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -159,33 +131,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.8.1</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -198,33 +143,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>2.4</version>
-          </plugin>
-
-          <!-- Extra deployment for tgz package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-tgz</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>tar.gz</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -1073,34 +1073,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -1114,33 +1086,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -1153,33 +1098,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>2.4</version>
-          </plugin>
-
-          <!-- Extra deployment for tgz package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-tgz</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>tar.gz</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -275,34 +275,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for rpm package. -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-rpm</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>noarch.rpm</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}-1.noarch.rpm</file>
-                  <classifier>1</classifier>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -316,33 +288,6 @@
             <artifactId>exec-maven-plugin</artifactId>
             <version>1.3.1</version>
           </plugin>
-
-          <!-- Extra deployment for deb package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-deb</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>deb</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
@@ -355,33 +300,6 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>2.4</version>
-          </plugin>
-
-          <!-- Extra deployment for tgz package -->
-          <!-- This has to be in child level, otherwise all modules would try to deploy. -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-tgz</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${dist.deploy.groupId}</groupId>
-                  <artifactId>${project.artifactId}</artifactId>
-                  <packaging>tar.gz</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -857,32 +857,6 @@
               </execution>
             </executions>
           </plugin>
-
-          <!-- Extra deployment for cdap sdk -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-deploy-plugin</artifactId>
-            <version>3.1.4</version>
-            <executions>
-              <execution>
-                <id>deploy-sdk</id>
-                <phase>deploy</phase>
-                <goals>
-                  <goal>deploy-file</goal>
-                </goals>
-                <configuration>
-                  <version>${project.version}</version>
-                  <groupId>${project.groupId}</groupId>
-                  <artifactId>cdap-sandbox</artifactId>
-                  <packaging>zip</packaging>
-                  <generatePom>false</generatePom>
-                  <file>${project.build.directory}/cdap-sandbox-${project.version}.zip</file>
-                  <repositoryId>continuuity</repositoryId>
-                  <url>${deploy.url}</url>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>

--- a/cdap-tms-tests/pom.xml
+++ b/cdap-tms-tests/pom.xml
@@ -125,11 +125,14 @@
     <plugins>
       <!-- Shouldn't deploy test module -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
         <configuration>
-          <skip>true</skip>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+          <skipPublishing>true</skipPublishing>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -95,18 +95,6 @@
     </repository>
   </repositories>
 
-
-  <distributionManagement>
-    <repository>
-      <id>sonatype.release</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>sonatype.snapshots</id>
-      <url>https://central.sonatype.com/repository/maven-snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <properties>
     <jee.version>7</jee.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -1679,16 +1667,15 @@
             </execution>
           </executions>
         </plugin>
-
-        <!-- Nexus deploy plugin -->
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>1.6.14</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.8.0</version>
           <extensions>true</extensions>
           <configuration>
-            <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
-            <serverId>sonatype.release</serverId>
+            <publishingServerId>sonatype.release</publishingServerId>
+            <autoPublish>false</autoPublish>
+            <ignorePublishedComponents>true</ignorePublishedComponents>
           </configuration>
         </plugin>
       </plugins>
@@ -1716,15 +1703,14 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.4</version>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.14</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>sonatype.release</publishingServerId>
+          <autoPublish>false</autoPublish>
+          <ignorePublishedComponents>true</ignorePublishedComponents>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
* maven-deploy-plugin and maven-release-plugin can no longer be used with central-publishing-maven-plugin.
* These can be safely removed since they are no longer used in the current build/deploy process.