### PR TITLE
add configurable polling interval for ui

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6627,4 +6627,12 @@
     </description>
   </property>
 
+  <property>
+    <name>ui.default.poll.interval.millis</name>
+    <value>10000</value>
+    <description>
+      The default polling interval in milliseconds for poll calls from cdap-ui.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
Adds property `ui.default.poll.interval.millis` in cdap-default.xml