### PR TITLE
[CDAP-21211] Include preview runner pod as part of authentication for internal apis

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
@@ -60,7 +60,7 @@ public class PreviewHttpServer extends AbstractIdleService {
       PreviewManager previewManager, CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
     this.discoveryService = discoveryService;
     NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
-            Constants.Service.PREVIEW_HTTP, false)
+            Constants.Service.PREVIEW_HTTP)
         .setHost(cConf.get(Constants.Preview.ADDRESS))
         .setPort(cConf.getInt(Constants.Preview.PORT))
         .setHttpHandlers(httpHandlers)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -46,7 +46,9 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.Security.Encryption;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.encryption.AeadCipher;
 import io.cdap.cdap.common.encryption.guice.UserCredentialAeadEncryptionModule;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
@@ -92,6 +94,8 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.security.ApplicationPermission;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.DefaultContextAccessEnforcer;
@@ -142,6 +146,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
   private final MessagingService messagingService;
   private final PreviewDataCleanupService previewDataCleanupService;
   private final MetricsCollectionService metricsCollectionService;
+  private final AeadCipher userEncryptionAeadCipher;
   private Injector previewInjector;
   private PreviewDataSubscriberService dataSubscriberService;
   private PreviewTMSLogSubscriber logSubscriberService;
@@ -161,7 +166,8 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       PreviewRequestQueue previewRequestQueue, PreviewStore previewStore,
       PreviewRunStopper previewRunStopper, MessagingService messagingService,
       PreviewDataCleanupService previewDataCleanupService,
-      MetricsCollectionService metricsCollectionService) {
+      MetricsCollectionService metricsCollectionService,
+      @Named(UserCredentialAeadEncryptionModule.USER_CREDENTIAL_ENCRYPTION) AeadCipher userEncryptionAeadCipher) {
     this.authenticationContext = authenticationContext;
     this.previewCConf = previewCConf;
     this.previewHConf = previewHConf;
@@ -178,6 +184,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     this.messagingService = messagingService;
     this.previewDataCleanupService = previewDataCleanupService;
     this.metricsCollectionService = metricsCollectionService;
+    this.userEncryptionAeadCipher = userEncryptionAeadCipher;
   }
 
   @Override
@@ -216,8 +223,8 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     accessEnforcer.enforce(previewApp, authenticationContext.getPrincipal(),
         ApplicationPermission.PREVIEW);
     ProgramId programId = getProgramIdFromRequest(previewApp, appRequest);
-    PreviewRequest previewRequest = new PreviewRequest(programId, appRequest,
-        authenticationContext.getPrincipal());
+    Principal principal = encryptCredential();
+    PreviewRequest previewRequest = new PreviewRequest(programId, appRequest, principal);
 
     if (state() != State.RUNNING) {
       throw new IllegalStateException(
@@ -420,6 +427,21 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     }
 
     return preview.program(programType, programName);
+  }
+
+  private Principal encryptCredential() {
+    Principal originalPrincipal = authenticationContext.getPrincipal();
+    if (originalPrincipal == null || originalPrincipal.getFullCredential() == null) {
+      return originalPrincipal;
+    }
+
+    Credential credential = originalPrincipal.getFullCredential();
+    String encryptedValue = userEncryptionAeadCipher.encryptToBase64(credential.getValue(),
+        Encryption.PREVIEW_RUNNER_ENCRYPTION_ASSOCIATED_DATA.getBytes());
+    Credential encryptedCredential = new Credential(encryptedValue, credential.getType());
+
+    return new Principal(originalPrincipal.getName(), originalPrincipal.getType(),
+        originalPrincipal.getKerberosPrincipal(), encryptedCredential);
   }
 
   private void stopQuietly(Service service) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -32,6 +32,8 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.InternalRouter;
 import io.cdap.cdap.common.conf.Constants.Preview;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.encryption.AeadCipher;
+import io.cdap.cdap.common.encryption.guice.UserCredentialAeadEncryptionModule;
 import io.cdap.cdap.common.feature.DefaultFeatureFlagsProvider;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -114,13 +116,14 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
       PreviewRunStopper previewRunStopper, MessagingService messagingService,
       MetricsCollectionService metricsCollectionService,
       PreviewDataCleanupService previewDataCleanupService,
