### PR TITLE
[CDAP-21223] Fix Cloud Spanner lock contention issues related to count() query

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/FlowControlService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/FlowControlService.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.proto.ProgramRunStatus;
@@ -30,7 +31,6 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
@@ -46,6 +46,7 @@ public class FlowControlService extends AbstractIdleService {
 
   private final MetricsCollectionService metricsCollectionService;
   private final TransactionRunner transactionRunner;
+  private final int readStalenessSeconds;
 
   private static final Map<String, String> tags = ImmutableMap.of(
       Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace()
@@ -59,9 +60,10 @@ public class FlowControlService extends AbstractIdleService {
   @Inject
   public FlowControlService(
       MetricsCollectionService metricsCollectionService,
-      TransactionRunner transactionRunner) {
+      TransactionRunner transactionRunner, CConfiguration cConf) {
     this.metricsCollectionService = metricsCollectionService;
     this.transactionRunner = transactionRunner;
+    this.readStalenessSeconds = cConf.getInt(Constants.Metrics.FlowControl.READ_STALENESS_SECONDS, 0);
   }
 
   @Override
@@ -92,8 +94,8 @@ public class FlowControlService extends AbstractIdleService {
           programOptions.getArguments().asMap(),
           programOptions.getUserArguments().asMap(),
           programDescriptor.getArtifactId().toApiArtifactId());
-      int launchingCount = store.getFlowControlLaunchingCount();
-      int runningCount = store.getFlowControlRunningCount();
+      int launchingCount = store.getFlowControlLaunchingCount(readStalenessSeconds);
+      int runningCount = store.getFlowControlRunningCount(readStalenessSeconds);
       return new Counter(launchingCount, runningCount);
     });
     LOG.info("Added request with runId {}.", programRunId);
@@ -114,7 +116,8 @@ public class FlowControlService extends AbstractIdleService {
   public Counter getCounter() {
     return TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore store = AppMetadataStore.create(context);
-      return new Counter(store.getFlowControlLaunchingCount(), store.getFlowControlRunningCount());
+      return new Counter(store.getFlowControlLaunchingCount(readStalenessSeconds),
+          store.getFlowControlRunningCount(readStalenessSeconds));
     });
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -71,6 +71,7 @@ import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.StaleReadOption;
 import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
 import java.io.StringReader;
@@ -1781,13 +1782,15 @@ public class AppMetadataStore {
    *
    * @return Count of records in launching state.
    */
-  public int getFlowControlLaunchingCount() throws IOException {
+  public int getFlowControlLaunchingCount(int readStalenessSeconds) throws IOException {
     ImmutableList<Field<?>> keyPrefix = ImmutableList.of(
         Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, TYPE_RUN_RECORD_ACTIVE));
     Collection<Field<?>> filterIndexes =
         ImmutableList.of(
-            Fields.stringField(StoreDefinition.AppMetadataStore.FLOW_CONTROL_STATUS, TYPE_FLOW_CONTROL_LAUNCHING));
-    return (int) getRunRecordsTable().count(Arrays.asList(Range.singleton(keyPrefix)), filterIndexes);
+            Fields.stringField(StoreDefinition.AppMetadataStore.FLOW_CONTROL_STATUS,
+                TYPE_FLOW_CONTROL_LAUNCHING));
+    return (int) getRunRecordsTable().count(Collections.singletonList(Range.singleton(keyPrefix)),
+        filterIndexes, new StaleReadOption(readStalenessSeconds));
   }
 
   /**
@@ -1795,13 +1798,15 @@ public class AppMetadataStore {
    *
    * @return Count of records in running state.
    */
-  public int getFlowControlRunningCount() throws IOException {
+  public int getFlowControlRunningCount(int readStalenessSeconds) throws IOException {
     ImmutableList<Field<?>> keyPrefix = ImmutableList.of(
         Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, TYPE_RUN_RECORD_ACTIVE));
     Collection<Field<?>> filterIndexes =
         ImmutableList.of(
-            Fields.stringField(StoreDefinition.AppMetadataStore.FLOW_CONTROL_STATUS, TYPE_FLOW_CONTROL_RUNNING));
-    return (int) getRunRecordsTable().count(Arrays.asList(Range.singleton(keyPrefix)), filterIndexes);
+            Fields.stringField(StoreDefinition.AppMetadataStore.FLOW_CONTROL_STATUS,
+                TYPE_FLOW_CONTROL_RUNNING));
+    return (int) getRunRecordsTable().count(Collections.singletonList(Range.singleton(keyPrefix)),
+        filterIndexes, new StaleReadOption(readStalenessSeconds));
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1182,6 +1182,7 @@ public final class Constants {
 
       public static final String LAUNCHING_COUNT = "flowcontrol.launching.count";
       public static final String RUNNING_COUNT = "flowcontrol.running.count";
+      public static final String READ_STALENESS_SECONDS = "flowcontrol.read.staleness.seconds";
     }
 
     /**

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
@@ -18,12 +18,15 @@ package io.cdap.cdap.storage.spanner;
 
 import com.google.api.client.util.Throwables;
 import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeyRange;
 import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.ReadContext;
 import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
+import com.google.cloud.spanner.TimestampBound;
 import com.google.cloud.spanner.TransactionContext;
 import com.google.cloud.spanner.Value;
 import io.cdap.cdap.api.dataset.lib.AbstractCloseableIterator;
@@ -38,6 +41,8 @@ import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.QueryOption;
+import io.cdap.cdap.spi.data.table.options.StaleReadOption;
 import io.cdap.cdap.storage.spanner.compression.CompressionConfig;
 import io.cdap.cdap.storage.spanner.compression.CompressorFactory;
 import io.cdap.cdap.storage.spanner.compression.CompressorType;
@@ -52,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -76,15 +82,17 @@ public class SpannerStructuredTable implements StructuredTable {
   private final TransactionContext transactionContext;
   private final SpannerStructuredTableSchema schema;
   private final SpannerFieldValidator fieldValidator;
+  private final DatabaseClient dbClient;
 
   /**
    * Constructor for {@link SpannerStructuredTable}.
    */
   public SpannerStructuredTable(TransactionContext transactionContext,
-      SpannerStructuredTableSchema schema) {
+      SpannerStructuredTableSchema schema, DatabaseClient dbClient) {
     this.transactionContext = transactionContext;
     this.schema = schema;
     this.fieldValidator = new SpannerFieldValidator(schema);
+    this.dbClient = dbClient;
   }
 
   @Override
@@ -477,6 +485,31 @@ public class SpannerStructuredTable implements StructuredTable {
         return 0L;
       }
       return resultSet.getCurrentRowAsStruct().getLong(0);
+    }
+  }
+
+  @Override
+  public long count(Collection<Range> keyRanges, Collection<Field<?>> filterIndexes,
+      QueryOption... options) throws InvalidFieldException, IOException {
+    Optional<StaleReadOption> staleOption = QueryOption.getOption(StaleReadOption.class, options);
+    // Fallback to strong read if option is missing OR staleness is not > 0.
+    // A staleness of 0 is effectively a strong read, which requires locks.
+    if (!staleOption.isPresent() || staleOption.get().getMaxStalenessInSeconds() <= 0) {
+      return count(keyRanges, filterIndexes);
+    }
+
+    fieldValidator.validateFilterIndexes(filterIndexes);
+    TimestampBound staleness = TimestampBound.ofMaxStaleness(
+        staleOption.get().getMaxStalenessInSeconds(), TimeUnit.SECONDS);
+    // Use a single-use snapshot to bypass transaction locks.
+    try (ReadContext readContext = dbClient.singleUse(staleness)) {
+      Statement sqlStatement = getCountStatement(keyRanges, filterIndexes);
+      try (ResultSet resultSet = readContext.executeQuery(sqlStatement)) {
+        if (!resultSet.next()) {
+          return 0L;
+        }
+        return resultSet.getCurrentRowAsStruct().getLong(0);
+      }
     }
   }
 

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableContext.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableContext.java
@@ -43,7 +43,8 @@ public class SpannerStructuredTableContext implements StructuredTableContext {
   @Override
   public StructuredTable getTable(StructuredTableId tableId)
       throws StructuredTableInstantiationException, TableNotFoundException {
-    return new SpannerStructuredTable(context, admin.getSpannerStructuredTableSchema(tableId));
+    return new SpannerStructuredTable(context, admin.getSpannerStructuredTableSchema(tableId),
+        admin.getDatabaseClient());
   }
 
   @Override

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.QueryOption;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -332,5 +333,24 @@ public interface StructuredTable extends Closeable {
   default long count(Collection<Range> keyRanges,
       Collection<Field<?>> filterIndexes) throws InvalidFieldException, IOException {
     throw new UnsupportedOperationException("No supported implementation.");
+  }
+
+  /**
+   * Get the number of records from the table matching the key range of specified index fields, with
+   * additional query options.
+   *
+   * @param keyRanges     key ranges of the rows to count
+   * @param filterIndexes the indexes to filter upon, OR logic will be applied
+   * @param options       optional {@link QueryOption}s to modify the query behavior (e.g., stale
+   *                      reads)
+   * @return the number of records matching the criteria
+   * @throws InvalidFieldException if a field is not part of the table schema, is not an indexed
+   *                               column, or the type does not match the schema
+   * @throws IOException           if there is an error reading from the table
+   */
+  default long count(Collection<Range> keyRanges,
+      Collection<Field<?>> filterIndexes, QueryOption... options)
+      throws InvalidFieldException, IOException {
+    return count(keyRanges, filterIndexes);
   }
 }

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/QueryOption.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/QueryOption.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.table.options;
+
+import java.util.Optional;
+
+/**
+ * An interface representing an optional configuration that can be passed to table operations (such
+ * as read, scan, or count) to modify their default behavior.
+ */
+public interface QueryOption {
+
+  /**
+   * Helper method to extract a specific type of {@link QueryOption} from a varargs array.
+   *
+   * @param clazz   the class of the option to extract
+   * @param options the array of options to search through
+   * @param <T>     the type of the option
+   * @return an {@link Optional} containing the option if an instance of the specified class is
+   * found, otherwise an empty {@link Optional}.
+   */
+  static <T extends QueryOption> Optional<T> getOption(Class<T> clazz, QueryOption... options) {
+    if (options == null || clazz == null) {
+      return Optional.empty();
+    }
+
+    for (QueryOption option : options) {
+      if (clazz.isInstance(option)) {
+        return Optional.of(clazz.cast(option));
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/StaleReadOption.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/StaleReadOption.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.table.options;
+
+/**
+ * A {@link QueryOption} for performing stale reads.
+ */
+public class StaleReadOption implements QueryOption {
+
+  private final int maxStalenessInSeconds;
+
+  public StaleReadOption(int maxStalenessInSeconds) {
+    this.maxStalenessInSeconds = maxStalenessInSeconds;
+  }
+
+  public int getMaxStalenessInSeconds() {
+    return maxStalenessInSeconds;
+  }
+}

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.StaleReadOption;
 import io.cdap.cdap.spi.data.transaction.TransactionException;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -1644,6 +1645,60 @@ public abstract class StructuredTableTest {
                              Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
                                         Range.Bound.EXCLUSIVE));
       Assert.assertEquals(max, table.count(ranges));
+    });
+  }
+
+  @Test
+  public void testCountWithFilterIndexes() throws Exception {
+    // Write records
+    int max = 5;
+    List<Collection<Field<?>>> fields = writeSimpleStructuredRows(max, "");
+    Assert.assertEquals(max, fields.size());
+    // Verify count
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      Assert.assertEquals(max, table.count(Collections.singleton(Range.all())));
+
+      Collection<Range> ranges = Arrays.asList(
+          Range.to(Collections.singletonList(Fields.intField(KEY, 2)),
+              Range.Bound.INCLUSIVE),
+          // Intentionally create overlapping range
+          Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
+              Range.Bound.EXCLUSIVE));
+      List<Field<?>> filterIndexes = Collections.singletonList(
+          Fields.stringField(STRING_COL, "val3"));
+      Assert.assertEquals(1,
+          table.count(ranges, filterIndexes));
+
+      // Partial primary keys range
+      ranges = Arrays.asList(Range.to(Collections.singletonList(Fields.intField(KEY, 4)),
+              Range.Bound.INCLUSIVE),
+          // Intentionally create overlapping range
+          Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
+              Range.Bound.EXCLUSIVE));
+      Assert.assertEquals(1,
+          table.count(ranges, filterIndexes));
+    });
+  }
+
+  @Test
+  public void testCountWithFilterIndexesAndQueryOptions() throws Exception {
+    int max = 5;
+    List<Collection<Field<?>>> fields = writeSimpleStructuredRows(max, "");
+    Assert.assertEquals(max, fields.size());
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      Assert.assertEquals(max, table.count(Collections.singleton(Range.all())));
+      Collection<Range> ranges = Arrays.asList(
+          Range.to(Collections.singletonList(Fields.intField(KEY, 2)),
+              Range.Bound.INCLUSIVE),
+          Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
+              Range.Bound.EXCLUSIVE));
+      List<Field<?>> filterIndexes = Collections.singletonList(
+          Fields.stringField(STRING_COL, "val3"));
+      Assert.assertEquals(1,
+          table.count(ranges, filterIndexes,
+              new StaleReadOption(1)));
     });
   }
 


### PR DESCRIPTION
This PR addresses Cloud Spanner lock contention issues encountered in 6.11 instances. The contention was primarily driven by high-frequency `SELECT COUNT(*)` queries on the `run_records` table used for flow control. These read queries acquired locks to the table as they were executed as part of `ReadWriteTransaction` ([reference](https://github.com/cdapio/cdap/blob/develop/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java#L39)).

### Changes:
1. Introduced new `QueryOption` interface & one of its implementation (`StaleReadsOption`)
2. `StructuredTable.count()` method that accepts these QueryOptions.
3. Flow Control service calls the new count method via AppMetaStore. The max staleness is decided based on cConf property.

### Testing:

- [x] CDAP Distributed docker image
- [x] Load test with concurrent launch of 1000 runs.