### PR TITLE
[CDAP-21211] Restrict preview runner to poll for only one request per lifecycle

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -167,6 +167,12 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements
     newRunnerService.startAndWait();
   }
 
+  @Override
+  public void stop(byte[] pollerInfo) throws Exception {
+    // This is a no-op in a non-distributed environment because there is no separate
+    // runner container to terminate. The preview runner is a thread in the same process.
+  }
+
   /**
    * Create injector for the given application id.
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
@@ -126,6 +126,20 @@ public interface PreviewStore {
   byte[] getPreviewRequestPollerInfo(ApplicationId applicationId);
 
   /**
+   * Retrieves the {@link ApplicationId} associated with a given preview runner's poller information.
+   * <p>
+   * This method uses a secondary index for a fast, direct lookup to find the mapping from a
+   * {@code pollerInfo} to an {@code ApplicationId}.
+   *
+   * @param pollerInfo the {@link PreviewRequestPollerInfo} of the preview runner.
+   * @return the {@link ApplicationId} associated with the given {@code pollerInfo},
+   *         or {@code null} if no association is found. A {@code null} return value
+   *         typically indicates that the runner is new and not yet assigned to a preview run.
+   */
+  @Nullable
+  ApplicationId getApplicationId(byte[] pollerInfo);
+
+  /**
    * Deletes the preview data older than ttl.
    *
    * @param ttlInSeconds ttl in seconds

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -23,7 +23,9 @@ import io.cdap.cdap.api.feature.FeatureFlagsProvider;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.app.preview.PreviewManager;
+import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.app.preview.PreviewRequestQueue;
+import io.cdap.cdap.app.preview.PreviewStatus;
 import io.cdap.cdap.app.store.preview.PreviewStore;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -46,6 +48,8 @@ import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
 import io.cdap.cdap.master.spi.twill.StatefulTwillPreparer;
 import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
@@ -65,6 +69,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.api.ResourceSpecification;
@@ -88,6 +93,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
   private final Configuration hConf;
   private final FeatureFlagsProvider featureFlagsProvider;
   private final TwillRunner twillRunner;
+  private final PreviewRunStopper previewRunStopper;
+  private final PreviewStore previewStore;
   private ScheduledExecutorService scheduler;
   private TwillController controller;
 
@@ -119,6 +126,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
     this.hConf = hConf;
     this.twillRunner = twillRunner;
     this.featureFlagsProvider = new DefaultFeatureFlagsProvider(cConf);
+    this.previewRunStopper = previewRunStopper;
+    this.previewStore = previewStore;
   }
 
   @Override
@@ -306,6 +315,43 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
       }
     }
     controller = activeController;
+  }
+
+  /**
+   * Overrides the default poll behavior to enforce a "one-request-per-runner" policy.
+   * <p>
+   * This implementation first checks if the polling runner is already associated with an active
+   * preview run. If it is, this indicates a protocol violation or a state inconsistency. In this
+   * case, the existing preview run is immediately marked as {@link PreviewStatus.Status#KILLED}
+   * with a reason indicating an invalid state. A best-effort attempt is then made to terminate the
+   * runner's container, and the poll request is denied by returning an empty {@link Optional}.
+   * <p>
+   * If the runner is not associated with an existing run, this method delegates to the parent
+   * {@code poll} method to retrieve the next available preview request from the queue.
+   *
+   * @param pollerInfo Information that uniquely identifies the polling preview runner.
+   * @return {@link Optional} containing a {@link PreviewRequest} if a job is available for a valid
+   * runner, or {@link Optional#empty()} if the request is denied due to a protocol violation or if
+   * no job is currently available in the queue.
+   */
+  @Override
+  public Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo) {
+    ApplicationId appId = previewStore.getApplicationId(pollerInfo);
+    if (appId != null) {
+      try {
+        PreviewStatus status = getStatus(appId);
+        previewStore.setPreviewStatus(appId, new PreviewStatus(PreviewStatus.Status.KILLED,
+            status.getSubmitTime(), new BasicThrowable(new IllegalStateException(
+            "Preview run stopped due to an invalid state. A runner can only be assigned one preview run at a time. "
+                + "Please try running preview again.")), null, null));
+        previewRunStopper.stop(pollerInfo);
+      } catch (Exception e) {
+        LOG.warn("Attempted to stop a runner due to a state violation but failed. " +
+            "The runner will be denied a new request, but may not have been terminated.", e);
+      }
+      return Optional.empty();
+    }
+    return super.poll(pollerInfo);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewRunStopper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewRunStopper.java
@@ -56,7 +56,12 @@ public class DistributedPreviewRunStopper implements PreviewRunStopper {
       throw new IllegalStateException(
           "Preview cannot be stopped. Please try stopping again or run the new preview.");
     }
+    stop(info);
+    LOG.info("Force stopped preview run {}", previewApp);
+  }
 