-      TwillRunner twillRunner) {
+      TwillRunner twillRunner,
+      @Named(UserCredentialAeadEncryptionModule.USER_CREDENTIAL_ENCRYPTION) AeadCipher userEncryptionAeadCipher) {
     super(discoveryServiceClient, datasetFramework, transactionSystemClient,
         accessControllerInstantiator, accessEnforcer, authenticationContext,
         previewLevelDbTableService,
         previewCconf, previewHconf, previewSconf, previewRequestQueue, previewStore,
         previewRunStopper,
-        messagingService, previewDataCleanupService, metricsCollectionService);
+        messagingService, previewDataCleanupService, metricsCollectionService, userEncryptionAeadCipher);
 
     this.cConf = cConf;
     this.hConf = hConf;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1965,6 +1965,12 @@ public final class Constants {
        */
       public static final String TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA
           = "TaskWorkerEncryptionAD";
+
+      /**
+       * Associated data for preview runner credential encryption.
+       */
+      public static final String PREVIEW_RUNNER_ENCRYPTION_ASSOCIATED_DATA
+          = "PreviewRunnerEncryptionAD";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/encryption/EncryptionExemptionHook.java
@@ -24,7 +24,6 @@ import io.cdap.http.HttpResponder;
 import io.cdap.http.internal.HandlerInfo;
 import io.netty.handler.codec.http.HttpRequest;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,37 +34,52 @@ import org.slf4j.LoggerFactory;
 public class EncryptionExemptionHook extends AbstractHandlerHook {
 
   private static final Logger LOG = LoggerFactory.getLogger(EncryptionExemptionHook.class);
-  private static final List<Pattern> EXEMPTED_URIS = ImmutableList.of(
-      Pattern.compile("/v3Internal/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
+
+  private static final List<Pattern> SHARED_WORKER_EXEMPTED_URIS = ImmutableList.of(
       Pattern.compile("/v3/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
+      Pattern.compile("/v3Internal/namespaces/([^/]+)/artifacts/([^/]+)/versions/([^/]+)(/.*)?$"),
       Pattern.compile(
           "/v3Internal/namespaces/([^/]+)/credentials/workloadIdentity/provision(\\?scopes=(.*))?$"),
-      Pattern.compile("/v3Internal/namespaces/([^/]+)/preferences([^/]+)"),
-      Pattern.compile("/v3/namespaces/([^/]+)/securekeys/([^/]+)(/.*)?$"),
       Pattern.compile("/v3/namespaces/([^/]+)/apps/([^/]+)/services/([^/]+)/methods"
           + "/v1/contexts/([^/]+)/connections(?:/.*)?$"),
-      Pattern.compile("/v3/namespaces/([^/]+)/apps/([^/]+)/services/([^/]+)/methods"
-          + "/v1/oauth/provider/([^/]+)(?:/authurl|/credential/([^/]+)(?:/valid)?)?$")
-
-  );
+      Pattern.compile(
+          "/v3/namespaces/([^/]+)/apps/([^/]+)/services/([^/]+)/methods"
+              + "/v1/oauth/provider/([^/]+)(?:/authurl|/credential/([^/]+)(?:/valid)?)?$"));
+  private static final List<Pattern> TASK_WORKER_EXEMPTED_URIS = ImmutableList.of(
+      Pattern.compile("/v3/namespaces/([^/]+)/securekeys/([^/]+)(/.*)?$"),
+      Pattern.compile("/v3Internal/namespaces/([^/]+)/preferences([^/]+)"));
+  private static final List<Pattern> PREVIEW_RUNNER_EXEMPTED_URIS = ImmutableList.of(
+      Pattern.compile("/v3Internal/namespaces/([^/]+)/artifacts/([^/]+)/versions(\\?.*)?$"),
+      Pattern.compile(
+          "/v3Internal/namespaces/([^/]+)/apps/([^/]+)/workflows/([^/]+)/preferences(\\?.*)?$"),
+      Pattern.compile("/v3/namespaces/([^/]+)/data/datasets/([^/]+)$"),
+      Pattern.compile("/v1/namespaces/system/topics/preview/publish"));
 
   @Override
   public boolean preCall(HttpRequest request, HttpResponder responder, HandlerInfo handlerInfo) {
-    try {
-      for (Pattern uriPattern : EXEMPTED_URIS) {
-        Matcher matcher = uriPattern.matcher(request.uri());
-        if (matcher.matches()) {
-          // For any pattern match, set the header to false, in order to prevent Unauthenticated exception
-          // after decryption.
-          request.headers().set(HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR, "false");
-          return true;
-        }
-      }
-    } catch (Throwable e) {
-      LOG.error("Encountered exception while pattern matching for URI {}", request.uri(), e);
+    WorkerDecryptionScope exemptionType = WorkerDecryptionScope.NONE;
+    String uri = request.uri();
+
+    if (isUriExempt(uri, SHARED_WORKER_EXEMPTED_URIS)) {
+      exemptionType = WorkerDecryptionScope.ANY_WORKER;
+    } else if (isUriExempt(uri, PREVIEW_RUNNER_EXEMPTED_URIS)) {
+      exemptionType = WorkerDecryptionScope.PREVIEW_RUNNER;
+    } else if (isUriExempt(uri, TASK_WORKER_EXEMPTED_URIS)) {
+      exemptionType = WorkerDecryptionScope.TASK_WORKER;
     }
 
-    request.headers().set(HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR, "true");
+    // Set the header with the determined exemption type.
+    request.headers().set(HttpHeaderNames.WORKER_DECRYPTION_HDR, exemptionType.name());
+    LOG.trace("URI {} exemption type set to {}", uri, exemptionType);
     return true;
+  }
+
+  private boolean isUriExempt(String uri, List<Pattern> exemptionList) {
+    for (Pattern pattern : exemptionList) {
+      if (pattern.matcher(uri).matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/encryption/WorkerDecryptionScope.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/encryption/WorkerDecryptionScope.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.encryption;
+
+/**
+ * Defines the type of worker that is allowed to decrypt data for a given URI. This is written to a
+ * response header to inform the requesting worker.
+ */
+public enum WorkerDecryptionScope {
+  NONE,
+  PREVIEW_RUNNER,
+  TASK_WORKER,
+  ANY_WORKER
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
@@ -20,9 +20,11 @@ import io.cdap.cdap.api.auditlogging.AuditLogWriter;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.Security.Encryption;
 import io.cdap.cdap.common.encryption.AeadCipher;
+import io.cdap.cdap.common.encryption.WorkerDecryptionScope;
 import io.cdap.cdap.common.encryption.guice.LazyDelegateAeadCipher;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Credential.CredentialType;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authentication.UnauthenticatedException;
 import io.cdap.cdap.security.spi.authorization.AuditLogContext;
@@ -67,16 +69,19 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
 
   private final boolean internalAuthEnabled;
   private final boolean auditLoggingEnabled;
-  private final boolean taskWorkerDecryptionEnabled;
+  private final boolean workerDecryptionEnabled;
   private final AuditLogWriter auditLogWriter;
   private final AeadCipher userEncryptionAeadCipher;
 
+  /**
+   * Constructor for {@link AuthenticationChannelHandler}.
+   */
   public AuthenticationChannelHandler(boolean internalAuthEnabled, boolean auditLoggingEnabled,
-                                      boolean taskWorkerDecryptionEnabled, AuditLogWriter auditLogWriter,
+                                      boolean workerDecryptionEnabled, AuditLogWriter auditLogWriter,
                                       AeadCipher userEncryptionAeadCipher) {
     this.internalAuthEnabled = internalAuthEnabled;
     this.auditLoggingEnabled = auditLoggingEnabled;
-    this.taskWorkerDecryptionEnabled = taskWorkerDecryptionEnabled;
+    this.workerDecryptionEnabled = workerDecryptionEnabled;
     this.auditLogWriter = auditLogWriter;
     this.userEncryptionAeadCipher = userEncryptionAeadCipher;
   }
@@ -116,8 +121,6 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
         currentUserIp = userIp;
       }
       String authHeader = request.headers().get(Constants.Security.Headers.RUNTIME_TOKEN);
-      boolean taskWorkerDecryptionHeader = Boolean.parseBoolean(
-          request.headers().get(HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR));
       if (authHeader != null) {
         int idx = authHeader.trim().indexOf(' ');
         if (idx < 0) {
@@ -132,18 +135,12 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
                 credentialTypeStr);
             String credentialValue = authHeader.substring(idx + 1).trim();
 
-            // If task worker decryption is disabled, use the credential value from auth header
-            // else decrypt the credential and check if task worker call
-            if (!taskWorkerDecryptionEnabled) {
+            // If task worker / preview runner decryption is disabled, use the credential value from auth header
+            // else decrypt the credential and check if this was call from workers.
+            if (!workerDecryptionEnabled) {
               currentUserCredential = new Credential(credentialValue, credentialType);
             } else {
-              ImmutablePair<Boolean, String> newCredentialPair = decryptAndIdentifyCredential(
-                  credentialValue, taskWorkerDecryptionHeader);
-              if (newCredentialPair.getFirst()) {
-                throw new UnauthenticatedException(
-                    String.format("Request denied for Task workers for URI: %s", request.uri()));
-              }
-              currentUserCredential = new Credential(newCredentialPair.getSecond(), credentialType);
+              currentUserCredential = validateAndGetCredential(request, credentialType, credentialValue);
             }
           } catch (IllegalArgumentException e) {
             LOG.error("Invalid credential type in Authorization header: {}", credentialTypeStr);
@@ -160,7 +157,8 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
       //Also set userIp in ATTR , to be used in audit logging incase it was replaced at a later stage
       ctx.channel().attr(AttributeKey.valueOf(AUDIT_LOG_USER_IP_ATTR)).set(currentUserIp);
       ctx.channel().attr(AttributeKey.valueOf(CDAP_USER_ID_ATTR)).set(currentUserId);
-      ctx.channel().attr(AttributeKey.valueOf(CDAP_USER_CREDENTIAL_ATTR)).set(currentUserCredential);
+      ctx.channel().attr(AttributeKey.valueOf(CDAP_USER_CREDENTIAL_ATTR))
+          .set(currentUserCredential);
     } else {
       Object userIpObj = ctx.channel().attr(AttributeKey.valueOf(AUDIT_LOG_USER_IP_ATTR)).get();
       Object userIdObj = ctx.channel().attr(AttributeKey.valueOf(CDAP_USER_ID_ATTR)).get();
@@ -302,18 +300,15 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
   }
 
   /**
-   * Tries to decrypt the credential value with task worker AD.
+   * Tries to decrypt the credential value with worker associatedData.
    * If decryption is successful, return the decrypted string else return original string.
    *
    * @return the decrypted string if possible, or original string.
    */
-  private String decryptIfPossible(String credentialValue) {
+  private String decryptIfPossible(String credentialValue, String associatedData) {
     if (userEncryptionAeadCipher instanceof LazyDelegateAeadCipher) {
       try {
-        String decryptedCredentialValue = userEncryptionAeadCipher.decryptStringFromBase64(
-            credentialValue,
-            Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes());
-        return decryptedCredentialValue;
+        return userEncryptionAeadCipher.decryptStringFromBase64(credentialValue, associatedData.getBytes());
       } catch (CipherException | IllegalArgumentException e) {
         return credentialValue;
       }
@@ -322,18 +317,59 @@ public class AuthenticationChannelHandler extends ChannelDuplexHandler {
   }
 
   /**
-   * Checks if the call is being made from task worker and if it is permitted:
-   * 1. Decrypt the credential with task worker AD
-   * 2. Check if the URI is exempted from task worker call checks or not
+   * Determines the worker type by attempting to decrypt the credential with different Associated
+   * Data (AD) strings.
    *
-   * @return Pair of boolean and string, boolean for checking valid call, string for decrypted credential value
+   * @param credentialValue the encrypted credential string from the request header.
+   * @return An {@link ImmutablePair} containing the determined {@link WorkerDecryptionScope}.
    */
-  private ImmutablePair<Boolean, String> decryptAndIdentifyCredential(String credentialValue,
-      boolean taskWorkerDecryptionHeader) {
-    String decryptedCredentialValue = decryptIfPossible(credentialValue);
-    if (!decryptedCredentialValue.equals(credentialValue) && taskWorkerDecryptionHeader) {
-      return new ImmutablePair<>(true, decryptedCredentialValue);
+  private ImmutablePair<WorkerDecryptionScope, String> determineWorkerTypeAndGetCredential(
+      String credentialValue) {
+
+    // Try to decrypt with Task Worker AD first.
+    String decrypted = decryptIfPossible(credentialValue,
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA);
+    if (!decrypted.equals(credentialValue)) {
+      return new ImmutablePair<>(WorkerDecryptionScope.TASK_WORKER, decrypted);
     }
-    return new ImmutablePair<>(false, decryptedCredentialValue);
+
+    // If that fails, try to decrypt with Preview runner AD.
+    decrypted = decryptIfPossible(credentialValue,
+        Encryption.PREVIEW_RUNNER_ENCRYPTION_ASSOCIATED_DATA);
+    if (!decrypted.equals(credentialValue)) {
+      return new ImmutablePair<>(WorkerDecryptionScope.PREVIEW_RUNNER, decrypted);
+    }
+
+    // If both fail, it's not a worker call.
+    return new ImmutablePair<>(WorkerDecryptionScope.NONE, credentialValue);
+  }
+
+  private Credential validateAndGetCredential(HttpRequest request, CredentialType credentialType,
+      String credentialValue) {
+    String expectedDecryptionHeader = request.headers().get(HttpHeaderNames.WORKER_DECRYPTION_HDR);
+    WorkerDecryptionScope expectedWorkerDecryptionScope =
+        (expectedDecryptionHeader == null) ? WorkerDecryptionScope.NONE
+            : WorkerDecryptionScope.valueOf(expectedDecryptionHeader);
+
+    // 1. Determine the ACTUAL worker type by trying to decrypt the credential.
+    ImmutablePair<WorkerDecryptionScope, String> workerInfo = determineWorkerTypeAndGetCredential(
+        credentialValue);
+    WorkerDecryptionScope actualWorkerType = workerInfo.getFirst();
+    String decryptedCredentialValue = workerInfo.getSecond();
+
+    // 2. If it's a worker, perform the second phase of validation.
+    if (actualWorkerType != WorkerDecryptionScope.NONE) {
+      // 3. FINAL VALIDATION: The actual type must be allowed by the exemption policy.
+      boolean isAuthorized = (expectedWorkerDecryptionScope == WorkerDecryptionScope.ANY_WORKER)
+          || (expectedWorkerDecryptionScope == actualWorkerType);
+
+      if (!isAuthorized) {
+        throw new UnauthenticatedException(String.format(
+            "Request from a %s was denied because the URI '%s' is not "
+                + "exempt for this worker type. Expected %s", actualWorkerType,
+            request.uri(), expectedWorkerDecryptionScope));
+      }
+    }
+    return new Credential(decryptedCredentialValue, credentialType);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -52,12 +52,12 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
    * @param cConf CConfiguration
    * @param serviceName Name of the service
    * @param metricsCollectionService MetricsCollectionService
-   * @param taskWorkerDecryptionEnabled flag to check if requests to this service are from task worker
+   * @param workerDecryptionEnabled flag to check if requests to this service are from task worker
    * @param auditLogWriter Writer to publish audit log requests
    * @param userEncryptionAeadCipher cipher used for decrypting user credentials
    */
   public CommonNettyHttpServiceBuilder(CConfiguration cConf, String serviceName,
-      MetricsCollectionService metricsCollectionService, boolean taskWorkerDecryptionEnabled,
+      MetricsCollectionService metricsCollectionService, boolean workerDecryptionEnabled,
       AuditLogWriter auditLogWriter, AeadCipher userEncryptionAeadCipher) {
     super(serviceName);
     if (cConf.getBoolean(Constants.Security.ENABLED)) {
@@ -74,7 +74,7 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           EventExecutor executor = pipeline.context("dispatcher").executor();
           pipeline.addBefore(executor, "dispatcher", AUTHENTICATOR_NAME,
                              new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
-                                 .INTERNAL_AUTH_ENABLED), auditLoggingEnabled, taskWorkerDecryptionEnabled,
+                                 .INTERNAL_AUTH_ENABLED), auditLoggingEnabled, workerDecryptionEnabled,
                                  auditLogWriter, userEncryptionAeadCipher));
         }
       };

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceFactory.java
@@ -56,8 +56,8 @@ public class CommonNettyHttpServiceFactory {
     return builder(serviceName, true);
   }
 
-  public CommonNettyHttpServiceBuilder builder(String serviceName, boolean taskWorkerDecryptionEnabled) {
+  public CommonNettyHttpServiceBuilder builder(String serviceName, boolean workerDecryptionEnabled) {
     return new CommonNettyHttpServiceBuilder(cConf, serviceName, metricsCollectionService,
-        taskWorkerDecryptionEnabled, auditLogWriter, userEncryptionAeadCipher);
+        workerDecryptionEnabled, auditLogWriter, userEncryptionAeadCipher);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/HttpHeaderNames.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/HttpHeaderNames.java
@@ -28,9 +28,9 @@ public final class HttpHeaderNames {
   public static final String CDAP_REQ_TIMESTAMP_HDR = "CDAP_REQ_TIMESTAMP_HDR";
 
   /**
-   * Store whether task worker decryption is required.
+   * Store which type of worker decryption is required.
    */
-  public static final String TASK_WORKER_DECRYPTION_HDR = "TASK_WORKER_DECRYPTION_HDR";
+  public static final String WORKER_DECRYPTION_HDR = "WORKER_DECRYPTION_HDR";
 
   // TODO move all other custom headers used by CDAP to this class. JIRA https://cdap.atlassian.net/browse/CDAP-18799
 

--- a/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/encryption/EncryptionExemptionHookTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.common.encryption;
 
-import static io.cdap.cdap.common.http.HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR;
+import static io.cdap.cdap.common.http.HttpHeaderNames.WORKER_DECRYPTION_HDR;
 
 import io.cdap.http.internal.HandlerInfo;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -43,35 +43,54 @@ public class EncryptionExemptionHookTest {
 
   // Parameters for the test
   private final String uri;
-  private final boolean expectedDecryptionHeader;
+  private final String expectedExemptionType;
   private final String testName;
 
-  public EncryptionExemptionHookTest(String uri, boolean expectedDecryptionHeader,
-      String testName) {
+  public EncryptionExemptionHookTest(String uri, String expectedExemptionType, String testName) {
     this.uri = uri;
-    this.expectedDecryptionHeader = expectedDecryptionHeader;
+    this.expectedExemptionType = expectedExemptionType;
     this.testName = testName;
   }
 
-  // Define the data set for the tests
+  // Define the data set for the tests.
   @Parameters(name = "{2}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][]{
-        // Successful (Exempt) Tests - Header should be FALSE.
-        {"/v3/namespaces/default/securekeys/personal-token", false, "SecureKeysExempt"},
         {"/v3Internal/namespaces/default/credentials/workloadIdentity/provision"
             + "?scopes=https://www.test.com/auth/test-platform",
-            false, "CredentialsWithQueryParamsExempt"},
-        {"/v3Internal/namespaces/default/credentials/workloadIdentity/provision", false,
-            "CredentialsWithoutQueryParamsExempt"},
+            WorkerDecryptionScope.ANY_WORKER.name(), "CredentialsWithQueryParamsExempt"},
+        {"/v3Internal/namespaces/default/credentials/workloadIdentity/provision",
+            WorkerDecryptionScope.ANY_WORKER.name(), "CredentialsWithoutQueryParamsExempt"},
         {"/v3/namespaces/system/apps/pipeline/services/studio/methods"
-            + "/v1/contexts/default/connections/testing",
-            false, "ConnectionValidationExempt"},
+            + "/v1/contexts/default/connections/testing", WorkerDecryptionScope.ANY_WORKER.name(),
+            "ConnectionValidationExempt"},
         {"/v3/namespaces/system/apps/pipeline/services/studio/methods"
             + "/v1/oauth/provider/provider/credential/REUSE_PROV_FALSE",
-            false, "OAuthMacroEvaluatorExempt"},
-        // Unsuccessful (Non-Exempt) Test - Header should be TRUE.
-        {"testing", true, "NonExempt"}});
+            WorkerDecryptionScope.ANY_WORKER.name(), "OAuthMacroEvaluatorExempt"},
+
+        {"/v3Internal/namespaces/system/artifacts/cdap-data-pipeline/versions?"
+            + "lower=6.12.0-SNAPSHOT&upper=6.12.0-SNAPSHOT&limit=1&order=DE",
+            WorkerDecryptionScope.PREVIEW_RUNNER.name(), "ArtifactsWithVersionParams"},
+        {"/v3Internal/namespaces/system/artifacts/MyApp/versions",
+            WorkerDecryptionScope.PREVIEW_RUNNER.name(), "ArtifactsVersionlessExempt"},
+        {"/v3Internal/namespaces/default/apps/e99c8132-8edd-11f0-9607-36a08ae62395/"
+            + "workflows/DataPipelineWorkflow/preferences?resolved=true",
+            WorkerDecryptionScope.PREVIEW_RUNNER.name(), "WorkflowPreferencesExempt"},
+        {"/v3/namespaces/user/data/datasets/MyDatasetName",
+            WorkerDecryptionScope.PREVIEW_RUNNER.name(), "DataDatasetsExempt"},
+        {"/v1/namespaces/system/topics/preview/publish",
+            WorkerDecryptionScope.PREVIEW_RUNNER.name(),
+            "SystemTopicPublishExempt"},
+
+        {"/v3Internal/namespaces/default/preferences?key=value",
+            WorkerDecryptionScope.TASK_WORKER.name(), "GenericPreferencesExempt"},
+        {"/v3/namespaces/default/securekeys/personal-token",
+            WorkerDecryptionScope.TASK_WORKER.name(),
+            "SecureKeysExempt"},
+
+        {"testing", WorkerDecryptionScope.NONE.name(), "NonExemptGeneric"},
+        {"/v3/system/services/status", WorkerDecryptionScope.NONE.name(), "NonExemptV3Status"}
+    });
   }
 
   @Before
@@ -86,14 +105,12 @@ public class EncryptionExemptionHookTest {
 
     hook.preCall(request, null, handlerInfo);
 
-    String message = String.format("Test case '%s' failed for URI: %s. Expected header value: %s.",
-        this.testName, this.uri, this.expectedDecryptionHeader);
+    String actualHeader = request.headers().get(WORKER_DECRYPTION_HDR);
 
-    Assert.assertEquals(message, this.expectedDecryptionHeader, isDecryptionHeaderSet(request));
-  }
+    String message = String.format(
+        "Test case '%s' failed for URI: %s. Expected Exemption Type: %s, Actual: %s.",
+        this.testName, this.uri, this.expectedExemptionType, actualHeader);
 
-  private boolean isDecryptionHeaderSet(HttpRequest request) {
-    String headerValue = request.headers().get(TASK_WORKER_DECRYPTION_HDR);
-    return Boolean.parseBoolean(headerValue);
+    Assert.assertEquals(message, this.expectedExemptionType, actualHeader);
   }
 }

--- a/cdap-common/src/test/java/io/cdap/cdap/common/http/AuthenticationChannelHandlerTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/http/AuthenticationChannelHandlerTest.java
@@ -27,6 +27,8 @@ import io.cdap.cdap.api.auditlogging.AuditLogWriter;
 import io.cdap.cdap.common.conf.Constants.Security.Encryption;
 import io.cdap.cdap.common.conf.Constants.Security.Headers;
 import io.cdap.cdap.common.encryption.AeadCipher;
+import io.cdap.cdap.common.encryption.FakeAeadCipher;
+import io.cdap.cdap.common.encryption.WorkerDecryptionScope;
 import io.cdap.cdap.common.encryption.guice.LazyDelegateAeadCipher;
 import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Credential.CredentialType;
@@ -34,6 +36,7 @@ import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authentication.UnauthenticatedException;
 import io.cdap.cdap.security.spi.authorization.AuditLogContext;
 import io.cdap.cdap.security.spi.authorization.AuditLogRequest;
+import io.cdap.cdap.security.spi.encryption.CipherException;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpRequest;
@@ -59,7 +62,8 @@ public class AuthenticationChannelHandlerTest {
   public void initHandler() {
     boolean internalAuthEnabled = true;
     mockAeadCipher = mock(AeadCipher.class);
-    handler = new AuthenticationChannelHandler(internalAuthEnabled, false, false, null, mockAeadCipher);
+    handler = new AuthenticationChannelHandler(internalAuthEnabled, false, false, null,
+        mockAeadCipher);
     ctx = mock(ChannelHandlerContext.class, RETURNS_DEEP_STUBS);
     req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "foo");
   }
@@ -74,8 +78,8 @@ public class AuthenticationChannelHandlerTest {
   @Test(expected = UnauthenticatedException.class)
   public void testMalformedInvalidCredentialThrows() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN, CredentialType.EXTERNAL_BEARER.getQualifiedName());
+        .headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.EXTERNAL_BEARER.getQualifiedName());
 
     handler.channelRead(ctx, req);
   }
@@ -83,8 +87,8 @@ public class AuthenticationChannelHandlerTest {
   @Test(expected = UnauthenticatedException.class)
   public void testMalformedValidCredentialThrows() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName());
+        .headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName());
 
     handler.channelRead(ctx, req);
   }
@@ -92,9 +96,9 @@ public class AuthenticationChannelHandlerTest {
   @Test(expected = UnauthenticatedException.class)
   public void testWellFormedInvalidCredentialThrows() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN,
-           CredentialType.EXTERNAL_BEARER.getQualifiedName() + " token");
+        .headers()
+        .set(Headers.RUNTIME_TOKEN,
+            CredentialType.EXTERNAL_BEARER.getQualifiedName() + " token");
 
     handler.channelRead(ctx, req);
   }
@@ -102,8 +106,8 @@ public class AuthenticationChannelHandlerTest {
   @Test
   public void testWellFormedValidCredentialCallsFireChannelReader() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+        .headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
 
     handler.channelRead(ctx, req);
     verify(ctx, times(1)).fireChannelRead(any());
@@ -111,21 +115,21 @@ public class AuthenticationChannelHandlerTest {
 
 
   /**
-   * This simulates the order for NamespaceHttpHandler#create
-   * The flow :
-   *  ACH.channelRead.fireChannelRead
-   *   ->NamespaceHttpHandler#create (sets AuditLogQueue in SRC)
-   *     -> AuditLogSetterHook (Generate metadata and set in SRC's Auditlogrequest.Builder )
-   *       -> ACH#readChannel's Finally block (Sets the AuditLogQueue, Auditlogrequest.Builder in Attribute of channel)
-   *         -> AuthChannelHandler#write (creates the AuditLogRequest from SRC or ATTR and publishes)
+   * This simulates the order for NamespaceHttpHandler#create The flow :
+   * ACH.channelRead.fireChannelRead ->NamespaceHttpHandler#create (sets AuditLogQueue in SRC) ->
+   * AuditLogSetterHook (Generate metadata and set in SRC's Auditlogrequest.Builder ) ->
+   * ACH#readChannel's Finally block (Sets the AuditLogQueue, Auditlogrequest.Builder in Attribute
+   * of channel) -> AuthChannelHandler#write (creates the AuditLogRequest from SRC or ATTR and
+   * publishes)
    */
   @Test
   public void testCallOrderCreateNamespaceForAuditLog() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+        .headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
     AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
-    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock, mockAeadCipher);
+    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock,
+        mockAeadCipher);
 
     //The ACH.channelRead.fireChannelRead , will trigger NamespaceHttpHandler and AuditLogSetterHook
     // So set AuditLogQueue and MetaData in SRC to simulate that.
@@ -155,37 +159,36 @@ public class AuthenticationChannelHandlerTest {
     // Now in Write and getAuditLogRequest , should create AuditLogRequest properly from ATTRs
     Mockito.when(ctx.channel().attr(AttributeKey.valueOf(
         AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR)).get()).thenReturn(
-            getAuditLogContexts());
+        getAuditLogContexts());
     Mockito.when(ctx.channel().attr(AttributeKey.valueOf(
         AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get()).thenReturn("testuserIp");
     Mockito.when(ctx.channel().attr(AttributeKey.valueOf(
         AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR)).get()).thenReturn(
-            getAuditLogRequestBuilder());
+        getAuditLogRequestBuilder());
 
     handler.write(ctx, "msg", new DefaultChannelPromise(ctx.channel()));
     verify(auditLogWriterMock, times(1)).publish(any());
   }
 
   /**
-   * This simulates the order for ArtifactHttpHandler#addArtifact
-   * The flow :
-   *  ACH.channelRead.fireChannelRead
-   *   ->ArtifactHttpHandler#addArtifact (sets AuditLogQueue in SRC)
-   *     -> ACH#readChannel's Finally block (Sets ONLY the AuditLogQueue from SRC in ATTR)
-   *       [Here AuditLogBuilder in channel's attribute Should be Null.]
-   *       -> 1000+ calls happen via channelRead as upload happens in chunks [ Nothing to mock here ]
-   *        ->  AuditLogSetterHook (Generate metadata and set in SRC's Auditlogrequest.Builder )
-   *            [This COULD ON DIFFERENT THREAD, this is the last call after Upload is complete]
-   *          -> ACH#readChannel's Finally block (Sets ONLY the Auditlogrequest.Builder from SRC in ATTR)
-   *            -> AuthChannelHandler#write (creates the AuditLogRequest from SRC or ATTR and publishes)
+   * This simulates the order for ArtifactHttpHandler#addArtifact The flow :
+   * ACH.channelRead.fireChannelRead ->ArtifactHttpHandler#addArtifact (sets AuditLogQueue in SRC)
+   * -> ACH#readChannel's Finally block (Sets ONLY the AuditLogQueue from SRC in ATTR) [Here
+   * AuditLogBuilder in channel's attribute Should be Null.] -> 1000+ calls happen via channelRead
+   * as upload happens in chunks [ Nothing to mock here ] ->  AuditLogSetterHook (Generate metadata
+   * and set in SRC's Auditlogrequest.Builder ) [This COULD ON DIFFERENT THREAD, this is the last
+   * call after Upload is complete] -> ACH#readChannel's Finally block (Sets ONLY the
+   * Auditlogrequest.Builder from SRC in ATTR) -> AuthChannelHandler#write (creates the
+   * AuditLogRequest from SRC or ATTR and publishes)
    */
   @Test
   public void testCallOrderAddArtifactForAuditLog() throws Exception {
     req
-      .headers()
-      .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+        .headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
     AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
-    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock, mockAeadCipher);
+    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock,
+        mockAeadCipher);
 
     //The ACH.channelRead.fireChannelRead , will trigger artifactHttpHandler and NOT AuditLogSetterHook
     // So set AuditLogQueue in SRC to simulate that.
@@ -200,11 +203,13 @@ public class AuthenticationChannelHandlerTest {
     handler.channelRead(ctx, req);
 
     //ENUSRE THAT ATTR WAS SET in ACH's Finally Block.
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR)),
-           times(1)).set(any());
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR)),
+        times(1)).set(any());
     // ENSURE AuditLogRequest Builder is NOT SET
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR)),
-           times(0)).set(any());
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR)),
+        times(0)).set(any());
 
     //Now in a different Thread , when the UPLOAD is finally complete, it reaches AuditLogSetterHook and sets only
     // the Metadata / Builder
