### PR TITLE
GitHub Actions should not be vulnerable to script injections

### DIFF
--- a/.github/workflows/build-sonar.yml
+++ b/.github/workflows/build-sonar.yml
@@ -84,6 +84,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: >-
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -fae -T 2 -B -V
@@ -93,7 +94,7 @@ jobs:
           -Dmaven.wagon.http.retryHandler.count=3
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
           -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
-          -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }}
+          -Dsonar.pullrequest.branch="$PR_HEAD_REF"
           -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}
 
       - name: Sonar report

--- a/.github/workflows/report-build-result.yml
+++ b/.github/workflows/report-build-result.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
       - name: Write result to BigQuery
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          echo '{ "repository": "${{ github.repository }}", "build_name": "${{ github.event.workflow.name }}", "branch": "${{ github.event.workflow_run.head_branch }}", "conclusion": "${{ github.event.workflow_run.conclusion }}", "started_at": "${{ github.event.workflow_run.created_at }}", "ended_at": "${{ github.event.workflow_run.updated_at }}", "url": "${{ github.event.workflow_run.html_url }}", "run_id": "${{ github.event.workflow_run.id }}", "run_attempt": "${{ github.event.workflow_run.run_attempt }}" }' | bq insert ${{ vars.BUILD_HISTORY_TABLE }}
+          echo "{ \"repository\": \"${{ github.repository }}\", \"build_name\": \"${{ github.event.workflow.name }}\", \"branch\": \"$HEAD_BRANCH\", \"conclusion\": \"${{ github.event.workflow_run.conclusion }}\", \"started_at\": \"${{ github.event.workflow_run.created_at }}\", \"ended_at\": \"${{ github.event.workflow_run.updated_at }}\", \"url\": \"${{ github.event.workflow_run.html_url }}\", \"run_id\": \"${{ github.event.workflow_run.id }}\", \"run_attempt\": \"${{ github.event.workflow_run.run_attempt }}\" }\" | bq insert ${{ vars.BUILD_HISTORY_TABLE }}
 


### PR DESCRIPTION
How does this change work?
The key difference lies in when and how the untrusted data is processed:

- Direct interpolation: When using ${{ github.event.workflow_run.head_branch }} directly in a shell command, GitHub Actions first substitutes the expression with the actual PR branch name, then passes the resulting string to the shell. If the title contains shell metacharacters, they become part of the command syntax and get executed.

- Environment variable approach: When the untrusted data is assigned to an environment variable, the shell receives it as a pre-existing variable value. The shell treats environment variable contents as literal data, not as executable code, regardless of what characters they contain.

This separation ensures that malicious shell syntax in the untrusted data cannot be interpreted as commands, effectively neutralizing injection attempts.