### PR TITLE
[CDAP-21213] Fix Stuck Task Worker : Refactor: Improve worker reliability with support for Liveness Probe and jvm exit logic

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -30,11 +30,15 @@ import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
 import io.cdap.cdap.common.internal.remote.TaskWorkerHttpHandlerInternal;
 import io.cdap.cdap.common.security.HttpsEnabler;
+import io.cdap.cdap.gateway.handlers.PingHandler;
 import io.cdap.http.ChannelPipelineModifier;
+import io.cdap.http.HttpHandler;
 import io.cdap.http.NettyHttpService;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.DiscoveryService;
@@ -70,6 +74,12 @@ public class TaskWorkerService extends AbstractIdleService {
       cConf.set(TaskWorker.WORK_DIR, workDir);
     }
 
+    List<HttpHandler> handlers = Arrays.asList(
+        new PingHandler(),
+        new TaskWorkerHttpHandlerInternal(cConf, discoveryService,
+            discoveryServiceClient, this::stopService,
+            metricsCollectionService));
+
     NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
             Constants.Service.TASK_WORKER, false)
         .setHost(cConf.get(Constants.TaskWorker.ADDRESS))
@@ -83,9 +93,7 @@ public class TaskWorkerService extends AbstractIdleService {
             pipeline.addAfter("compressor", "decompressor", new HttpContentDecompressor());
           }
         })
-        .setHttpHandlers(new TaskWorkerHttpHandlerInternal(cConf, discoveryService,
-            discoveryServiceClient, this::stopService,
-            metricsCollectionService));
+        .setHttpHandlers(handlers);
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -269,6 +269,14 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             }
           }
 