@@ -217,19 +222,24 @@ public class AuthenticationChannelHandlerTest {
     handler.channelRead(ctx, req);
 
     //ENUSRE THAT auditLogContextQueue was NOT SET i.e. ( total overall 1 call )
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR)),
-           times(1)).set(any());
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR)),
+        times(1)).set(any());
     // ENSURE AuditLogRequest Builder is SET
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR)),
-           times(1)).set(any());
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR)),
+        times(1)).set(any());
 
     // Now in Write and getAuditLogRequest , should create AuditLogRequest properly from ATTRs
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
-                   .get()).thenReturn(getAuditLogContexts());
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
-      .thenReturn("testuserIp");
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
-                   .get()).thenReturn(getAuditLogRequestBuilder());
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
+        .get()).thenReturn(getAuditLogContexts());
+    Mockito.when(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
+        .thenReturn("testuserIp");
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
+        .get()).thenReturn(getAuditLogRequestBuilder());
 
     handler.write(ctx, "msg", new DefaultChannelPromise(ctx.channel()));
     verify(auditLogWriterMock, times(1)).publish(any());
@@ -237,14 +247,18 @@ public class AuthenticationChannelHandlerTest {
 
   @Test
   public void testWriteWithAuditLogging() throws Exception {
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
-                   .get()).thenReturn(getAuditLogContexts());
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
-      .thenReturn("testuserIp");
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
-                   .get()).thenReturn(getAuditLogRequestBuilder());
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
+        .get()).thenReturn(getAuditLogContexts());
+    Mockito.when(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
+        .thenReturn("testuserIp");
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
+        .get()).thenReturn(getAuditLogRequestBuilder());
     AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