+  @Override
+  public void stop(byte[] info) throws Exception {
     PreviewRequestPollerInfo pollerInfo = GSON.fromJson(new String(info, StandardCharsets.UTF_8),
         PreviewRequestPollerInfo.class);
     Iterator<TwillController> controllers = twillRunner.lookup(PreviewRunnerTwillApplication.NAME)
@@ -65,20 +70,18 @@ public class DistributedPreviewRunStopper implements PreviewRunStopper {
       throw new IllegalStateException("Preview runners cannot be stopped. Please try again.");
     }
 
-    LOG.debug("Stopping preview run {} with poller info {}", previewApp, pollerInfo);
+    LOG.debug("Stopping preview run with poller info {}", pollerInfo);
 
     TwillController controller = controllers.next();
     Future<String> future;
     if (controller instanceof ExtendedTwillController) {
       future = ((ExtendedTwillController) controller).restartInstance(
-          PreviewRunnerTwillRunnable.class.getSimpleName(),
-          pollerInfo.getInstanceId(),
+          PreviewRunnerTwillRunnable.class.getSimpleName(), pollerInfo.getInstanceId(),
           pollerInfo.getInstanceUid());
     } else {
       future = controller.restartInstances(PreviewRunnerTwillRunnable.class.getSimpleName(),
           pollerInfo.getInstanceId());
     }
     future.get();
-    LOG.info("Force stopped preview run {}", previewApp);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
@@ -30,4 +30,21 @@ public interface PreviewRunStopper {
    * @throws Exception if any error while stopping
    */
   void stop(ApplicationId preview) throws Exception;
+
+  /**
+   * Stops the preview runner associated with the given poller information.
+   * <p>
+   * In a distributed environment (e.g., Kubernetes), this method is responsible for finding the
+   * runner's container and terminating it. This is a critical action for enforcing the
+   * "one-request-per-runner" security policy when a suspicious runner is detected.
+   * </p><p>
+   * In a non-distributed (standalone) environment, this is a no-op as there is no separate container
+   * to terminate.
+   * </p>
+   *
+   * @param pollerInfo The poller information identifying the preview runner to be stopped.
+   * @throws Exception if there is an error while attempting to stop the runner in a distributed
+   *                   environment.
+   */
+  void stop(byte[] pollerInfo) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
@@ -54,17 +54,21 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of the {@link PreviewStore} that stores data in a level db table.
  */
 public class DefaultPreviewStore implements PreviewStore {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPreviewStore.class);
   private static final DatasetId PREVIEW_TABLE_ID = NamespaceId.SYSTEM.dataset("preview.table");
   private static final DatasetId PREVIEW_QUEUE_TABLE_ID = NamespaceId.SYSTEM.dataset(
       "preview.queue.table");
   private static final byte[] DATA_ROW_KEY_PREFIX = Bytes.toBytes("dr");
   private static final byte[] META_ROW_KEY_PREFIX = Bytes.toBytes("mr");
+  private static final byte[] POLLER_INFO_TO_APP_ID_PREFIX = Bytes.toBytes("p2a");
   private static final byte[] TRACER = Bytes.toBytes("t");
   private static final byte[] PROPERTY = Bytes.toBytes("p");
   private static final byte[] VALUE = Bytes.toBytes("v");
@@ -84,6 +88,8 @@ public class DefaultPreviewStore implements PreviewStore {
   private static final byte[] CONFIG = Bytes.toBytes("c");
   private static final byte[] APPID = Bytes.toBytes("a");
   private static final byte[] PRINCIPAL = Bytes.toBytes("p");
+  private static final Gson ENTITY_GSON = new GsonBuilder().registerTypeAdapter(EntityId.class,
+      new EntityIdTypeAdapter()).create();
 
   private final AtomicLong counter = new AtomicLong(0L);
 
@@ -167,6 +173,18 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public void remove(ApplicationId applicationId) {
+    byte[] pollerInfo = getPreviewRequestPollerInfo(applicationId);
+    if (pollerInfo != null) {
+      MDSKey indexKey = new MDSKey.Builder().add(POLLER_INFO_TO_APP_ID_PREFIX).add(pollerInfo)
+          .build();
+      try {
+        previewTable.deleteDefaultVersion(indexKey.getKey(), APPID);
+      } catch (IOException e) {
+        // It is ok to not throw exception here, as the data will be eventually cleaned up by the ttl remover.
+        LOG.warn("Failed to delete poller info for application {}", applicationId, e);
+      }
+    }
+
     removeFromWaitingState(applicationId);
     // remove actual preview user data
     removePreviewData(DATA_ROW_KEY_PREFIX, applicationId);
@@ -176,14 +194,11 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public void setProgramId(ProgramRunId programRunId) {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
-        .create();
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX,
         programRunId.getParent().getParent()).build();
     try {
       previewTable.putDefaultVersion(mdsKey.getKey(), RUN,
-          Bytes.toBytes(gson.toJson(programRunId)));
+          Bytes.toBytes(ENTITY_GSON.toJson(programRunId)));
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to put %s into preview store", programRunId),
           e);
@@ -192,9 +207,6 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public ProgramRunId getProgramRunId(ApplicationId applicationId) {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
-        .create();
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     byte[] runId = null;
@@ -206,7 +218,7 @@ public class DefaultPreviewStore implements PreviewStore {
           String.format("Failed to get program run id for preview %s", applicationId), e);
     }
     if (runId != null) {
-      return gson.fromJson(Bytes.toString(runId), ProgramRunId.class);
+      return ENTITY_GSON.fromJson(Bytes.toString(runId), ProgramRunId.class);
     }
     return null;
   }
@@ -368,6 +380,16 @@ public class DefaultPreviewStore implements PreviewStore {
           gson.toJson(pollerInfo), applicationId);
       throw new RuntimeException(msg, e);
     }
+
+    // Add an entry to the index: pollerInfo -> applicationId
+    MDSKey indexKey = new MDSKey.Builder().add(POLLER_INFO_TO_APP_ID_PREFIX).add(pollerInfo)
+        .build();
+    try {
+      previewTable.putDefaultVersion(indexKey.getKey(), APPID,
+          Bytes.toBytes(gson.toJson(applicationId)));
+    } catch (IOException e) {
+      throw new RuntimeException("Error while creating poller info index.", e);
+    }
   }
 
   @Override
