### PR TITLE
[CDAP-21211] Authenticate Preview Runner to Preview Manager communication done via CDAP Messaging Service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewDataPublisher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewDataPublisher.java
@@ -30,4 +30,16 @@ public interface PreviewDataPublisher {
    * @param previewMessage preview message
    */
   void publish(EntityId entityId, PreviewMessage previewMessage);
+
+  /**
+   * Sets the identifying information for the publisher of the preview data.
+   * This is typically called once to associate the publisher with a specific preview runner.
+   * The provided information should be a serialized {@code PreviewRequestPollerInfo} object,
+   * which contains the unique identity of the runner pod. This information is used by the
+   * receiving service to authenticate the origin of the messages.
+   *
+   * @param publisherInfo a byte array containing the serialized identifying information
+   *                      for the publisher (the preview runner).
+   */
+  void setPublisherInfo(byte[] publisherInfo);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewMessage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewMessage.java
@@ -23,14 +23,14 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 /**
- * A container for messages in the preview topic configured by {@link
- * Constants.Preview#MESSAGING_TOPIC}. It carries the message type and the payload as {@link
- * JsonElement}.
+ * A container for messages in the preview topic configured by
+ * {@link Constants.Preview#MESSAGING_TOPIC}. It carries the message type and the payload as
+ * {@link JsonElement}.
  */
 public final class PreviewMessage {
 
   /**
-   * The message type
+   * The message type.
    */
   public enum Type {
     DATA,
@@ -41,13 +41,14 @@ public final class PreviewMessage {
   private final Type type;
   private final EntityId entityId;
   private final JsonElement payload;
+  private byte[] publisherInfo;
 
   /**
    * Create an instance of message.
    *
-   * @param type type of the message
+   * @param type     type of the message
    * @param entityId program run id associated with the message
-   * @param payload the payload
+   * @param payload  the payload
    */
   public PreviewMessage(Type type, EntityId entityId, JsonElement payload) {
     this.type = type;
@@ -72,13 +73,34 @@ public final class PreviewMessage {
   /**
    * Returns the payload by decoding the json to the given type.
    *
-   * @param gson the {@link Gson} for decoding the json element
+   * @param gson    the {@link Gson} for decoding the json element
    * @param objType the resulting object type
-   * @param <T> the resulting object type
+   * @param <T>     the resulting object type
    * @return the decode object
    */
   public <T> T getPayload(Gson gson, java.lang.reflect.Type objType) {
     return gson.fromJson(payload, objType);
+  }
+
+  /**
+   * Returns the serialized information that identifies and authenticates the publisher. This is
+   * expected to be a serialized {@link PreviewRequestPollerInfo} object.
+   *
+   * @return the publisher information byte array, or {@code null} if not set.
+   */
+  public byte[] getPublisherInfo() {
+    return publisherInfo;
+  }
+
+  /**
+   * Sets the identifying information for the publisher of this message. This information is used by
+   * the receiving service to authenticate the message's origin.
+   *
+   * @param publisherInfo a byte array containing the serialized {@link PreviewRequestPollerInfo},
+   *                      which includes the runner's identity and secret token for authentication.
+   */
+  public void setPublisherInfo(byte[] publisherInfo) {
+    this.publisherInfo = publisherInfo;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequest.java
@@ -32,6 +32,7 @@ public class PreviewRequest {
   private final ProgramId program;
   private final AppRequest<?> appRequest;
   private final Principal principal;
+  private byte[] runnerInfo;
 
   public PreviewRequest(ProgramId program, AppRequest<?> appRequest,
       @Nullable Principal principal) {
@@ -56,6 +57,14 @@ public class PreviewRequest {
   @Nullable
   public Principal getPrincipal() {
     return principal;
+  }
+
+  public byte[] getRunnerInfo() {
+    return runnerInfo;
+  }
+
+  public void setRunnerInfo(byte[] runnerInfo) {
+    this.runnerInfo = runnerInfo;
   }
 
   private static ProgramId getProgramIdFromRequest(ApplicationId preview, AppRequest request) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.runtime.k8s.PreviewRequestPollerInfo;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
@@ -57,7 +58,7 @@ public class PreviewHttpHandlerInternal extends AbstractHttpHandler {
 
     if (previewRequest != null) {
       LOG.debug("Send preview request {} to poller {}", previewRequest.getProgram(),
-          Bytes.toString(pollerInfo));
+          GSON.fromJson(Bytes.toString(pollerInfo), PreviewRequestPollerInfo.class));
       responder.sendString(HttpResponseStatus.OK, GSON.toJson(previewRequest));
     } else {
       responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -350,6 +350,9 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
             bind(PreviewRequestQueue.class).toInstance(previewRequestQueue);
             expose(PreviewRequestQueue.class);
 
+            bind(PreviewRunStopper.class).toInstance(previewRunStopper);
+            expose(PreviewRunStopper.class);
+
             bind(Store.class).to(DefaultStore.class);
             bind(OwnerStore.class).to(DefaultOwnerStore.class);
             bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -158,7 +158,9 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   }
 
   @Override
-  public Future<PreviewRequest> startPreview(PreviewRequest previewRequest) throws Exception {
+  public Future<PreviewRequest> startPreview(PreviewRequest previewRequest)
+      throws Exception {
+    previewDataPublisher.setPublisherInfo(previewRequest.getRunnerInfo());
     ProgramId programId = previewRequest.getProgram();
     long submitTimeMillis = RunIds.getTime(programId.getApplication(), TimeUnit.MILLISECONDS);
     previewStarted(programId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/MessagingPreviewDataPublisher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/MessagingPreviewDataPublisher.java
@@ -28,9 +28,9 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.cdap.messaging.client.StoreRequestBuilder;
 import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.spi.StoreRequest;
-import io.cdap.cdap.messaging.client.StoreRequestBuilder;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
@@ -46,6 +46,7 @@ public class MessagingPreviewDataPublisher implements PreviewDataPublisher {
   private final TopicId topic;
   private final MessagingService messagingService;
   private final RetryStrategy retryStrategy;
+  private byte[] publisherInfo;
 
   @Inject
   MessagingPreviewDataPublisher(CConfiguration cConf,
@@ -57,6 +58,11 @@ public class MessagingPreviewDataPublisher implements PreviewDataPublisher {
 
   @Override
   public void publish(EntityId entityId, PreviewMessage previewMessage) {
+    if (publisherInfo != null) {
+      // The publisherInfo is null in case of non-distributed environments, because there is no separate
+      // runner container. The preview runner is a thread in the same process.
+      previewMessage.setPublisherInfo(publisherInfo);
+    }
     StoreRequest request = StoreRequestBuilder.of(topic).addPayload(GSON.toJson(previewMessage))
         .build();
     try {
@@ -67,5 +73,9 @@ public class MessagingPreviewDataPublisher implements PreviewDataPublisher {
           "Failed to publish preview message " + previewMessage + " for application " + entityId,
           e);
     }
+  }
+
+  public void setPublisherInfo(byte[] publisherInfo) {
+    this.publisherInfo = publisherInfo;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewDataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewDataSubscriberService.java
@@ -35,9 +35,10 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
-import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
+import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
@@ -45,6 +46,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -68,6 +70,7 @@ public class PreviewDataSubscriberService extends
   private final MultiThreadMessagingContext messagingContext;
   private final TransactionRunner transactionRunner;
   private final int maxRetriesOnError;
+  private final PreviewRunStopper previewRunStopper;
   private int errorCount;
   private String erroredMessageId;
   private MetricsCollectionService metricsCollectionService;
@@ -81,7 +84,8 @@ public class PreviewDataSubscriberService extends
       @Named(PreviewConfigModule.GLOBAL_METRICS) MetricsCollectionService
           metricsCollectionService,
       PreviewStore previewStore,
-      TransactionRunner transactionRunner) {
+      TransactionRunner transactionRunner,
+      PreviewRunStopper previewRunStopper) {
     super(
         NamespaceId.SYSTEM.topic(cConf.get(Constants.Preview.MESSAGING_TOPIC)),
         cConf.getInt(Constants.Metadata.MESSAGING_FETCH_SIZE),
@@ -101,6 +105,7 @@ public class PreviewDataSubscriberService extends
     this.transactionRunner = transactionRunner;
     this.maxRetriesOnError = cConf.getInt(Constants.Metadata.MESSAGING_RETRIES_ON_CONFLICT);
     this.metricsCollectionService = metricsCollectionService;
+    this.previewRunStopper = previewRunStopper;
   }
 
   @Override
@@ -131,6 +136,9 @@ public class PreviewDataSubscriberService extends
       ImmutablePair<String, PreviewMessage> next = messages.next();
       String messageId = next.getFirst();
       PreviewMessage message = next.getSecond();
+      if (!validateMessage(message)) {
+        continue;
+      }
 
       PreviewMessageProcessor processor = processors.computeIfAbsent(message.getType(), type -> {
         switch (type) {
@@ -201,13 +209,6 @@ public class PreviewDataSubscriberService extends
 
     @Override
     public void processMessage(PreviewMessage message) {
-      if (!(message.getEntityId() instanceof ApplicationId)) {
-        LOG.warn(
-            "Missing application id from the preview data information. Ignoring the message {}",
-            message);
-        return;
-      }
-
       ApplicationId applicationId = (ApplicationId) message.getEntityId();
       PreviewDataPayload payload;
       try {
@@ -230,13 +231,6 @@ public class PreviewDataSubscriberService extends
 
     @Override
     public void processMessage(PreviewMessage message) {
-      if (!(message.getEntityId() instanceof ApplicationId)) {
-        LOG.warn(
-            "Missing application id from the preview status information. Ignoring the message {}",
-            message);
-        return;
-      }
-
       ApplicationId applicationId = (ApplicationId) message.getEntityId();
       PreviewStatus payload;
       try {
@@ -268,12 +262,6 @@ public class PreviewDataSubscriberService extends
 
     @Override
     public void processMessage(PreviewMessage message) {
-      if (!(message.getEntityId() instanceof ApplicationId)) {
-        LOG.warn("Missing application id from the preview run information. Ignoring the message {}",
-            message);
-        return;
-      }
-
       ProgramRunId payload;
       try {
         payload = message.getPayload(GSON, ProgramRunId.class);
@@ -284,6 +272,78 @@ public class PreviewDataSubscriberService extends
         return;
       }
       previewStore.setProgramId(payload);
+    }
+  }
+
+  /**
+   * Validates an incoming {@link PreviewMessage} to enforce security policies. This method performs
+   * the following checks:
+   * <ul>
+   *   <li>Ensures the message is associated with a valid {@link ApplicationId}.</li>
+   *   <li>Allows messages that do not contain publisher information to pass (for non-authenticated flows).</li>
+   *   <li>If publisher information is present, it validates that the message's {@code ApplicationId}
+   *       matches the one registered for that publisher in the {@link PreviewStore}.</li>
+   * </ul>
+   * If a mismatch is found, it is treated as a violation, and an attempt is made to
+   * terminate the offending runner.
+   *
+   * @param message the message to be validated.
+   * @return {@code true} if the message is valid, {@code false} otherwise.
+   */
+  private boolean validateMessage(PreviewMessage message) {
+    if (!(message.getEntityId() instanceof ApplicationId)) {
+      LOG.warn("Missing application id from the preview run information. Ignoring message: {}",
+          message);
+      return false;
+    }
+
+    byte[] messageRunnerInfo = message.getPublisherInfo();
+    // If there's no publisher info, the message is considered valid but unauthenticated.
+    // This allows for backward compatibility or simpler, non-secure, non-distributed environments.
+    if (messageRunnerInfo == null) {
+      return true;
+    }
+
+    ApplicationId appIdFromMessage = (ApplicationId) message.getEntityId();
+    byte[] registeredRunnerInfo = previewStore.getPreviewRequestPollerInfo(appIdFromMessage);
+
+    // Happy Path: If no runner is registered for this app yet, or if the messageRunnerInfo from the message
+    // matches the registered messageRunnerInfo, the message is valid.
+    if (Arrays.equals(registeredRunnerInfo, messageRunnerInfo)) {
+      return true;
+    }
+
+    // Failure Path: The publisher information does not match.
+    LOG.warn(
+        "Authentication failure: A message for application '{}' was received with a non-registered "
+            + "runner. Terminating the runner.", appIdFromMessage);
+    terminateRunner(messageRunnerInfo);
+
+    return false;
+  }
+
+  /**
+   * This method finds the application the suspicious runner was registered to, marks its status as
+   * KILLED, and then stops the runner's container.
+   */
+  private void terminateRunner(byte[] runnerInfo) {
+    try {
+      ApplicationId appId = previewStore.getApplicationId(runnerInfo);
+      if (appId != null) {
+        PreviewStatus status = previewStore.getPreviewStatus(appId);
+        if (status != null && !status.getStatus().isEndState()) {
+          previewStore.setPreviewStatus(appId,
+              new PreviewStatus(PreviewStatus.Status.KILLED,
+                  status.getSubmitTime(), new BasicThrowable(new IllegalStateException(
+                  "Preview run stopped due to an authentication failure."
+                      + "Please try running preview again.")), null, null));
+        }
+      }
+      previewRunStopper.stop(runnerInfo);
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to stop runner after an authentication failure. The invalid message was still rejected.",
+          e);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -77,6 +77,7 @@ import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.data.StorageProvider;
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -169,12 +170,13 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     hConf.clear();
     hConf.addResource(new File(getArgument("hConf")).toURI().toURL());
 
+    byte[] secureToken = generateSecureToken();
     PreviewRequestPollerInfo pollerInfo;
     if (context instanceof ExtendedTwillContext) {
       pollerInfo = new PreviewRequestPollerInfo(context.getInstanceId(),
-          ((ExtendedTwillContext) context).getUID());
+          ((ExtendedTwillContext) context).getUID(), secureToken);
     } else {
-      pollerInfo = new PreviewRequestPollerInfo(context.getInstanceId(), null);
+      pollerInfo = new PreviewRequestPollerInfo(context.getInstanceId(), null, secureToken);
     }
 
     CConfiguration cConf = CConfiguration.create(new File(getArgument("cConf")).toURI().toURL());
@@ -275,5 +277,15 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     });
 
     return Guice.createInjector(modules);
+  }
+
+  /**
+   * Generates a cryptographically strong random byte array to be used as a secret token.
+   */
+  private byte[] generateSecureToken() {
+    SecureRandom random = new SecureRandom();
+    byte[] token = new byte[32]; // 256 bits
+    random.nextBytes(token);
+    return token;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
@@ -55,19 +55,24 @@ public class RemotePreviewRequestFetcher implements PreviewRequestFetcher {
 
   @Override
   public Optional<PreviewRequest> fetch() throws IOException, UnauthorizedException {
+    byte[] runnerInfo = pollerInfoProvider.get();
     HttpRequest request = remoteClientInternal.requestBuilder(HttpMethod.POST, "requests/pull")
-        .withBody(ByteBuffer.wrap(pollerInfoProvider.get()))
+        .withBody(ByteBuffer.wrap(runnerInfo))
         .build();
 
     HttpResponse httpResponse = remoteClientInternal.execute(request);
     if (httpResponse.getResponseCode() == 200) {
       PreviewRequest previewRequest = GSON.fromJson(httpResponse.getResponseBodyAsString(),
           PreviewRequest.class);
-      if (previewRequest != null && previewRequest.getPrincipal() != null) {
-        SecurityRequestContext.setUserId(previewRequest.getPrincipal().getName());
-        SecurityRequestContext.setUserCredential(previewRequest.getPrincipal().getFullCredential());
-      }
-      return Optional.ofNullable(previewRequest);
+      return Optional.ofNullable(previewRequest)
+          .map(req -> {
+            if (req.getPrincipal() != null) {
+              SecurityRequestContext.setUserId(req.getPrincipal().getName());
+              SecurityRequestContext.setUserCredential(req.getPrincipal().getFullCredential());
+            }
+            req.setRunnerInfo(runnerInfo);
+            return req;
+          });
     }
     throw new IOException(
         String.format("Received status code:%s and body: %s", httpResponse.getResponseCode(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
@@ -16,19 +16,32 @@
 
 package io.cdap.cdap.internal.app.runtime.k8s;
 
+import com.google.common.base.Objects;
+import java.util.Arrays;
 import javax.annotation.Nullable;
 
 /**
- * Poller information holder.
+ * A holder for information that uniquely identifies and authenticates a preview runner. This object
+ * is serialized and stored in the PreviewStore.
  */
 public class PreviewRequestPollerInfo {
 
   private final int instanceId;
   private final String instanceUid;
+  private final byte[] secureToken;
 
-  public PreviewRequestPollerInfo(int instanceId, @Nullable String instanceUid) {
+  /**
+   * Constructs a new PreviewRequestPollerInfo.
+   *
+   * @param instanceId  the instance id of the runner
+   * @param instanceUid the unique UID of the runner pod
+   * @param secureToken a secret token used to authenticate requests from the runner
+   */
+  public PreviewRequestPollerInfo(int instanceId, @Nullable String instanceUid,
+      @Nullable byte[] secureToken) {
     this.instanceId = instanceId;
     this.instanceUid = instanceUid;
+    this.secureToken = secureToken;
   }
 
   public int getInstanceId() {
@@ -42,9 +55,25 @@ public class PreviewRequestPollerInfo {
 
   @Override
   public String toString() {
-    return "PreviewRequestPollerInfo{"
-        + "instanceId=" + instanceId
-        + ", instanceUid='" + instanceUid + '\''
-        + '}';
+    return "PreviewRequestPollerInfo{" + "instanceId=" + instanceId + ", instanceUid='"
+        + instanceUid + '\'' + '}';
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(instanceId, instanceUid, Arrays.hashCode(secureToken));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PreviewRequestPollerInfo that = (PreviewRequestPollerInfo) o;
+    return instanceId == that.instanceId && Objects.equal(instanceUid, that.instanceUid)
+        && Arrays.equals(secureToken, that.secureToken);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.cdap.cdap.internal.app.store.preview;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -90,6 +91,8 @@ public class DefaultPreviewStore implements PreviewStore {
   private static final byte[] PRINCIPAL = Bytes.toBytes("p");
   private static final Gson ENTITY_GSON = new GsonBuilder().registerTypeAdapter(EntityId.class,
       new EntityIdTypeAdapter()).create();
+  private static final Gson SCHEMA_GSON = new GsonBuilder().registerTypeAdapter(Schema.class,
+      new SchemaTypeAdapter()).create();
 
   private final AtomicLong counter = new AtomicLong(0L);
 
@@ -133,9 +136,6 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public Map<String, List<JsonElement>> get(ApplicationId applicationId, String tracerName) {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
-        .create();
     byte[] startRowKey = getPreviewRowKeyBuilder(DATA_ROW_KEY_PREFIX, applicationId)
         .add(tracerName).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
@@ -146,7 +146,7 @@ public class DefaultPreviewStore implements PreviewStore {
       while ((indexRow = scanner.next()) != null) {
         Map<byte[], byte[]> columns = indexRow.getColumns();
         String propertyName = Bytes.toString(columns.get(PROPERTY));
-        JsonElement value = gson.fromJson(Bytes.toString(columns.get(VALUE)), JsonElement.class);
+        JsonElement value = SCHEMA_GSON.fromJson(Bytes.toString(columns.get(VALUE)), JsonElement.class);
         List<JsonElement> values = result.computeIfAbsent(propertyName, k -> new ArrayList<>());
         values.add(value);
       }
@@ -265,9 +265,6 @@ public class DefaultPreviewStore implements PreviewStore {
   @Override
   public void add(ApplicationId applicationId, AppRequest appRequest,
       @Nullable Principal principal) {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
-        .create();
     long timeInSeconds = RunIds.getTime(applicationId.getApplication(), TimeUnit.SECONDS);
     MDSKey mdsKey = new MDSKey.Builder()
         .add(WAITING)
@@ -278,11 +275,11 @@ public class DefaultPreviewStore implements PreviewStore {
 
     try {
       previewQueueTable.putDefaultVersion(mdsKey.getKey(), APPID,
-          Bytes.toBytes(gson.toJson(applicationId)));
+          Bytes.toBytes(SCHEMA_GSON.toJson(applicationId)));
       previewQueueTable.putDefaultVersion(mdsKey.getKey(), CONFIG,
-          Bytes.toBytes(gson.toJson(appRequest)));
+          Bytes.toBytes(SCHEMA_GSON.toJson(appRequest)));
       previewQueueTable.putDefaultVersion(mdsKey.getKey(), PRINCIPAL,
-          Bytes.toBytes(gson.toJson(principal)));
+          Bytes.toBytes(SCHEMA_GSON.toJson(principal)));
       long submitTimeInMillis = RunIds.getTime(applicationId.getApplication(),
           TimeUnit.MILLISECONDS);
       setPreviewStatus(applicationId,
@@ -319,9 +316,6 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public List<PreviewRequest> getAllInWaitingState() {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
-        .create();
     byte[] startRowKey = new MDSKey.Builder().add(WAITING).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
@@ -330,10 +324,10 @@ public class DefaultPreviewStore implements PreviewStore {
       Row indexRow;
       while ((indexRow = scanner.next()) != null) {
         Map<byte[], byte[]> columns = indexRow.getColumns();
-        AppRequest request = gson.fromJson(Bytes.toString(columns.get(CONFIG)), AppRequest.class);
-        ApplicationId applicationId = gson.fromJson(Bytes.toString(columns.get(APPID)),
+        AppRequest request = SCHEMA_GSON.fromJson(Bytes.toString(columns.get(CONFIG)), AppRequest.class);
+        ApplicationId applicationId = SCHEMA_GSON.fromJson(Bytes.toString(columns.get(APPID)),
             ApplicationId.class);
-        Principal principal = gson.fromJson(Bytes.toString(columns.get(PRINCIPAL)),
+        Principal principal = SCHEMA_GSON.fromJson(Bytes.toString(columns.get(PRINCIPAL)),
             Principal.class);
         result.add(new PreviewRequest(applicationId, request, principal));
       }
@@ -367,9 +361,6 @@ public class DefaultPreviewStore implements PreviewStore {
   }
 
   private void setPollerinfo(ApplicationId applicationId, byte[] pollerInfo) {
-    // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
-    Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
-        .create();
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     try {
@@ -377,7 +368,7 @@ public class DefaultPreviewStore implements PreviewStore {
     } catch (IOException e) {
       String msg = String.format(
           "Error while setting the poller information %s for waiting preview application %s.",
-          gson.toJson(pollerInfo), applicationId);
+          SCHEMA_GSON.toJson(pollerInfo), applicationId);
       throw new RuntimeException(msg, e);
     }
 
@@ -386,7 +377,7 @@ public class DefaultPreviewStore implements PreviewStore {
         .build();
     try {
       previewTable.putDefaultVersion(indexKey.getKey(), APPID,
-          Bytes.toBytes(gson.toJson(applicationId)));
+          Bytes.toBytes(SCHEMA_GSON.toJson(applicationId)));
     } catch (IOException e) {
       throw new RuntimeException("Error while creating poller info index.", e);
     }
@@ -403,11 +394,7 @@ public class DefaultPreviewStore implements PreviewStore {
       throw new RuntimeException(
           String.format("Failed to get the poller info for preview %s", applicationId), e);
     }
-    if (pollerInfo != null) {
-      return pollerInfo;
-    }
-
-    return null;
+    return pollerInfo;
   }
 
   public ApplicationId getApplicationId(byte[] pollerInfo) {
@@ -418,7 +405,7 @@ public class DefaultPreviewStore implements PreviewStore {
       if (applicationIdBytes == null) {
         return null;
       }
-      return ENTITY_GSON.fromJson(Bytes.toString(applicationIdBytes), ApplicationId.class);
+      return SCHEMA_GSON.fromJson(Bytes.toString(applicationIdBytes), ApplicationId.class);
     } catch (IOException e) {
       throw new RuntimeException("Error while getting application id for poller info.", e);
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnableTest.java
@@ -36,7 +36,7 @@ public class PreviewRunnerTwillRunnableTest {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
     Injector injector = PreviewRunnerTwillRunnable.createInjector(cConf, new Configuration(),
-                                                                  new PreviewRequestPollerInfo(0, "testuid"));
+                                                                  new PreviewRequestPollerInfo(0, "testuid", null));
     DefaultPreviewRunnerManager defaultPreviewRunnerManager = (DefaultPreviewRunnerManager) injector
       .getInstance(PreviewRunnerManager.class);
     Injector previewInjector = defaultPreviewRunnerManager.createPreviewInjector();
@@ -48,7 +48,7 @@ public class PreviewRunnerTwillRunnableTest {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_SQL);
     Injector injector = PreviewRunnerTwillRunnable.createInjector(cConf, new Configuration(),
-                                                                  new PreviewRequestPollerInfo(0, "testuid"));
+                                                                  new PreviewRequestPollerInfo(0, "testuid", null));
     DefaultPreviewRunnerManager defaultPreviewRunnerManager = (DefaultPreviewRunnerManager) injector
       .getInstance(PreviewRunnerManager.class);
     Injector previewInjector = defaultPreviewRunnerManager.createPreviewInjector();


### PR DESCRIPTION
This change authenticates messages sent from a PreviewRunner to the PreviewManager to ensure a runner can only update its own assigned preview run.

### Key Changes:
- **Enhanced PreviewRequestPollerInfo:** A secretToken field has been added to act as a session password. This is generated in PreviewRunnerTwillRunnable at the start of the runner's lifecycle
- **Authenticated Messages:** The serialized PreviewRequestPollerInfo (as publisherInfo) is now attached to every PreviewMessage sent from the runner.
- **Strict Validation:** The PreviewDataSubscriberService now validates the publisherInfo in every message against the record in the PreviewStore. A mismatch results in message rejection and termination of the offending runner

### Guice Dependency Issue:
To accommodate differences between distributed and non-distributed modes, the following design was used to propagate the pollerInfo.

**The Challenge:** The pollerInfo (with the secretToken) is generated only in the distributed environment within [PreviewRunnerTwillRunnable](https://github.com/cdapio/cdap/blob/e9e8a245ac61d06acace5bbe350d0370902ed32b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java#L257). However, it's needed by generic components like [PreviewMessage](https://github.com/cdapio/cdap/blob/develop/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewMessage.java)(which stores the runner info now) to create the [DefaultPreviewRunner](https://github.com/cdapio/cdap/blob/develop/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java#L213) and [DefaultDataTracer](https://github.com/cdapio/cdap/blob/develop/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultDataTracerFactory.java#L28) which are created without direct knowledge of the distributed-only class. 

**The Solution:** To decouple the components, the publisherInfo is not injected at construction. Instead, it's set explicitly at runtime (e.g., during the startPreview call), allowing the generic components to support both modes while enabling the new authentication mechanism in the distributed environment.

### Testing:
- [x] Quickstart pipeline run
- [x] One runner tries to update preview run associated to different runner
<img width="3446" height="402" alt="image" src="https://github.com/user-attachments/assets/d0f4be15-a4df-4f64-a60d-e7ff9292feb2" />

- [x] Secret token is different for the same runner
<img width="2628" height="314" alt="image" src="https://github.com/user-attachments/assets/89c6ae61-bfa5-41d9-aa52-8f03f0bf348d" />

- [x] Unit tests validating cdap sandbox preview run