-    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock, mockAeadCipher);
+    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock,
+        mockAeadCipher);
     handler.write(ctx, "msg", new DefaultChannelPromise(ctx.channel()));
 
     verify(auditLogWriterMock, times(1)).publish(any());
@@ -252,14 +266,18 @@ public class AuthenticationChannelHandlerTest {
 
   @Test
   public void testCloseWithAuditLogging() throws Exception {
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
-                   .get()).thenReturn(getAuditLogContexts());
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
-      .thenReturn("testuserIp");
-    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
-                   .get()).thenReturn(getAuditLogRequestBuilder());
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_CONTEXT_QUEUE_ATTR))
+        .get()).thenReturn(getAuditLogContexts());
+    Mockito.when(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_USER_IP_ATTR)).get())
+        .thenReturn("testuserIp");
+    Mockito.when(ctx.channel()
+        .attr(AttributeKey.valueOf(AuthenticationChannelHandler.AUDIT_LOG_REQ_BUILDER_ATTR))
+        .get()).thenReturn(getAuditLogRequestBuilder());
     AuditLogWriter auditLogWriterMock = mock(AuditLogWriter.class);
-    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock, mockAeadCipher);
+    handler = new AuthenticationChannelHandler(true, true, false, auditLogWriterMock,
+        mockAeadCipher);
     handler.close(ctx, new DefaultChannelPromise(ctx.channel()));
 
     verify(auditLogWriterMock, times(1)).publish(any());