@@ -388,10 +410,22 @@ public class DefaultPreviewStore implements PreviewStore {
     return null;
   }
 
+  public ApplicationId getApplicationId(byte[] pollerInfo) {
+    MDSKey indexKey = new MDSKey.Builder().add(POLLER_INFO_TO_APP_ID_PREFIX).add(pollerInfo)
+        .build();
+    try {
+      byte[] applicationIdBytes = previewTable.getDefaultVersion(indexKey.getKey(), APPID);
+      if (applicationIdBytes == null) {
+        return null;
+      }
+      return ENTITY_GSON.fromJson(Bytes.toString(applicationIdBytes), ApplicationId.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Error while getting application id for poller info.", e);
+    }
+  }
+
   @Override
   public void deleteExpiredData(long ttlInSeconds) {
-    Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter())
-        .create();
     byte[] startRowKey = new MDSKey.Builder().add(META_ROW_KEY_PREFIX).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
@@ -405,7 +439,7 @@ public class DefaultPreviewStore implements PreviewStore {
           continue;
         }
 
-        ApplicationId applicationId = gson.fromJson(applicationIdGson, ApplicationId.class);
+        ApplicationId applicationId = ENTITY_GSON.fromJson(applicationIdGson, ApplicationId.class);
         long applicationSubmitTime = RunIds.getTime(applicationId.getApplication(),
             TimeUnit.SECONDS);
         if ((currentTimeInSeconds - applicationSubmitTime) > ttlInSeconds) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueueTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueueTest.java
@@ -142,6 +142,12 @@ public class DefaultPreviewRequestQueueTest {
       return new byte[0];
     }
 
+    @Nullable
+    @Override
+    public ApplicationId getApplicationId(byte[] pollerInfo) {
+      return null;
+    }
+
     @Override
     public void deleteExpiredData(long ttlInSeconds) {
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
@@ -69,7 +69,7 @@ public class DefaultPreviewStoreTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
 
     Injector injector = Guice.createInjector(
-      new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create())
+        new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create())
     );
     store = injector.getInstance(DefaultPreviewStore.class);
   }
