### PR TITLE
CDAP-21186 : [Required for JAVA 11] Update parent classloader to include java.sql

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStorageProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStorageProvider.java
@@ -186,7 +186,9 @@ public class PostgreSqlStorageProvider implements StorageProvider {
     }
 
     // Create a separate classloader for the JDBC driver, which doesn't have any CDAP dependencies in it.
-    ClassLoader driverClassLoader = new DirectoryClassLoader(driverExtensionDir, null);
+    // Passing java.sql.Driver's parent classloader for java 11 + as it doesn't load them if we pass null.
+    ClassLoader driverClassLoader = new DirectoryClassLoader(driverExtensionDir,
+                                                             java.sql.Driver.class.getClassLoader());
     try {
       Driver driver = (Driver) Class.forName(driverName, true, driverClassLoader).newInstance();
 


### PR DESCRIPTION
The issue was in Java 11 URLclassloader doesn't automatically have java.sql.* packages. 

SO, adding `java.sql`'s classloader as parent only before isolating the driver class . This is safe as  `java.sql` would be the platform classloader which will not have any external dependencies

Testing : Developer is working now : 
<img width="737" height="517" alt="Screenshot 2025-07-15 at 5 29 43 PM" src="https://github.com/user-attachments/assets/e08e310a-5c66-4328-b83b-6ace029e45e8" />
