### PR TITLE
[CDAP-21187] Update dataproc's default image to 2.3

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -459,8 +459,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   String getImageVersion(ProvisionerContext context, DataprocConf conf) {
     String imageVersion = conf.getImageVersion();
     if (imageVersion == null) {
-      // Dataproc 2.1 is the default version from 6.10.0 and later
-      imageVersion = "2.2";
+      // Dataproc 2.3 is the default version from 6.11.1 and later
+      imageVersion = "2.3";
     }
     return imageVersion;
   }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -272,20 +272,20 @@ public class DataprocProvisionerTest {
     ));
 
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.3", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.5.0"));
-    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.3", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.4.0"));
-    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.3", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     //Doublecheck we still get 2.1 for Spark 3 even with CDAP 6.4
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.3", provisioner.getImageVersion(context, defaultConf));
 
   }
 
@@ -313,7 +313,7 @@ public class DataprocProvisionerTest {
     Mockito.when(dataprocClient.getCluster("cdap-app-runId"))
         .thenReturn(Optional.empty());
     Mockito.when(dataprocClient.createCluster(Mockito.eq("cdap-app-runId"),
-            Mockito.eq("2.2"), addedLabelsCaptor.capture(), Mockito.eq(false),
+            Mockito.eq("2.3"), addedLabelsCaptor.capture(), Mockito.eq(false),
             Mockito.any()))
       .thenReturn(ClusterOperationMetadata.getDefaultInstance());
     Cluster expectedCluster = new Cluster(


### PR DESCRIPTION
as per dataproc’s [Release Notes](https://cloud.google.com/dataproc/docs/release-notes#June_09_2025) : Image Version 2.3 is a lightweight image that contains only core components, reducing exposure to Common Vulnerabilities and Exposures (CVEs). For higher security compliance requirements, use the image version 2.3 or later when creating a Dataproc cluster