### PR TITLE
[CDAP-21196] Updating exempted uri for credentials

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
@@ -70,6 +70,8 @@ public class GcpWorkloadIdentityHttpHandlerInternal extends AbstractHttpHandler 
   public void provisionCredential(HttpRequest request, HttpResponder responder,
       @PathParam("namespace-id") String namespace, @QueryParam("scopes") String scopes)
       throws CredentialProvisioningException, IOException, NotFoundException {
+    // If query params are updated, update the pattern matching URI at
+    // io.cdap.cdap.common.encryption.EncryptionExemptionHook
     try {
       responder.sendJson(HttpResponseStatus.OK,
           GSON.toJson(credentialProvider.provision(namespace, scopes)));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
@@ -40,7 +40,7 @@ public class EncryptionExemptionHook extends AbstractHandlerHook {
   private static final List<Pattern> EXEMPTED_URIS = ImmutableList.of(
       Pattern.compile("/v3Internal/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
       Pattern.compile("/v3/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
-      Pattern.compile("/v3Internal/namespaces/([^/]+)/credentials/workloadIdentity/provision$"),
+      Pattern.compile("/v3Internal/namespaces/([^/]+)/credentials/workloadIdentity/provision(\\?scopes=(.*))?$"),
       Pattern.compile("/v3Internal/namespaces/([^/]+)/preferences([^/]+)"),
       Pattern.compile("/v3/namespaces/([^/]+)/securekeys/([^/]+)(/.*)?$")
   );

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
@@ -140,7 +140,8 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
               ImmutablePair<Boolean, String> newCredentialPair = decryptAndIdentifyCredential(
                   credentialValue, taskWorkerDecryptionHeader);
               if (newCredentialPair.getFirst()) {
-                throw new UnauthenticatedException("Request denied for Task workers");
+                throw new UnauthenticatedException(
+                    String.format("Request denied for Task workers for URI: %s", request.uri()));
               }
               currentUserCredential = new Credential(newCredentialPair.getSecond(), credentialType);
             }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
@@ -59,8 +59,6 @@ import java.util.function.Predicate;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Helper class for executing a {@link RunnableTaskRequest} on a remote worker.

--- a/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
@@ -45,6 +45,31 @@ public class EncryptionExemptionHookTest {
   }
 
   @Test
+  public void testPatternMatchingCredentialsUriWithQueryParamsSuccessful() {
+    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+        "/v3Internal/namespaces/default/credentials/workloadIdentity/"
+            + "provision?scopes=https://www.test.com/auth/test-platform");
+    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
+    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
+
+    hook.preCall(request, null, handlerInfo);
+
+    Assert.assertFalse(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
+  }
+
+  @Test
+  public void testPatternMatchingCredentialsUriWithoutQueryParamsSuccessful() {
+    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+        "/v3Internal/namespaces/default/credentials/workloadIdentity/provision");
+    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
+    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
+
+    hook.preCall(request, null, handlerInfo);
+
+    Assert.assertFalse(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
+  }
+
+  @Test
   public void testPatternMatchingUnsuccessful() {
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "testingUri");
     HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -441,7 +441,6 @@ public class TestBase {
       ((CoreSchedulerService) scheduler).waitUntilFunctional(10, TimeUnit.SECONDS);
     }
     appStateStoreProvider = injector.getInstance(AppStateStoreProvider.class);
-    LOG.error("Got all instances");
   }
 
   /**


### PR DESCRIPTION
Fix for [JIRA](https://cdap.atlassian.net/browse/CDAP-21196).

### Context

Updating the pattern for credentials URI matching to include arguments post "provision" block. The URI which was not getting exempted before:

```
/v3Internal/namespaces/default/credentials/workloadIdentity/provision?scopes=https://www.googleapis.com/auth/cloud-platform
```

### Testing

Ensured that the sampling with a GCS bucket is working fine without errors