+          if (cConf.getBoolean(TaskWorker.TASK_WORKER_PROBE_ENABLED)) {
+            if (twillPreparer instanceof ExtendedTwillPreparer) {
+              twillPreparer = ((ExtendedTwillPreparer) twillPreparer)
+                  .addProbes(TaskWorkerTwillRunnable.class.getSimpleName(),
+                      cConf.getPropsWithPrefix(TaskWorker.TASK_WORKER_PROBE_PREFIX));
+            }
+          }
+
           // Set JVM options for task worker and artifact localizer
           twillPreparer.setJVMOptions(TaskWorkerTwillRunnable.class.getSimpleName(),
               cConf.get(Constants.TaskWorker.CONTAINER_JVM_OPTS));

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -75,6 +75,8 @@ public class TaskWorkerServiceTest {
   private TaskWorkerService taskWorkerService;
   private CompletableFuture<Service.State> serviceCompletionFuture;
 
+  private SecurityManager securityManager;
+
   private CConfiguration createCConf() {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.TaskWorker.ADDRESS, "localhost");
@@ -91,7 +93,7 @@ public class TaskWorkerServiceTest {
   }
 
   @Before
-  public void beforeTest() {
+  public void beforeTest() throws Exception {
     CConfiguration cConf = createCConf();
     SConfiguration sConf = createSConf();
 
@@ -105,6 +107,8 @@ public class TaskWorkerServiceTest {
     // start the service
     taskWorkerService.startAndWait();
     this.taskWorkerService = taskWorkerService;
+    securityManager = System.getSecurityManager();
+    System.setSecurityManager(new NoExitSecurityManager());
   }
 
   @After
@@ -113,6 +117,7 @@ public class TaskWorkerServiceTest {
       taskWorkerService.stopAndWait();
       taskWorkerService = null;
     }
+    System.setSecurityManager(securityManager);
   }
 
   @Test
@@ -497,6 +502,19 @@ public class TaskWorkerServiceTest {
         Thread.sleep(Integer.parseInt(context.getParam()));
       }
       context.writeResult(context.getParam().getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  public class NoExitSecurityManager extends SecurityManager {
+
+    @Override
+    public void checkExit(int status) {
+      throw new SecurityException("System.exit attempted, status=" + status);
+    }
+
+    @Override
+    public void checkPermission(java.security.Permission perm) {
+      // allow everything else
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -554,8 +554,14 @@ public final class Constants {
     public static final String METADATA_SERVICE_END_POINT = "task.worker.metadata.service.endpoint";
     public static final String METRIC_PREFIX = "task.worker.";
     public static final String GCE_METADATA_HOST_ENV_VAR = "GCE_METADATA_HOST";
-  }
 
+    /**
+     * Task worker container probe configurations.
+     * For usage for k8s probes refer : `io.cdap.cdap.k8s.util.ProbeFactory`
+     */
+    public static final String TASK_WORKER_PROBE_ENABLED = "task.worker.probe.enabled";
+    public static final String TASK_WORKER_PROBE_PREFIX = "task.worker.probe.";
+  }
 
   /**
    * System pods.

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -183,9 +183,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
           "Task worker service is about to restart in {} seconds, no new tasks will be accepted.",
           finalTaskDeadlineSeconds);
       if (runningRequestCount.get() == 0) {
-        stopper.accept("");
-        executorService.shutdown();
-        return;
+        stopAndShutdown(executorService, stopper);
       }
       try {
         Thread.sleep(TimeUnit.SECONDS.toMillis(finalTaskDeadlineSeconds));
@@ -194,9 +192,14 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
             "Interrupted while waiting for task completion. Stopping immediately",
             e);
       }
-      stopper.accept("");
-      executorService.shutdown();
+      stopAndShutdown(executorService, stopper);
     }, waitTime, finalTaskDeadlineSeconds, TimeUnit.SECONDS);
+  }
+
+  private void stopAndShutdown(ScheduledExecutorService executorService, Consumer<String> stopper) {
+    stopper.accept("");
+    executorService.shutdown();
+    System.exit(0);
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5610,6 +5610,95 @@
     </description>
   </property>
 
+  <property>
+    <name>task.worker.probe.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to configure a probe for the task worker.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.names</name>
+    <value>liveness</value>
+    <description>
+      A Comma separated value of kubernetes probe names. Ex : "liveness","readiness"
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.type</name>
+    <value>httpget</value>
+    <description>
+      Which type of liveness probe to be used.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.http.port</name>
+    <value>${task.worker.bind.port}</value>
+    <description>
+      The port number on the container where the API server is listening.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.http.path</name>
+    <value>/ping</value>
+    <description>
+      The specific URL path to access on the container.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.init.delay.seconds</name>
+    <value>20</value>
+    <description>
+      Seconds to wait after container start before the first probe for a task worker.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.timeout.seconds</name>
+    <value>5</value>
+    <description>
+      Seconds after which the probe is considered failed due to no response.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.failure.threshold</name>
+    <value>12</value>
+    <description>
+      Number of consecutive failures before k8s restarts the task worker container.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.period.seconds</name>
+    <value>10</value>
+    <description>
+      The time interval (in seconds) between consecutive probe executions.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.success.threshold</name>
+    <value>1</value>
+    <description>
+      Minimum consecutive successes for the probe to be considered successful after having failed.
+      Keeping same as K8s default.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.probe.k8s.liveness.http.scheme</name>
+    <value>HTTPS</value>
+    <description>
+      The protocol used to connect to the host.
+    </description>
+  </property>
+
   <!-- System pods Configuration  -->
   <property>
     <name>system.worker.program.twill.controller.start.seconds</name>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -22,6 +22,8 @@ import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.k8s.util.ProbeFactory;
+import io.cdap.cdap.k8s.util.ProbeFactory.ProbeName;
 import io.cdap.cdap.k8s.util.WorkloadIdentityUtil;
 import io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment;
 import io.cdap.cdap.master.environment.k8s.PodInfo;
@@ -65,6 +67,7 @@ import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimBuilder;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodSpecBuilder;
+import io.kubernetes.client.openapi.models.V1Probe;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import io.kubernetes.client.openapi.models.V1ResourceRequirementsBuilder;
 import io.kubernetes.client.openapi.models.V1SecurityContext;
@@ -195,6 +198,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private final Map<String, Set<String>> readonlyDisks;
   private final Map<String, Map<String, String>> runnableConfigs;
   private final Map<String, StringBuilder> runnableJvmOptions;
+  private final Map<String, Map<ProbeName, V1Probe>> containerProbes;
   private final String cdapInstallNamespace;
   private final boolean workloadIdentityEnabled;
   private final long workloadIdentityKsaTtl;
@@ -272,6 +276,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     this.cdapRuntimeNamespace = null;
     this.globalJvmOptions = new StringBuilder();
     this.workDirVolumeSource = new V1EmptyDirVolumeSource();
+    this.containerProbes = new HashMap<>();
   }
 
   @Override
@@ -284,6 +289,19 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   public ExtendedTwillPreparer setShouldLocalizeConfigurationAsConfigmap(
       boolean shouldLocalizeConfigurationAsConfigmap) {
     this.shouldLocalizeConfigurationAsConfigmap = shouldLocalizeConfigurationAsConfigmap;
+    return this;
+  }
+
+  @Override
+  public ExtendedTwillPreparer addProbes(String runnableName, Map<String, String> probeConf) {
+    containerProbes.putIfAbsent(runnableName, new HashMap<>());
+    Map<String, String> k8sProbeConf = filterAndRemoveKeyPrefix(probeConf, ProbeFactory.PROBE_ENV);
+    Arrays.stream(k8sProbeConf.get(ProbeFactory.PROBE_NAME_CSV).split(","))
+        .map(String::trim)
+        .forEach(probeName -> containerProbes.get(runnableName).put(
+            ProbeName.valueOf(probeName.toUpperCase()),
+            ProbeFactory.createV1Probe(
+                filterAndRemoveKeyPrefix(k8sProbeConf, String.format("%s.", probeName)))));
     return this;
   }
 
@@ -1398,6 +1416,25 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       }
     }
 
+    if (containerProbes.containsKey(name)){
+      containerProbes.get(name).forEach((probeName, probeObj) -> {
+        switch (probeName) {
+          case LIVENESS:
+            builder.withLivenessProbe(probeObj);
+            break;
+          case READINESS:
+            builder.withReadinessProbe(probeObj);
+            break;
+          case STARTUP:
+            builder.withStartupProbe(probeObj);
+            break;
+          default:
+            throw new IllegalArgumentException(
+                String.format("Unsupported k8s Probe type : %s", probeName));
+        }
+      });
+    }
+
     return builder
         .withName(cleanse(name, 254))
         .withImage(containerImage)
@@ -1583,5 +1620,24 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     List<SecretDisk> getSecretDisks() {
       return secretDisks;
     }
+  }
+
+  /**
+   * Get {@link Map} of properties prefixed with the string provided as an input.
+   * Property names in the mapping are trimmed to remove the prefix.
+   *
+   * @param originalMap
+   * @param prefix
+   * @return
+   */
+  public static Map<String, String> filterAndRemoveKeyPrefix(Map<String, String> originalMap,
+      String prefix) {
+
+    return originalMap.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(
+            entry -> entry.getKey().substring(prefix.length()),
+            Map.Entry::getValue
+        ));
   }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/ProbeFactory.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/ProbeFactory.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.util;
+
+import com.google.common.base.Preconditions;
+import io.kubernetes.client.openapi.models.V1HTTPGetAction;
+import io.kubernetes.client.openapi.models.V1Probe;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Utility class to create a {@link V1Probe} from the given map of configs.
+ *
+ * Usage for k8s probe :
+ * Please refer to this class's parameter constants for forming full
+ * config name regarding a k8s probe.
+ * Example : for PROBE_INIT_DELAY_SEC = "task.worker.probe.k8s.liveness.init.delay.seconds"`
+ * The format is :
+ * TASK_WORKER_PROBE_PREFIX + ENV + PROBE_NAME + . + PARAMETER_CONSTANT
+ * task.worker.probe        + k8s + liveness   + . + init.delay.seconds
+ *   //
+ * TASK_WORKER_PROBE_PREFIX = it is defined in constants (Ex : `task.worker.probe.`)
+ * ENV = The value from Constant defined in an Environment Class. Example : `ProbeFactory`'s PROBE_ENV = k8s
+ *   //
+ * PROBE_NAME =
+ *    it's the cConf valueOf [ TASK_WORKER_PROBE_PREFIX
+ *    + ENV + PROBE_NAME_CSV (constant in ProbeFactory) ],
+ *    (Ex : `task.worker.probe.k8s.names` = `liveness,readiness`)
+ * PARAMETER_CONSTANT = it's the value of a CONSTANT in `ProbeFactory` (Ex : `init.delay.seconds`)
+ *   //
+ * Minimum required fields for k8s :
+ * `task.worker.probe.enabled` = true
+ * `task.worker.probe.k8s.names`
+ * `task.worker.probe.k8s.<PROBE_NAME>.type`
+ *
+ */
+public final class ProbeFactory {
+
+  public enum ProbeName {
+    LIVENESS,
+    READINESS,
+    STARTUP
+  }
+
+  public static final String PROBE_ENV = "k8s.";
+  public static final String PROBE_NAME_CSV = "names";
+
+  // --- Common Parameter Configs ---
+  private static final String PROBE_ACTION_TYPE = "type";
+  private static final String PROBE_INIT_DELAY_SEC = "init.delay.seconds";
+  private static final String PROBE_TIMEOUT_SEC = "timeout.seconds";
+  private static final String PROBE_FAILURE_THRESHOLD = "failure.threshold";
+  private static final String PROBE_SUCCESS_THRESHOLD = "success.threshold";
+  private static final String PROBE_PERIOD_SECONDS = "period.seconds";
+  private static final String PROBE_TERM_GRACE_PERIOD_SECONDS =
+      "termination.grace.period.seconds";
+
+  // HTTP Probe Specific Keys
+  private static final String PROBE_HTTP_PATH = "http.path";
+  private static final String PROBE_HTTP_PORT = "http.port";
+  private static final String PROBE_HTTP_HOST = "http.host";
+  private static final String PROBE_HTTP_SCHEME = "http.scheme";
+
+  private ProbeFactory() {}
+
+  public static V1Probe createV1Probe(Map<String, String> probeConf) {
+    V1Probe probe = new V1Probe();
+    setCommonProbeFields(probe, probeConf);
+
+    Preconditions.checkArgument(probeConf.get(PROBE_ACTION_TYPE) != null, "Probe Type cannot be null.");
+    // Only supporting HTTP for now.
+    switch (probeConf.get(PROBE_ACTION_TYPE).trim().toLowerCase()) {
+      case "httpget":
+        probe.setHttpGet(createHTTPGetAction(probeConf));
+        break;
+      default:
+        throw new IllegalStateException("Unsupported Probe Type: " + probeConf.get(PROBE_ACTION_TYPE));
+    }
+    return probe;
+  }
+
+  private static void setCommonProbeFields(V1Probe probe, Map<String, String> probeConf) {
+    // 1. initialDelaySeconds (Integer, min 0)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_INIT_DELAY_SEC,
+        Integer::valueOf,
+        (val) -> val >= 0,
+        "initialDelaySeconds cannot be less than 0",
+        probe::initialDelaySeconds);
+
+    // 2. timeoutSeconds (Integer, min 1)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_TIMEOUT_SEC,
+        Integer::valueOf,
+        (val) -> val >= 1,
+        "timeoutSeconds cannot be less than 1",
+        probe::timeoutSeconds);
+
+    // 3. failureThreshold (Integer, min 1)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_FAILURE_THRESHOLD,
+        Integer::valueOf,
+        (val) -> val >= 1,
+        "failureThreshold cannot be less than 1",
+        probe::failureThreshold);
+
+    // 4. successThreshold (Integer, min 1)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_SUCCESS_THRESHOLD,
+        Integer::valueOf,
+        (val) -> val >= 1,
+        "successThreshold cannot be less than 1",
+        probe::successThreshold);
+
+    // 5. periodSeconds (Integer, min 1)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_PERIOD_SECONDS,
+        Integer::valueOf,
+        (val) -> val >= 1,
+        "periodSeconds cannot be less than 1",
+        probe::periodSeconds);
+
+    // 6. terminationGracePeriodSeconds (Long, min 1)
+    setProbeFieldIfPresent(
+        probeConf,
+        PROBE_TERM_GRACE_PERIOD_SECONDS,
+        Long::valueOf,
+        (val) -> val >= 1,
+        "terminationGracePeriodSeconds cannot be less than 1",
+        probe::terminationGracePeriodSeconds);
+  }
+
+  /**
+   * Encapsulates the logic for extracting, validating, and setting a field on the V1Probe object.
+   * @param <T> The target type of the field (e.g., Integer, Long).
+   * @param probeConf The map containing probe configurations.
+   * @param key The configuration key for the field.
+   * @param converter A function to convert the String value to type T.
+   * @param validator A predicate to validate the converted value (e.g., check for min value).
+   * @param errorMessage The message for the Preconditions.checkArgument if validation fails.
+   * @param setter A consumer function (method reference) to set the value on the V1Probe object.
+   */
+  private static <T> void setProbeFieldIfPresent(
+      Map<String, String> probeConf,
+      String key,
+      Function<String, T> converter,
+      Function<T, Boolean> validator, // Changed to Function<T, Boolean> for clarity/simplicity in this pattern
+      String errorMessage,
+      Consumer<T> setter) {
+
+    Optional<T> valueOpt = getValue(probeConf, key, converter);
+
+    valueOpt.ifPresent(val -> {
+      Preconditions.checkArgument(validator.apply(val), errorMessage);
+      setter.accept(val);
+    });
+  }
+
+  private static <T> Optional<T> getValue(Map<String, String> conf, String key, Function<String, T> converter) {
+    String strVal = conf.get(key);
+    T val = null;
+    if (strVal != null) {
+      val = converter.apply(strVal);
+    }
+    return Optional.ofNullable(val);
+  }
+
+  private static V1HTTPGetAction createHTTPGetAction(Map<String, String> probeConf) {
+    V1HTTPGetAction action = new V1HTTPGetAction();
+
+    // Port (required for an HTTP probe)
+    Preconditions.checkArgument(probeConf.get(PROBE_HTTP_PORT) != null,
+        "Port of a HTTP Probe cannot be null.");
+    Optional.ofNullable(probeConf.get(PROBE_HTTP_PORT))
+        .map(Integer::parseInt)
+        .map(io.kubernetes.client.custom.IntOrString::new)
+        .ifPresent(action::port);
+
+    // Path (optional)
+    Optional.ofNullable(probeConf.get(PROBE_HTTP_PATH))
+        .ifPresent(action::path);
+
+    // Host (optional) , If not set, it defaults to the pod IP, which is usually correct.
+    Optional.ofNullable(probeConf.get(PROBE_HTTP_HOST))
+        .ifPresent(action::host);
+
+    // Scheme (optional)
+    Optional.ofNullable(probeConf.get(PROBE_HTTP_SCHEME))
+        .ifPresent(action::scheme);
+
+    return action;
+  }
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.k8s.runtime;
 
+import static io.cdap.cdap.k8s.runtime.KubeTwillPreparer.filterAndRemoveKeyPrefix;
+
 import io.cdap.cdap.master.environment.k8s.PodInfo;
 import io.cdap.cdap.master.spi.MasterOptionConstants;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
@@ -394,6 +396,26 @@ public class KubeTwillPreparerTest {
     Assert.assertEquals("name-1", KubeTwillPreparer.cleanse("name_1",
         6));
   }
+
+  @Test
+  public void testBasicFilteringAndPrefixRemoval() {
+    Map<String, String> original = new HashMap<>();
+    original.put("k8s.liveness.init.delay.seconds", "10");
+    original.put("gcp.liveness.init.delay.seconds", "100");
+    original.put("app.version", "1.0");
+    original.put("k8s.liveness.period.seconds", "2");
+
+    String prefix = "k8s.";
+    Map<String, String> expected = new HashMap<>();
+    expected.put("liveness.init.delay.seconds", "10");
+    expected.put("liveness.period.seconds", "2");
+
+    Map<String, String> actual = filterAndRemoveKeyPrefix(original, prefix);
+
+    Assert.assertEquals("The resulting map size should match the expected size.", expected.size(), actual.size());
+    Assert.assertEquals("The filtered map should contain the correct entries with prefixes removed.", expected, actual);
+  }
+
 
   private static Map<String, String> getTwillConfigs() {
     HashMap<String, String> cConf = new HashMap<>();

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.master.spi.twill;
 
 
+import java.util.Map;
 import org.apache.twill.api.TwillPreparer;
 
 /**
@@ -44,4 +45,10 @@ public interface ExtendedTwillPreparer extends TwillPreparer {
    */
   ExtendedTwillPreparer setShouldLocalizeConfigurationAsConfigmap(
       boolean shouldLocalizeConfigurationAsConfigmap);
+
+  /**
+   * Creates the probes based on the Probe Config passed and assigns to the given runnable.
+   * Example : It can be used for a Liveness Probe in k8s
+   */
+  ExtendedTwillPreparer addProbes(String runnableName, Map<String, String> probeConf);
 }


### PR DESCRIPTION
### End Goal : 
We want to restart a task worker anyhow if it's stuck. 
- it can be due to non daemon threads or process getting stuck. 

### Major changes : 
- addition of `System.exit(0)` in shutdown logic of task worker. 
- Add `PingHandler` in task worker service 
- Add support for liveness Probe in master-api , similar to `SecretDisk` 
-  Prepare a config object `ProbeConfig` in `TaskWorkerServiceLauncher` and add it to twill preparer if FEATURE is enabled. 
- In `KubeTwillPreparer` convert the  `ProbeConfig` into k8s client probe object and add it to Suitable container 

###  Testing : 

#### Set Up : 
- Enterprise instance in Test Env 
- Changed 
  - task.worker.container.count: "1"
  - task.worker.container.kill.after.duration.second: "300"
     - (5 mins - it should restart automatically)
 - Prepared a plugin that spins up Non Daemon threads in `configurePipeline` . This method is called during Validation call. 
 
 Was able to reproduce the issue and the task worker was stuck. 

- `Changed image with this branch` 

#### 1. By default Liveness Probe should not be enabled 
On changing the image and running `kubectl describe sts` , no livenessProbe was mentioned 


#### 2. Enable with `task.worker.liveness.probe.enabled` = true 
On changing the image and running `kubectl describe pod <task_worker_pod>` 
- output : `Liveness:  http-get https://:11020/ping delay=90s timeout=5s period=15s #success=1 #failure=20` 

#### 3. With Good case plugin / no activity it should restart every 5 mins 
`cdap-abc-worker-807423a5-c74b--3c7e74d1eb-0            2/2     Running   3 (3m34s ago)   20m`

#### 4. Plugin with NON-DAEMON threads - should shutdown properly. 
IN logs of task worker : 
```
2025-11-06 15:50:29,725 - DEBUG [task.worker-executor-13:i.c.c.i.a.w.SystemAppTask@157] - System app task completed io.cdap.cdap.datapipeline.service.RemoteValidationTask
Non-Daemon Thread is running...
.
```
Task worker restarted correctly (not via livenessProbe)
` Normal   Started                 8m12s (x5 over 30m)  kubelet                  Started container taskworkertwillrunnable` 

#### 5. Plugin with NON-DAEMON threads + Shutdown Hook - should call the hook and shutdown properly. 
```
kubectl logs cdap-abc-task-worker-807423a5-c74b--3c7e74d1eb-0 -p | grep -i "shutdown"
--- Shutdown Hook finished ---
```

The shutdown hook was triggered and restart was successful. 


#### 6. Plugin with NON-DAEMON sleeping threads that makes the process zombie. - The livenessProbe should restart the container. 

in some time on monitoring using `kubectl describe podc dap-abc-task-worker-807423a5-c74b--3c7e74d1eb-0`

```
Warning  Unhealthy  7s (x3 over 37s)     kubelet            Liveness probe failed: Get "https://10.5.32.79:11020/ping": dial tcp 10.5.32.79:11020: connect: connection refused
```
and finally : 

```
  Warning  Unhealthy  115s (x20 over 6m40s)  kubelet            Liveness probe failed: Get "https://10.5.32.79:11020/ping": dial tcp 10.5.32.79:11020: connect: connection refused
  Normal   Killing    115s                   kubelet            Container taskworkertwillrunnable failed liveness probe, will be restarted
  Normal   Pulling    84s (x5 over 28m)      kubelet            Pulling image "abc/blah-blah:latest"
  Normal   Started    83s (x5 over 28m)      kubelet            Started container taskworkertwillrunnable
  Normal   Created    83s (x5 over 28m)      kubelet            Created container: taskworkertwillrunnable
  ```

The task worker restarted correctly.