@@ -87,10 +87,12 @@ public class DefaultPreviewStoreTest {
   @Test
   public void testPreviewStore() {
     String firstApplication = RunIds.generate().getId();
-    ApplicationId firstApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), firstApplication);
+    ApplicationId firstApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(),
+        firstApplication);
 
     String secondApplication = RunIds.generate().getId();
-    ApplicationId secondApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), secondApplication);
+    ApplicationId secondApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(),
+        secondApplication);
 
     // put data for the first application
     store.put(firstApplicationId, "mytracer", "key1", "value1");
@@ -113,10 +115,12 @@ public class DefaultPreviewStoreTest {
     Assert.assertEquals(2, firstApplicationData.get("key1").get(1).getAsInt());
     Assert.assertEquals(3, firstApplicationData.get("key2").get(0).getAsInt());
     Assert.assertEquals(propertyMap, GSON.fromJson(firstApplicationData.get("key2").get(1),
-                                                   new TypeToken<HashMap<Object, Object>>() { }.getType()));
+        new TypeToken<HashMap<Object, Object>>() {
+        }.getType()));
 
     // get the data for second application and logger name "mytracer"
-    Map<String, List<JsonElement>> secondApplicationData = store.get(secondApplicationId, "mytracer");
+    Map<String, List<JsonElement>> secondApplicationData = store.get(secondApplicationId,
+        "mytracer");
     Assert.assertEquals(1, secondApplicationData.size());
     Assert.assertEquals("value1", secondApplicationData.get("key1").get(0).getAsString());
 
@@ -136,9 +140,10 @@ public class DefaultPreviewStoreTest {
     // test put and get
     ApplicationId applicationId = new ApplicationId("ns1", "app1");
     ProgramRunId runId = new ProgramRunId("ns1", "app1", ProgramType.WORKFLOW, "test",
-                                          RunIds.generate().getId());
-    PreviewStatus status = new PreviewStatus(PreviewStatus.Status.COMPLETED, System.currentTimeMillis(), null, 0L,
-                                             System.currentTimeMillis());
+        RunIds.generate().getId());
+    PreviewStatus status = new PreviewStatus(PreviewStatus.Status.COMPLETED,
+        System.currentTimeMillis(), null, 0L,
+        System.currentTimeMillis());
     store.setProgramId(runId);
     store.setPreviewStatus(applicationId, status);
 
@@ -151,7 +156,8 @@ public class DefaultPreviewStoreTest {
     byte[] pollerInfo = Bytes.toBytes("runner-1");
 
     PreviewConfig previewConfig = new PreviewConfig("WordCount", ProgramType.WORKFLOW, null, null);
-    AppRequest<?> testRequest = new AppRequest<>(new ArtifactSummary("test", "1.0"), null, previewConfig);
+    AppRequest<?> testRequest = new AppRequest<>(new ArtifactSummary("test", "1.0"), null,
+        previewConfig);
     Assert.assertEquals(0, store.getAllInWaitingState().size());
 
     RunId id1 = RunIds.generate();
@@ -191,9 +197,9 @@ public class DefaultPreviewStoreTest {
     // Add a preview request that has a principle associated with it
     ApplicationId applicationId4 = new ApplicationId("ns1", RunIds.generate().getId());
     Principal principal = new Principal("userForApplicationId4",
-                                        Principal.PrincipalType.USER,
-                                        new Credential("userForApplicationId4Credential",
-                                                       Credential.CredentialType.EXTERNAL));
+        Principal.PrincipalType.USER,
+        new Credential("userForApplicationId4Credential",
+            Credential.CredentialType.EXTERNAL));
     store.add(applicationId4, testRequest, principal);
     allWaiting = store.getAllInWaitingState();
     Assert.assertEquals(1, allWaiting.size());
@@ -207,16 +213,20 @@ public class DefaultPreviewStoreTest {
   @Test
   public void testPreviewTTL() throws Exception {
     PreviewConfig previewConfig = new PreviewConfig("WordCount", ProgramType.WORKFLOW, null, null);
-    AppRequest<?> testRequest = new AppRequest<>(new ArtifactSummary("test", "1.0"), null, previewConfig);
+    AppRequest<?> testRequest = new AppRequest<>(new ArtifactSummary("test", "1.0"), null,
+        previewConfig);
 
     String firstApplication = RunIds.generate(System.currentTimeMillis() - 5000).getId();
-    ApplicationId firstApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), firstApplication);
+    ApplicationId firstApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(),
+        firstApplication);
 
     String secondApplication = RunIds.generate(System.currentTimeMillis() - 4000).getId();
