### PR TITLE
[CDAP-21207] Add error classification during input/output format initialization

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingInputFormat.java
@@ -85,9 +85,9 @@ public abstract class DelegatingInputFormat<K, V> extends InputFormat<K, V> {
       }
       return inputFormat;
     } catch (Exception e) {
-      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+      throw new RuntimeException(
         String.format("Unable to instantiate delegate input format class '%s'.",
-          delegateClassName), e.getMessage(), ErrorType.SYSTEM, false, e);
+          delegateClassName), e);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingOutputFormat.java
@@ -85,9 +85,9 @@ public class DelegatingOutputFormat<K, V> extends OutputFormat<K, V> {
       }
       return outputFormat;
     } catch (Exception e) {
-      throw ErrorUtils.getProgramFailureException(new ErrorCategory(ErrorCategoryEnum.PLUGIN),
+      throw new RuntimeException(
         String.format("Unable to instantiate delegate output format class '%s'.",
-          delegateClassName), e.getMessage(), ErrorType.SYSTEM, false, e);
+          delegateClassName), e);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ErrorDetails.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ErrorDetails.java
@@ -16,12 +16,15 @@
 
 package io.cdap.cdap.etl.common;
 
+import com.google.common.base.Throwables;
+import io.cdap.cdap.api.exception.FailureDetailsProvider;
 import io.cdap.cdap.api.exception.ProgramFailureException;
 import io.cdap.cdap.api.exception.WrappedStageException;
 import io.cdap.cdap.etl.api.exception.ErrorContext;
 import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
 import io.cdap.cdap.etl.api.exception.ErrorPhase;
 import io.cdap.cdap.etl.api.exception.NoopErrorDetailsProvider;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,10 +73,34 @@ public class ErrorDetails {
     ErrorDetailsProvider errorDetailsProvider, ErrorPhase phase) {
     ProgramFailureException exception = null;
 
-    if (!(e instanceof ProgramFailureException)) {
+    if (!(isFailureDetailsProviderInCausalChain(e))) {
       exception = errorDetailsProvider == null ? null :
-        errorDetailsProvider.getExceptionDetails(e, new ErrorContext(phase));
+          errorDetailsProvider.getExceptionDetails(e, new ErrorContext(phase));
+    }
+    WrappedStageException wrappedStageException = getWrappedStageExceptionFromCausalChain(e);
+    if (wrappedStageException != null) {
+      return wrappedStageException;
     }
     return new WrappedStageException(exception == null ? e : exception, stageName);
+  }
+
+  public static boolean isFailureDetailsProviderInCausalChain(Throwable e) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable cause : causalChain) {
+      if (cause instanceof FailureDetailsProvider) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static WrappedStageException getWrappedStageExceptionFromCausalChain(Throwable e) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable cause : causalChain) {
+      if (cause instanceof WrappedStageException) {
+        return (WrappedStageException) cause;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
context : Below errors are classified as `SYSTEM` errors.

```
https://docs.oracle.com/error-help/db/ora-02391/
	at com.google.common.base.Throwables.propagate(Throwables.java:160)
	at io.cdap.plugin.db.source.DataDrivenETLDBInputFormat.getConnection(DataDrivenETLDBInputFormat.java:119)
	at io.cdap.plugin.db.source.DataDrivenETLDBInputFormat.createConnection(DataDrivenETLDBInputFormat.java:128)
	at org.apache.hadoop.mapreduce.lib.db.DBInputFormat.setConf(DBInputFormat.java:165)
	... 33 common frames omitted
Caused by: java.sql.SQLException: ORA-02391: exceeded simultaneous SESSIONS_PER_USER limit
```