@@ -273,7 +291,9 @@ public class AuthenticationChannelHandlerTest {
 
     handler.channelRead(ctx, req);
 
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)), times(1))
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
         .set(credentialArgumentCaptor.capture());
     Credential actualCredential = credentialArgumentCaptor.getValue();
     Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
@@ -282,23 +302,112 @@ public class AuthenticationChannelHandlerTest {
   }
 
   @Test
-  public void testCredentialGetsDecrypted() throws Exception {
+  public void testCredentialGetsDecryptedTaskWorker() throws Exception {
     mockAeadCipher = Mockito.mock(LazyDelegateAeadCipher.class);
     handler = new AuthenticationChannelHandler(true, false, true, null, mockAeadCipher);
     req.headers()
         .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+    req.headers()
+        .set(HttpHeaderNames.WORKER_DECRYPTION_HDR, WorkerDecryptionScope.TASK_WORKER.name());
     ArgumentCaptor<Credential> credentialArgumentCaptor = ArgumentCaptor.forClass(Credential.class);
 
-    when(mockAeadCipher.decryptStringFromBase64("token", Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
         .thenReturn("decryptedToken");
 
     handler.channelRead(ctx, req);
 
-    verify(ctx.channel().attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)), times(1))
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
         .set(credentialArgumentCaptor.capture());
     Credential actualCredential = credentialArgumentCaptor.getValue();
     Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
     Assert.assertEquals("decryptedToken", actualCredential.getValue());
+    verify(ctx, times(1)).fireChannelRead(any());
+  }
+
+  @Test
+  public void testCredentialGetsDecryptedAnyWorker() throws Exception {
+    mockAeadCipher = Mockito.mock(LazyDelegateAeadCipher.class);
+    handler = new AuthenticationChannelHandler(true, false, true, null, mockAeadCipher);
+    req.headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+    req.headers()
+        .set(HttpHeaderNames.WORKER_DECRYPTION_HDR, WorkerDecryptionScope.ANY_WORKER.name());
+    ArgumentCaptor<Credential> credentialArgumentCaptor = ArgumentCaptor.forClass(Credential.class);
+
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+        .thenReturn("decryptedToken");
+
+    handler.channelRead(ctx, req);
+
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
+        .set(credentialArgumentCaptor.capture());
+    Credential actualCredential = credentialArgumentCaptor.getValue();
+    Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
+    Assert.assertEquals("decryptedToken", actualCredential.getValue());
+    verify(ctx, times(1)).fireChannelRead(any());
+  }
+
+  @Test
+  public void testCredentialGetsDecryptedPreviewRunner() throws Exception {
+    mockAeadCipher = Mockito.mock(LazyDelegateAeadCipher.class);
+    handler = new AuthenticationChannelHandler(true, false, true, null, mockAeadCipher);
+    req.headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+    req.headers()
+        .set(HttpHeaderNames.WORKER_DECRYPTION_HDR, WorkerDecryptionScope.PREVIEW_RUNNER.name());
+
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+        .thenThrow(new CipherException("Cannot decrypt by task worker AD"));
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.PREVIEW_RUNNER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+        .thenReturn("decryptedToken");
+    ArgumentCaptor<Credential> credentialArgumentCaptor = ArgumentCaptor.forClass(Credential.class);
+
+    handler.channelRead(ctx, req);
+
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
+        .set(credentialArgumentCaptor.capture());
+    Credential actualCredential = credentialArgumentCaptor.getValue();
+    Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
+    Assert.assertEquals("decryptedToken", actualCredential.getValue());
+    verify(ctx, times(1)).fireChannelRead(any());
+  }
+
+  @Test
+  public void testCredentialUnchangedNoEncryption() throws Exception {
+    mockAeadCipher = Mockito.mock(LazyDelegateAeadCipher.class);
+    handler = new AuthenticationChannelHandler(true, false, true, null, mockAeadCipher);
+    req.headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+    req.headers()
+        .set(HttpHeaderNames.WORKER_DECRYPTION_HDR, WorkerDecryptionScope.NONE.name());
+
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+        .thenThrow(new CipherException("Cannot decrypt by task worker AD"));
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.PREVIEW_RUNNER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+        .thenThrow(new CipherException("Cannot decrypt by preview runner AD"));
+    ArgumentCaptor<Credential> credentialArgumentCaptor = ArgumentCaptor.forClass(Credential.class);
+
+    handler.channelRead(ctx, req);
+
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
+        .set(credentialArgumentCaptor.capture());
+    Credential actualCredential = credentialArgumentCaptor.getValue();
+    Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
+    Assert.assertEquals("token", actualCredential.getValue());
     verify(ctx, times(1)).fireChannelRead(any());
   }
 
@@ -309,12 +418,32 @@ public class AuthenticationChannelHandlerTest {
     req.headers()
         .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
     req.headers()
-        .set(HttpHeaderNames.TASK_WORKER_DECRYPTION_HDR, "true");
+        .set(HttpHeaderNames.WORKER_DECRYPTION_HDR, WorkerDecryptionScope.NONE.name());
 
-    when(mockAeadCipher.decryptStringFromBase64("token", Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
+    when(mockAeadCipher.decryptStringFromBase64("token",
+        Encryption.TASK_WORKER_ENCRYPTION_ASSOCIATED_DATA.getBytes()))
         .thenReturn("decryptedToken");
 
     handler.channelRead(ctx, req);
+  }
+
+  @Test
+  public void testDifferentCipher() throws Exception {
+    mockAeadCipher = new FakeAeadCipher();
+    handler = new AuthenticationChannelHandler(true, false, true, null, mockAeadCipher);
+    req.headers()
+        .set(Headers.RUNTIME_TOKEN, CredentialType.INTERNAL.getQualifiedName() + " token");
+    ArgumentCaptor<Credential> credentialArgumentCaptor = ArgumentCaptor.forClass(Credential.class);
+
+    handler.channelRead(ctx, req);
+    verify(ctx.channel()
+            .attr(AttributeKey.valueOf(AuthenticationChannelHandler.CDAP_USER_CREDENTIAL_ATTR)),
+        times(1))
+        .set(credentialArgumentCaptor.capture());
+    Credential actualCredential = credentialArgumentCaptor.getValue();
+    Assert.assertEquals(Credential.CredentialType.INTERNAL, actualCredential.getType());
+    Assert.assertEquals("token", actualCredential.getValue());
+    verify(ctx, times(1)).fireChannelRead(any());
   }
 
   private ChannelHandlerContext setAuditLogsInFireChannelRead() {
@@ -326,20 +455,20 @@ public class AuthenticationChannelHandlerTest {
     Queue<AuditLogContext> auditLogContexts = new ArrayDeque<>();
     auditLogContexts.add(AuditLogContext.Builder.defaultNotRequired());
     auditLogContexts.add(new AuditLogContext.Builder()
-                           .setAuditLoggingRequired(true)
-                           .setAuditLogBody("Test Audit Logs")
-                           .build());
+        .setAuditLoggingRequired(true)
+        .setAuditLogBody("Test Audit Logs")
+        .build());
     return auditLogContexts;
   }
 
   private AuditLogRequest.Builder getAuditLogRequestBuilder() {
     return new AuditLogRequest.Builder()
-      .operationResponseCode(200)
-      .uri("v3/test")
-      .handler("Testhandler")
-      .method("create")
-      .methodType("POST")
-      .startTimeNanos(1000000L)
-      .endTimeNanos(1000002L);
+        .operationResponseCode(200)
+        .uri("v3/test")
+        .handler("Testhandler")
+        .method("create")
+        .methodType("POST")
+        .startTimeNanos(1000000L)
+        .endTimeNanos(1000002L);
   }
 }


### PR DESCRIPTION
Extending the security model already implemented for task workers in https://github.com/cdapio/cdap/pull/15948 to restrict preview runners from making unauthorized calls to internal APIs.

When a preview is initiated, the `PreviewManager` now encrypts the user's credentials within the `PreviewRequest` using a dedicated AEAD cipher. This encrypted credential acts as a tag, identifying any subsequent API calls as originating from a preview runner.

When an internal CDAP service receives a request, the `AuthenticationChannelHandler` attempts to decrypt the credential. A successful decryption confirms the request's origin is a preview runner. The service then validates the request's URI against a pre-approved exemption list. If the URI is not on this list, the request is denied, preventing unauthorized internal API calls.

### Testing

- non rbac instance 
<img width="5074" height="630" alt="image" src="https://github.com/user-attachments/assets/65138e08-916b-4fb1-84c1-de3ccacb38de" />

- rbac instance and plugin with UseConnection Enabled 
<img width="3830" height="496" alt="image" src="https://github.com/user-attachments/assets/fa68f944-747a-4b8f-9798-644ed8841688" />

- 6.10 upgraded rbac instance  
<img width="3010" height="418" alt="image" src="https://github.com/user-attachments/assets/f95cdb2c-4752-4960-898b-f783b8837110" />