-    ApplicationId secondApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), secondApplication);
+    ApplicationId secondApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(),
+        secondApplication);
 
     String thirdApplication = RunIds.generate(System.currentTimeMillis()).getId();
-    ApplicationId thirdApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), thirdApplication);
+    ApplicationId thirdApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(),
+        thirdApplication);
 
     store.add(firstApplicationId, testRequest, null);
     store.add(secondApplicationId, testRequest, null);
@@ -246,6 +256,39 @@ public class DefaultPreviewStoreTest {
 
     // only thirdApplication should be in waiting now
     Assert.assertEquals(1, store.getAllInWaitingState().size());
-    Assert.assertEquals(thirdApplicationId, store.getAllInWaitingState().iterator().next().getProgram().getParent());
+    Assert.assertEquals(thirdApplicationId,
+        store.getAllInWaitingState().iterator().next().getProgram().getParent());
+  }
+
+  @Test
+  public void testGetApplicationIdForPollerInfo() throws Exception {
+    byte[] pollerInfo1 = Bytes.toBytes("runner-1");
+    byte[] pollerInfo2 = Bytes.toBytes("runner-2");
+
+    PreviewConfig previewConfig = new PreviewConfig("WordCount", ProgramType.WORKFLOW, null, null);
+    AppRequest<?> testRequest = new AppRequest<>(new ArtifactSummary("test", "1.0"), null,
+        previewConfig);
+
+    // 1. Test success case: associate pollerInfo1 with applicationId1
+    ApplicationId applicationId1 = new ApplicationId("ns1", RunIds.generate().getId());
+    store.add(applicationId1, testRequest, null);
+    store.setPreviewRequestPollerInfo(applicationId1, pollerInfo1);
+
+    // Verify that the mapping is correct
+    Assert.assertEquals(applicationId1, store.getApplicationId(pollerInfo1));
+
+    // 2. Test failure case: pollerInfo2 is not associated with any application
+    Assert.assertNull(store.getApplicationId(pollerInfo2));
+
+    // 3. Test re-association: associate pollerInfo1 with a new application
+    // This simulates a scenario where a runner with the same info is reused, overwriting the index.
+    ApplicationId applicationId2 = new ApplicationId("ns1", RunIds.generate().getId());
+    store.add(applicationId2, testRequest, null);
+    store.setPreviewRequestPollerInfo(applicationId2, pollerInfo1);
+    Assert.assertEquals(applicationId2, store.getApplicationId(pollerInfo1));
+
+    // 4. Test removal: remove the application and verify the mapping is gone
+    store.remove(applicationId2);
+    Assert.assertNull(store.getApplicationId(pollerInfo1));
   }
 }


### PR DESCRIPTION
Restrict preview runners access to the preview queue by allowing processing of just one request during its lifecycle.

### Change Summary

- `PreviewStore` is updated to store another key value mapping : pollerInfo <-> appId. Whenever a new poll request is received by the previewManager, it will validate that the runner is not associated with any application id based on this mapping. 
- A new method, `stopPreview(PreviewRequestPollerInfo)`, is added to the `DistributedPreviewRunStopper` to handle the termination of the runner's container. This termination method is invoked from `PreviewManager` when an invalid poll request is detected.
- Upon termination, the corresponding preview run's status is set to KILLED, and a relevant error message is displayed.

### Testing

#### Happy path :
<img width="5074" height="630" alt="image" src="https://github.com/user-attachments/assets/4755b17c-1562-4acd-ad5c-1a74a84bb5ee" />

#### Poll for more than one request : 
<img width="3818" height="276" alt="image" src="https://github.com/user-attachments/assets/1ea46b8c-4ce4-4ef4-8ae5-4a2541671c9d" />

<img width="3200" height="261" alt="image" src="https://github.com/user-attachments/assets/301b93a5-09e7-4125-986d-12fbc3ae72bf" />


