### PR TITLE
[CDAP-21076] Add the post cleanup logic for conditional plugin

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
@@ -61,6 +61,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/connector/ConnectorSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/connector/ConnectorSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2025 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,6 +24,7 @@ import io.cdap.cdap.api.workflow.WorkflowConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.common.Constants;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.io.LongWritable;
@@ -31,6 +32,9 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.lib.input.CombineTextInputFormat;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Internal batch source used as a connector between pipeline phases. Though this extends
@@ -48,6 +52,7 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
  */
 public class ConnectorSource<T> extends BatchSource<LongWritable, Text, T> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorSource.class);
   // you can't read from the basedir of a FileSet so adding an arbitrary directory where data will be stored/read.
   static final String DATA_DIR = "data";
   private final String datasetName;
@@ -74,4 +79,32 @@ public class ConnectorSource<T> extends BatchSource<LongWritable, Text, T> {
     context.setInput(Input.ofDataset(datasetName, arguments));
   }
 
+  @Override
+  public void onRunFinish(boolean succeeded, BatchSourceContext context) {
+    super.onRunFinish(succeeded, context);
+    try {
+      cleanupDataset(context);
+    } catch (Exception e) {
+      LOG.warn("Failed to clean up source dataset '{}'.", datasetName, e);
+    }
+  }
+
+  /**
+   * Deletes the underlying FileSet data.
+   */
+  private void cleanupDataset(BatchSourceContext context) throws IOException {
+    FileSet fileSet = context.getDataset(datasetName);
+    Location baseLocation = fileSet.getBaseLocation();
+    if (baseLocation == null || !baseLocation.exists()) {
+      LOG.info("Base location does not exist for dataset '{}'. Skipping cleanup.", datasetName);
+      return;
+    }
+
+    if (!baseLocation.delete(true)) {
+      throw new IOException(
+          String.format("Failed to delete file(s) at location '%s'.", baseLocation));
+    }
+
+    LOG.info("Successfully cleaned up file(s) at location '{}'.", baseLocation);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/batch/connector/ConnectorSourceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/batch/connector/ConnectorSourceTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch.connector;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.cdap.cdap.api.dataset.lib.FileSet;
+import io.cdap.cdap.etl.api.batch.BatchSourceContext;
+import java.io.IOException;
+import org.apache.twill.filesystem.Location;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * Unit tests for the {@link ConnectorSource} class.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectorSourceTest {
+
+  private static final String TEST_DATASET_NAME = "testConnectorData";
+
+  @Mock
+  private BatchSourceContext mockContext;
+
+  @Mock
+  private FileSet mockFileSet;
+
+  @Mock
+  private Location mockLocation;
+
+  private ConnectorSource<Object> connectorSource;
+
+  @Before
+  public void setUp() {
+    connectorSource = new ConnectorSource<>(TEST_DATASET_NAME);
+  }
+
+  @Test
+  public void testOnRunFinish_whenRunSucceeds_shouldDeleteLocation() throws IOException {
+    when(mockContext.getDataset(TEST_DATASET_NAME)).thenReturn(mockFileSet);
+    when(mockFileSet.getBaseLocation()).thenReturn(mockLocation);
+    when(mockLocation.exists()).thenReturn(true);
+    when(mockLocation.delete(true)).thenReturn(true);
+    connectorSource.onRunFinish(true, mockContext);
+
+    verify(mockContext).getDataset(TEST_DATASET_NAME);
+    verify(mockLocation).delete(true);
+  }
+
+  @Test
+  public void testOnRunFinish_whenBaseLocationDoesNotExist_shouldSkipDelete() throws IOException {
+    when(mockContext.getDataset(TEST_DATASET_NAME)).thenReturn(mockFileSet);
+    when(mockFileSet.getBaseLocation()).thenReturn(mockLocation);
+    when(mockLocation.exists()).thenReturn(false);
+    connectorSource.onRunFinish(true, mockContext);
+
+    verify(mockLocation, never()).delete(true);
+  }
+
+  @Test
+  public void testOnRunFinish_whenBaseLocationIsNull_shouldSkipDelete() {
+    when(mockContext.getDataset(TEST_DATASET_NAME)).thenReturn(mockFileSet);
+    when(mockFileSet.getBaseLocation()).thenReturn(null);
+    connectorSource.onRunFinish(true, mockContext);
+
+    verify(mockFileSet).getBaseLocation();
+  }
+
+  @Test
+  public void testOnRunFinish_whenDeletionFails_shouldLogWarningAndNotThrow() throws IOException {
+    when(mockContext.getDataset(TEST_DATASET_NAME)).thenReturn(mockFileSet);
+    when(mockFileSet.getBaseLocation()).thenReturn(mockLocation);
+    when(mockLocation.exists()).thenReturn(true);
+    when(mockLocation.delete(true)).thenReturn(false);
+    connectorSource.onRunFinish(true, mockContext);
+
+    verify(mockLocation).delete(true);
+  }
+}


### PR DESCRIPTION
[Jira Link](https://cdap.atlassian.net/browse/CDAP-21076)

### Context:
For customers using static dataproc clusters, the hdfs storage does not get cleaned up which ends up causing storage issues and subsequently pipeline executions start failing. Since after a pipeline run is successful, the corresponding files are no longer important, we can delete them after the run. Location: ` cdap/namespaces/<namespace_name>/data `

### Changes
The cleanup logic is implemented within the onRunFinish method of the ConnectorSource class.

- After a pipeline run completes successfully (i.e., the succeeded flag is true), the new logic will delete the data associated with that specific run from its underlying FileSet.
- The logic targets the baseLocation of the dataset, which corresponds to the run-specific directory (e.g., `/cdap/namespaces/<namespace>/data/conn-0/<run_id>`).
- If a pipeline run fails, the cleanup is skipped, preserving the intermediate data for debugging and inspection.

### Testing
- Created a multi-phase pipeline using conditional plugins to ensure data is passed via the connector.
- Verified that the run-specific HDFS directory created by the connector during the pipeline execution was automatically deleted upon successful completion.

<img width="3000" height="1670" alt="image" src="https://github.com/user-attachments/assets/44189d03-6b98-4bce-a69d-07212306a295" />


