### PR TITLE
[CDAP-21206] Fix task worker encryption for connection and oauth macro evaluator in rbac instances

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -170,7 +170,7 @@ public class AppFabricServer extends AbstractIdleService {
 
     // Create encryption exemption handler hooks
     List<EncryptionExemptionHook> encryptionHandlerHooks = handlerHookNames.stream()
-        .map(name -> new EncryptionExemptionHook(cConf, name))
+        .map(name -> new EncryptionExemptionHook())
         .collect(Collectors.toList());
 
     handlerHooks.addAll(auditHandlerHooks);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.common.encryption;
 
 import com.google.common.collect.ImmutableList;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.http.HttpHeaderNames;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.http.AbstractHandlerHook;
@@ -34,20 +33,21 @@ import org.slf4j.LoggerFactory;
  * Sets encryption exception metadata to {@link SecurityRequestContext}.
  */
 public class EncryptionExemptionHook extends AbstractHandlerHook {
-  private static final Logger LOG = LoggerFactory.getLogger(EncryptionExemptionHook.class);
-  private final String serviceName;
 
+  private static final Logger LOG = LoggerFactory.getLogger(EncryptionExemptionHook.class);
   private static final List<Pattern> EXEMPTED_URIS = ImmutableList.of(
       Pattern.compile("/v3Internal/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
       Pattern.compile("/v3/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
-      Pattern.compile("/v3Internal/namespaces/([^/]+)/credentials/workloadIdentity/provision(\\?scopes=(.*))?$"),
+      Pattern.compile(
+          "/v3Internal/namespaces/([^/]+)/credentials/workloadIdentity/provision(\\?scopes=(.*))?$"),
       Pattern.compile("/v3Internal/namespaces/([^/]+)/preferences([^/]+)"),
-      Pattern.compile("/v3/namespaces/([^/]+)/securekeys/([^/]+)(/.*)?$")
-  );
+      Pattern.compile("/v3/namespaces/([^/]+)/securekeys/([^/]+)(/.*)?$"),
+      Pattern.compile("/v3/namespaces/([^/]+)/apps/([^/]+)/services/([^/]+)/methods"
+          + "/v1/contexts/([^/]+)/connections(?:/.*)?$"),
+      Pattern.compile("/v3/namespaces/([^/]+)/apps/([^/]+)/services/([^/]+)/methods"
+          + "/v1/oauth/provider/([^/]+)(?:/authurl|/credential/([^/]+)(?:/valid)?)?$")
 
-  public EncryptionExemptionHook(CConfiguration cConf, String serviceName) {
-    this.serviceName = serviceName;
-  }
+  );
 
   @Override
   public boolean preCall(HttpRequest request, HttpResponder responder, HandlerInfo handlerInfo) {
@@ -55,7 +55,8 @@ public class EncryptionExemptionHook extends AbstractHandlerHook {
       for (Pattern uriPattern : EXEMPTED_URIS) {
         Matcher matcher = uriPattern.matcher(request.uri());
         if (matcher.matches()) {
-          // For any pattern match, set the header to false to prevent Unauthenticated exception after decryption
+          // For any pattern match, set the header to false, in order to prevent Unauthenticated exception
+          // after decryption.
           request.headers().set(HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR, "false");
           return true;
         }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -83,7 +83,7 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
     this.setHandlerHooks(Collections.unmodifiableList(
       Arrays.asList(new MetricsReporterHook(cConf, metricsCollectionService, serviceName),
                     new AuditLogSetterHook(cConf, serviceName),
-                    new EncryptionExemptionHook(cConf, serviceName))));
+                    new EncryptionExemptionHook())));
   }
 
   /**

--- a/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
@@ -18,65 +18,82 @@ package io.cdap.cdap.common.encryption;
 
 import static io.cdap.cdap.common.http.HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR;
 
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.http.internal.HandlerInfo;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpVersion;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
+/**
+ * Tests for {@link EncryptionExemptionHook}.
+ */
+@RunWith(Parameterized.class)
 public class EncryptionExemptionHookTest {
-  private static final String TESTSERVICENAME = "test.Service";
-  private static final String TESTHANDLERNAME = "test.handler";
-  private static final String TESTMETHODNAME = "testMethod";
 
-  @Test
-  public void testPatternMatchingSuccessful() {
-    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
-        "/v3/namespaces/default/securekeys/personal-token");
-    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
-    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
+  private HandlerInfo handlerInfo;
+  private EncryptionExemptionHook hook;
 
-    hook.preCall(request, null, handlerInfo);
+  // Parameters for the test
+  private final String uri;
+  private final boolean expectedDecryptionHeader;
+  private final String testName;
 
-    Assert.assertFalse(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
+  public EncryptionExemptionHookTest(String uri, boolean expectedDecryptionHeader,
+      String testName) {
+    this.uri = uri;
+    this.expectedDecryptionHeader = expectedDecryptionHeader;
+    this.testName = testName;
+  }
+
+  // Define the data set for the tests
+  @Parameters(name = "{2}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        // Successful (Exempt) Tests - Header should be FALSE.
+        {"/v3/namespaces/default/securekeys/personal-token", false, "SecureKeysExempt"},
+        {"/v3Internal/namespaces/default/credentials/workloadIdentity/provision"
+            + "?scopes=https://www.test.com/auth/test-platform",
+            false, "CredentialsWithQueryParamsExempt"},
+        {"/v3Internal/namespaces/default/credentials/workloadIdentity/provision", false,
+            "CredentialsWithoutQueryParamsExempt"},
+        {"/v3/namespaces/system/apps/pipeline/services/studio/methods"
+            + "/v1/contexts/default/connections/testing",
+            false, "ConnectionValidationExempt"},
+        {"/v3/namespaces/system/apps/pipeline/services/studio/methods"
+            + "/v1/oauth/provider/provider/credential/REUSE_PROV_FALSE",
+            false, "OAuthMacroEvaluatorExempt"},
+        // Unsuccessful (Non-Exempt) Test - Header should be TRUE.
+        {"testing", true, "NonExempt"}});
+  }
+
+  @Before
+  public void setup() {
+    handlerInfo = new HandlerInfo("test.handler", "testMethod");
+    hook = new EncryptionExemptionHook();
   }
 
   @Test
-  public void testPatternMatchingCredentialsUriWithQueryParamsSuccessful() {
-    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
-        "/v3Internal/namespaces/default/credentials/workloadIdentity/"
-            + "provision?scopes=https://www.test.com/auth/test-platform");
-    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
-    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
+  public void testPreCall() {
+    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, this.uri);
 
     hook.preCall(request, null, handlerInfo);
 
-    Assert.assertFalse(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
+    String message = String.format("Test case '%s' failed for URI: %s. Expected header value: %s.",
+        this.testName, this.uri, this.expectedDecryptionHeader);
+
+    Assert.assertEquals(message, this.expectedDecryptionHeader, isDecryptionHeaderSet(request));
   }
 
-  @Test
-  public void testPatternMatchingCredentialsUriWithoutQueryParamsSuccessful() {
-    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
-        "/v3Internal/namespaces/default/credentials/workloadIdentity/provision");
-    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
-    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
-
-    hook.preCall(request, null, handlerInfo);
-
-    Assert.assertFalse(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
-  }
-
-  @Test
-  public void testPatternMatchingUnsuccessful() {
-    HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "testingUri");
-    HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
-    EncryptionExemptionHook hook = new EncryptionExemptionHook(CConfiguration.create(), TESTSERVICENAME);
-
-    hook.preCall(request, null, handlerInfo);
-
-    Assert.assertTrue(Boolean.parseBoolean(request.headers().get(TASK_WORKER_DECRYPTION_HDR)));
+  private boolean isDecryptionHeaderSet(HttpRequest request) {
+    String headerValue = request.headers().get(TASK_WORKER_DECRYPTION_HDR);
+    return Boolean.parseBoolean(headerValue);
   }
 }


### PR DESCRIPTION
Addresses : 
```
Got exception: Request denied for Task workers for URI: /v3/namespaces/system/apps/pipeline/services/studio/methods/v1/contexts/default/connections/testing
io.cdap.cdap.security.spi.authentication.UnauthenticatedException: Request denied for Task workers for URI: /v3/namespaces/system/apps/pipeline/services/studio/methods/v1/contexts/default/connections/testing
```

```
Got exception: Request denied for workers for URI: /v3/namespaces/system/apps/pipeline/services/studio/methods/v1/oauth/provider/provider/credential/REUSE_PROV_FALSE
io.cdap.cdap.security.spi.authentication.UnauthenticatedException: Request denied for workers for URI: /v3/namespaces/system/apps/pipeline/services/studio/methods/v1/oauth/provider/provider/credential/REUSE_PROV_FALSE
```

It is a plugin validation / oauth provider call, hence api call to `pipeline-studio` service is required. 

This PR exempts other `contexts/defaults/connections` and  `/oauth/provider` api endpoints as well. They already have authorization support in their handlers. [reference](https://www.google.com/url?q=https://github.com/cdapio/cdap/blob/c45f4fcc5ef0d2f05769f54195b006ed43823aaf/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java%23L145&sa=D&source=docs&ust=1758561253626340&usg=AOvVaw21oCSdwadtQxNAkjgFxBie)

### Testing

#### RBAC

<img width="5104" height="1306" alt="image" src="https://github.com/user-attachments/assets/cfd3481b-7d83-4b42-81a8-df9b2bfc5bae" />
<img width="5078" height="1444" alt="image" src="https://github.com/user-attachments/assets/3b0c8fde-d30a-4a25-b02b-2feec5add00d" />


#### Non RBAC

<img width="5094" height="1374" alt="image" src="https://github.com/user-attachments/assets/b5a5bcb0-5576-4365-bceb-8d4177aadbb2" />
<img width="5118" height="1464" alt="image" src="https://github.com/user-attachments/assets/4ac97014-b9fd-40af-b28b-a296da908094" />

