### PR TITLE
[CDAP-21049] Add HTTP access token authentication for Bitbucket server provider

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
@@ -58,12 +58,17 @@ public class AuthConfig {
       failures.add(new RepositoryValidationFailure("'type' must be specified in 'auth'."));
     }
 
-    if (type == AuthType.PAT) {
+    if (type == AuthType.PAT || type == AuthType.HTTP_ACCESS_TOKEN) {
       if (patConfig == null) {
         failures.add(new RepositoryValidationFailure("'patConfig' must be specified in 'auth'."));
       } else {
         failures.addAll(patConfig.validate(provider));
       }
+    }
+
+    if (type == AuthType.HTTP_ACCESS_TOKEN && provider != Provider.BITBUCKET_SERVER) {
+      failures.add(new RepositoryValidationFailure(
+          "HTTP access token must only be used with bitbucket server."));
     }
 
     return failures;

--- a/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/AuthConfigTest.java
+++ b/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/AuthConfigTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import org.junit.Test;
+
+public class AuthConfigTest {
+
+  @Test
+  public void testHttpAccessTokenWithBitbucketServer_shouldPass() {
+    PatConfig patConfig = new PatConfig("test-name", "");
+    AuthConfig authConfig = new AuthConfig(AuthType.HTTP_ACCESS_TOKEN, patConfig);
+
+    Collection<RepositoryValidationFailure> failures = authConfig.validate(
+        Provider.BITBUCKET_SERVER);
+
+    assertTrue("Expected no validation errors", failures.isEmpty());
+  }
+
+  @Test
+  public void testHttpAccessTokenWithNonBitbucketProvider_shouldFailValidation() {
+    PatConfig patConfig = new PatConfig("test-password", "x-token-auth");
+    AuthConfig authConfig = new AuthConfig(AuthType.HTTP_ACCESS_TOKEN, patConfig);
+
+    Collection<RepositoryValidationFailure> failures = authConfig.validate(Provider.GITHUB);
+
+    assertFalse("Expected validation failures", failures.isEmpty());
+
+    String expectedMessage = "HTTP access token must only be used with bitbucket server.";
+    boolean hasExpectedMessage = false;
+    for (RepositoryValidationFailure failure : failures) {
+      if (expectedMessage.equals(failure.getMessage())) {
+        hasExpectedMessage = true;
+        break;
+      }
+    }
+
+    assertTrue("Expected specific validation message: "
+        + expectedMessage, hasExpectedMessage);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
@@ -42,12 +42,16 @@ public class AuthenticationStrategyProvider {
    */
   AuthenticationStrategy get(RepositoryConfig repoConfig) throws
       AuthenticationStrategyNotFoundException {
-    if (repoConfig.getAuth().getType() == AuthType.PAT) {
-      return new PatAuthenticationStrategy(secureStore, repoConfig, namespaceId);
+    AuthType authType = repoConfig.getAuth().getType();
+    switch (authType) {
+      case PAT:
+        return new PatAuthenticationStrategy(secureStore, repoConfig, namespaceId);
+      case HTTP_ACCESS_TOKEN:
+        return new HttpAccessTokenAuthenticationStrategy(secureStore, repoConfig, namespaceId);
+      default:
+        throw new AuthenticationStrategyNotFoundException(
+            String.format("No strategy found for provider %s and type %s.",
+                repoConfig.getProvider(), authType));
     }
-    throw new AuthenticationStrategyNotFoundException(
-        String.format("No strategy found for provider %s and type %s.",
-            repoConfig.getProvider(),
-            repoConfig.getAuth().getType()));
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/HttpAccessTokenAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/HttpAccessTokenAuthenticationStrategy.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.proto.sourcecontrol.PatConfig;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.TransportHttp;
+import org.eclipse.jgit.transport.URIish;
+
+/**
+ * An {@link AuthenticationStrategy} for repositories that use HTTP Bearer Token authentication.
+ */
+public class HttpAccessTokenAuthenticationStrategy implements AuthenticationStrategy {
+
+  private final HttpAccessTokenCredentialsProvider credentialsProvider;
+
+  /**
+   * Constructs an HttpAccessTokenAuthenticationStrategy.
+   *
+   * @param secureStore The secure store to retrieve credentials from.
+   * @param config The repository configuration.
+   * @param namespaceId The namespace ID associated with the repository.
+   */
+  public HttpAccessTokenAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config,
+      String namespaceId) {
+    PatConfig httpAccessTokenConfig = config.getAuth().getPatConfig();
+    this.credentialsProvider = new HttpAccessTokenCredentialsProvider(
+        secureStore,
+        httpAccessTokenConfig.getPasswordName(),
+        namespaceId
+    );
+  }
+
+  @Override
+  public RefreshableCredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
+  }
+
+  /**
+   * Credentials provider that adds a Bearer token as HTTP header.
+   */
+  static class HttpAccessTokenCredentialsProvider extends RefreshableCredentialsProvider
+      implements TransportCommandConfigurator {
+
+    private final SecureStore secureStore;
+    private final String accessTokenKeyName;
+    private final String namespaceId;
+    private String accessToken;
+
+    HttpAccessTokenCredentialsProvider(SecureStore secureStore, String accessTokenKeyName,
+        String namespaceId) {
+      this.secureStore = secureStore;
+      this.accessTokenKeyName = accessTokenKeyName;
+      this.namespaceId = namespaceId;
+    }
+
+    @Override
+    public void refresh() throws IOException, AuthenticationConfigException {
+      byte[] data;
+      try {
+        data = secureStore.getData(namespaceId, accessTokenKeyName);
+      } catch (Exception e) {
+        throw new AuthenticationConfigException("Failed to get token from secure store", e);
+      }
+      if (data == null) {
+        throw new AuthenticationConfigException(
+            String.format("Token with key name '%s' not found in secure store",
+                accessTokenKeyName));
+      }
+      accessToken = new String(data, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean isInteractive() {
+      return false;
+    }
+
+    @Override
+    public boolean supports(CredentialItem... credentialItems) {
+      // We don't use JGit's CredentialItems for bearer auth; return true to continue.
+      return true;
+    }
+
+    @Override
+    public boolean get(URIish uri, CredentialItem... credentialItems)
+        throws UnsupportedCredentialItem {
+      // This provider uses a TransportConfigCallback to inject the Bearer token directly
+      // as an HTTP header, bypassing JGit's standard username/password mechanism.
+      // This method is left empty but must return true to satisfy the API contract.
+      return true;
+    }
+
+    @Override
+    public void configure(TransportCommand<?, ?> command) {
+      command.setTransportConfigCallback(transport -> {
+        if (transport instanceof TransportHttp) {
+          ((TransportHttp) transport).setAdditionalHeaders(
+              Collections.singletonMap("Authorization", "Bearer " + accessToken));
+        }
+      });
+    }
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -424,6 +424,11 @@ public class RepositoryManager implements AutoCloseable {
     C command = creator.get();
     command.setCredentialsProvider(credentialsProvider);
     command.setTimeout(sourceControlConfig.getGitCommandTimeoutSeconds());
+
+    if (credentialsProvider instanceof TransportCommandConfigurator) {
+      ((TransportCommandConfigurator) credentialsProvider).configure(command);
+    }
+
     return command;
   }
 

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/TransportCommandConfigurator.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/TransportCommandConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Cask Data, Inc.
+ * Copyright © 2025 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,12 +14,15 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.sourcecontrol;
+package io.cdap.cdap.sourcecontrol;
+
+import org.eclipse.jgit.api.TransportCommand;
 
 /**
- * Auth Type Enums.
+ * An interface for CredentialsProviders that need to apply custom configurations to a
+ * {@link TransportCommand}, such as adding special headers.
  */
-public enum AuthType {
-  PAT,
-  HTTP_ACCESS_TOKEN
+public interface TransportCommandConfigurator {
+
+  void configure(TransportCommand<?, ?> command);
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/HttpAccessTokenAuthenticationStrategyTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/HttpAccessTokenAuthenticationStrategyTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.proto.sourcecontrol.AuthConfig;
+import io.cdap.cdap.proto.sourcecontrol.AuthType;
+import io.cdap.cdap.proto.sourcecontrol.PatConfig;
+import io.cdap.cdap.proto.sourcecontrol.Provider;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.eclipse.jgit.api.TransportCommand;
+import org.eclipse.jgit.transport.TransportHttp;
+import org.junit.Before;
+import org.junit.Test;
+
+public class HttpAccessTokenAuthenticationStrategyTest {
+
+  private static final String NAMESPACE = "test-ns";
+  private static final String TOKEN_KEY = "token-key";
+  private static final String TOKEN_VALUE = "mock-token";
+
+  private SecureStore mockSecureStore;
+  private RepositoryConfig mockRepoConfig;
+
+  @Before
+  public void setup() throws Exception {
+    mockSecureStore = mock(SecureStore.class);
+    when(mockSecureStore.getData(NAMESPACE, TOKEN_KEY))
+        .thenReturn(TOKEN_VALUE.getBytes(StandardCharsets.UTF_8));
+
+    PatConfig patConfig = new PatConfig(TOKEN_KEY, null);
+    AuthConfig authConfig = new AuthConfig(AuthType.HTTP_ACCESS_TOKEN, patConfig);
+
+    mockRepoConfig = new RepositoryConfig.Builder()
+        .setProvider(Provider.BITBUCKET_SERVER)
+        .setLink("http://fake.repo.com")
+        .setDefaultBranch("main")
+        .setAuth(authConfig)
+        .build();
+  }
+
+  @Test
+  public void testConfigureSetsBearerHeader() throws Exception {
+    HttpAccessTokenAuthenticationStrategy strategy =
+        new HttpAccessTokenAuthenticationStrategy(mockSecureStore, mockRepoConfig, NAMESPACE);
+
+    RefreshableCredentialsProvider provider = strategy.getCredentialsProvider();
+    provider.refresh();
+
+    HttpAccessTokenAuthenticationStrategy.HttpAccessTokenCredentialsProvider tokenProvider =
+        (HttpAccessTokenAuthenticationStrategy.HttpAccessTokenCredentialsProvider) provider;
+
+    TransportCommand<?, ?> mockCommand = mock(TransportCommand.class);
+    TransportHttp mockTransport = mock(TransportHttp.class);
+
+    doAnswer(invocation -> {
+      Object callback = invocation.getArgument(0);
+      ((org.eclipse.jgit.api.TransportConfigCallback) callback).configure(mockTransport);
+      return null;
+    }).when(mockCommand).setTransportConfigCallback(any());
+
+    tokenProvider.configure(mockCommand);
+
+    verify(mockTransport).setAdditionalHeaders(
+        Collections.singletonMap("Authorization", "Bearer " + TOKEN_VALUE));
+  }
+}


### PR DESCRIPTION
Currently, we only support PAT authentication mechanism for Bitbucket server. But newer versions of Bitbucket server support HTTP access tokens - https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html
In this PR, we are adding the support for HTTP access token authentication by implementing Bearer auth mechanism for BITBUCKET_SERVER provider. Jgit  only supports username-password auth and doesn't directly support bearer auth but there is a workaround for it - https://github.com/eclipse-jgit/jgit/issues/94.

**Testing**
- Created a bitbucket server locally -
`docker run -v bitbucketVolume:/var/atlassian/application-data/bitbucket --name="bitbucket" -d -p 7990:7990 -p 7999:7999 atlassian/bitbucket`
- Created a secure key (bug-fix-token) containing HTTP access token
- Connected a repo of provider BITBUCKET_SERVER and auth type as HTTP_ACCESS_TOKEN
<img width="1811" height="685" alt="Screenshot 2025-07-21 at 10 23 01 AM" src="https://github.com/user-attachments/assets/61193133-238b-4c25-b9f1-6124b3e534b0" />
- Source control management page:
<img width="1843" height="635" alt="Screenshot 2025-07-21 at 10 23 28 AM" src="https://github.com/user-attachments/assets/e7bf711b-eff0-42e8-9dac-657310e97a45" />
- Successfully pulled pipelines

<img width="1844" height="691" alt="Screenshot 2025-07-21 at 10 24 39 AM" src="https://github.com/user-attachments/assets/9d175c28-f759-4b6b-88d8-5de2ffc628ed" />
- Successfully pushed pipelines

<img width="1617" height="634" alt="Screenshot 2025-07-21 at 10 25 00 AM" src="https://github.com/user-attachments/assets/841d3e29-f32d-4b2e-9881-ffce74cf30a6" />
- Bitbucket server:
<img width="1595" height="761" alt="Screenshot 2025-07-21 at 10 25 30 AM" src="https://github.com/user-attachments/assets/2038ae02-6940-489a-bacf-92d8ce11eeb8" />

