### PR TITLE
[CDAP-21224] Ignore PluginNotFoundException  during AppSpec deserialization 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/AppSpecDeserializationContext.java
@@ -34,7 +34,10 @@ import io.cdap.cdap.store.StoreDefinition.ArtifactStore;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
 
@@ -49,8 +52,10 @@ public class AppSpecDeserializationContext {
   private static final Gson GSON = new Gson();
   private ArtifactId rootArtifact;
   private String namespace;
+  private String appName;
   private final StructuredTable pluginDataTable;
   private final StructuredTable universalPluginDataTable;
+  private Set<String> missingPlugins;
   private final LoadingCache<PluginKey, PluginClass> pluginCache;
 
   /**
@@ -65,6 +70,7 @@ public class AppSpecDeserializationContext {
     this.namespace = namespace;
     this.pluginDataTable = pluginDataTable;
     this.universalPluginDataTable = universalPluginDataTable;
+    this.missingPlugins = new HashSet<>();
     this.pluginCache = CacheBuilder.newBuilder().maximumSize(10)
         .build(new CacheLoader<PluginKey, PluginClass>() {
           @Override
@@ -82,7 +88,7 @@ public class AppSpecDeserializationContext {
       row = fetchFromUniversalPluginDataTable(pluginKey);
       if (!row.isPresent()) {
         throw new PluginNotExistsException(
-            new io.cdap.cdap.proto.id.ArtifactId(pluginKey.getParentNamespace(),
+            new io.cdap.cdap.proto.id.ArtifactId(pluginKey.getArtifactNamespace(),
                 pluginKey.getArtifactName(), pluginKey.getArtifactVersion()),
             pluginKey.getPluginType(), pluginKey.getPluginName());
       }
@@ -172,6 +178,36 @@ public class AppSpecDeserializationContext {
    */
   public void setRootArtifact(ArtifactId rootArtifact) {
     this.rootArtifact = rootArtifact;
+  }
+
+  /**
+   * Appends a plugin that could not be resolved during deserialization.
+   */
+  public void appendMissingPlugin(String pluginInfo) {
+    if (pluginInfo != null) {
+      this.missingPlugins.add(pluginInfo);
+    }
+  }
+
+  /**
+   * Returns a read-only view of the plugins that were missing during the deserialization process.
+   */
+  public Set<String> getMissingPlugins() {
+    return Collections.unmodifiableSet(this.missingPlugins);
+  }
+
+  /**
+   * Sets the application name.
+   */
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
+
+  /**
+   * Gets the application name, set externally.
+   */
+  public String getAppName() {
+    return appName;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaAdapter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaAdapter.java
@@ -25,7 +25,10 @@ import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.ApplicationSpecificationCodec;
 import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.spi.data.StructuredTable;
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages Gson instances specifically configured for ApplicationMeta serialization and
@@ -38,6 +41,7 @@ public final class ApplicationMetaAdapter {
 
   private static final Gson GSON_INSTANCE_REDUCTION_ENABLED = buildGsonInternal(true);
   private static final Gson GSON_INSTANCE_REDUCTION_DISABLED = buildGsonInternal(false);
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationMetaAdapter.class);
 
   private ApplicationMetaAdapter() {
   }
@@ -55,7 +59,13 @@ public final class ApplicationMetaAdapter {
     AppSpecDeserializationContextHolder.setContext(operationContext);
     try {
       Gson gson = getGson(appSpecReductionEnabled);
-      return gson.fromJson(jsonString, classOfT);
+      T result = gson.fromJson(jsonString, classOfT);
+      Set<String> missingPlugins = operationContext.getMissingPlugins();
+      if (!missingPlugins.isEmpty()) {
+        LOG.trace("For application {} : {}", operationContext.getAppName(),
+            operationContext.getMissingPlugins());
+      }
+      return result;
     } finally {
       AppSpecDeserializationContextHolder.clearContext();
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaCodec.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/ApplicationMetaCodec.java
@@ -87,6 +87,10 @@ public class ApplicationMetaCodec implements JsonSerializer<ApplicationMeta>,
             "ArtifactId in ApplicationSpecification was null for app: " + id);
       }
     }
+
+    JsonElement appNameJson = specJson.get("name");
+    appSpecDeserializationContext.setAppName(appNameJson == null ? null : appNameJson.getAsString());
+
     ApplicationSpecification spec = context.deserialize(specJson, ApplicationSpecification.class);
     return new ApplicationMeta(id, spec, null, null);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginDeserializer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/adapters/PluginDeserializer.java
@@ -34,12 +34,16 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Gson deserializer for {@link Plugin}s. Uses {@link AppSpecDeserializationContext} to enrich
  * {@link PluginClass} data if initially minimal.
  */
 public class PluginDeserializer implements JsonDeserializer<Plugin> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PluginDeserializer.class);
 
   /**
    * Deserializes JSON to {@link Plugin}. If {@link PluginClass#getClassName()} is empty, attempts
@@ -105,8 +109,10 @@ public class PluginDeserializer implements JsonDeserializer<Plugin> {
         exception = e;
       }
     }
-    throw new RuntimeException(
-        "No data found in plugin data table OR universal plugin data table for key: " + exception);
+    if (exception != null) {
+      appSpecDeserializationContext.appendMissingPlugin(exception.getMessage());
+    }
+    return pluginClass;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisionerStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisionerStore.java
@@ -72,7 +72,7 @@ public final class ProvisionerStore {
           StructuredRow row = iterator.next();
           result.add(ProvisioningTaskInfoAdapter.fromJson(
               row.getString(StoreDefinition.ProvisionerStore.PROVISIONER_TASK_INFO_FIELD),
-              context));
+              row.getString(StoreDefinition.ProvisionerStore.NAMESPACE_FIELD), context));
         }
       }
       return result;
@@ -176,6 +176,9 @@ public final class ProvisionerStore {
         createPrimaryKey(key.getProgramRunId(), key.getType()));
     String taskInfoJson = row.map(structuredRow -> structuredRow.getString(
         StoreDefinition.ProvisionerStore.PROVISIONER_TASK_INFO_FIELD)).orElse(null);
-    return ProvisioningTaskInfoAdapter.fromJson(taskInfoJson, context);
+    String namespace = row.map(
+            structuredRow -> structuredRow.getString(StoreDefinition.ProvisionerStore.NAMESPACE_FIELD))
+        .orElse(null);
+    return ProvisioningTaskInfoAdapter.fromJson(taskInfoJson, namespace, context);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/adapters/ProgramDescriptorDeserializer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/adapters/ProgramDescriptorDeserializer.java
@@ -67,6 +67,8 @@ public class ProgramDescriptorDeserializer implements JsonDeserializer<ProgramDe
             + programId.getApplication());
       }
     }
+    JsonElement appNameJson = specJson.get("name");
+    appSpecDeserializationContext.setAppName(appNameJson != null ? appNameJson.getAsString() : null);
     ApplicationSpecification spec = context.deserialize(specJson, ApplicationSpecification.class);
     return new ProgramDescriptor(programId, spec);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/adapters/ProvisioningTaskInfoAdapter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/adapters/ProvisioningTaskInfoAdapter.java
@@ -38,6 +38,8 @@ import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.store.StoreDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages Gson instances specifically configured for {@link ProvisioningTaskInfo} serialization and
@@ -48,6 +50,7 @@ import io.cdap.cdap.store.StoreDefinition;
  */
 public final class ProvisioningTaskInfoAdapter {
 
+  private static final Logger LOG = LoggerFactory.getLogger(ProvisioningTaskInfo.class);
   private static final Gson GSON_INSTANCE_REDUCTION_ENABLED = buildGsonInternal(true);
   private static final Gson GSON_INSTANCE_REDUCTION_DISABLED = buildGsonInternal(false);
 
@@ -80,16 +83,23 @@ public final class ProvisioningTaskInfoAdapter {
    * {@link AppSpecDeserializationContext} lifecycle via
    * {@link AppSpecDeserializationContextHolder}.
    */
-  public static ProvisioningTaskInfo fromJson(String jsonString, StructuredTableContext context) {
-    boolean appSpecReductionEnabled = isAppSpecReductionEnabled(context);
-    if (appSpecReductionEnabled) {
-      AppSpecDeserializationContext operationContext = new AppSpecDeserializationContext(null,
-          getPluginDataTable(context), getUniversalPluginDataTable(context));
-      AppSpecDeserializationContextHolder.setContext(operationContext);
+  public static ProvisioningTaskInfo fromJson(String jsonString, String namespace,
+      StructuredTableContext context) {
+    boolean reductionEnabled = isAppSpecReductionEnabled(context);
+    AppSpecDeserializationContext opContext =
+        reductionEnabled ? new AppSpecDeserializationContext(namespace, getPluginDataTable(context),
+            getUniversalPluginDataTable(context)) : null;
+    if (opContext != null) {
+      AppSpecDeserializationContextHolder.setContext(opContext);
     }
     try {
-      Gson gson = getGson(appSpecReductionEnabled);
-      return gson.fromJson(jsonString, ProvisioningTaskInfo.class);
+      Gson gson = getGson(reductionEnabled);
+      ProvisioningTaskInfo taskInfo = gson.fromJson(jsonString, ProvisioningTaskInfo.class);
+      if (opContext != null && !opContext.getMissingPlugins().isEmpty()) {
+        LOG.trace("Missing plugins for application {}: {}", opContext.getAppName(),
+            opContext.getMissingPlugins());
+      }
+      return taskInfo;
     } finally {
       AppSpecDeserializationContextHolder.clearContext();
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -67,6 +67,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -1673,7 +1674,7 @@ public abstract class AppMetadataStoreTest {
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
     ApplicationReference appRef = new ApplicationReference(NamespaceId.DEFAULT, appName);
     ApplicationId appId = appRef.app(appName + "_version_" + 1);
-    ApplicationSpecification spec = createDummyAppSpecWithWorkflow(appId, artifactId);
+    ApplicationSpecification spec = createDummyAppSpecWithWorkflow(appId, artifactId, false);
     ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
         new ChangeDetail(null, null, null,
             creationTimeMillis + 1, true));
@@ -1696,6 +1697,33 @@ public abstract class AppMetadataStoreTest {
     });
 
     Assert.assertEquals(meta.toString(), gotMeta[0].toString());
+  }
+
+  @Test
+  public void testCreateAndGetApplicationWithMissingPlugins() {
+    String appName = "application1";
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    ApplicationReference appRef = new ApplicationReference(NamespaceId.DEFAULT, appName);
+    ApplicationId appId = appRef.app(appName + "_version_" + 1);
+    ApplicationSpecification spec = createDummyAppSpecWithWorkflow(appId, artifactId, true);
+    ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
+        new ChangeDetail(null, null, null,
+            creationTimeMillis + 1, true));
+
+    // Deploy the first version
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      StructuredTable pluginDataTable = metaStore.getPluginDataTable();
+      Plugins.addFormatTextPluginToTable(pluginDataTable);
+      metaStore.createLatestApplicationVersion(appId, meta);
+    });
+
+    // Verify latest version
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      ApplicationMeta gotMeta  = metaStore.getApplication(appId);
+      Assert.assertEquals(meta.toString(), Objects.requireNonNull(gotMeta).toString());
+    });
   }
 
   @Test
@@ -1839,8 +1867,10 @@ public abstract class AppMetadataStoreTest {
   }
 
   private ApplicationSpecification createDummyAppSpecWithWorkflow(ApplicationId appId,
-      ArtifactId artifactId) {
-    Map<String, Plugin> plugins = Plugins.createDummyPlugins();
+      ArtifactId artifactId, boolean isAppSpecReductionEnabled) {
+    Map<String, Plugin> plugins =
+        isAppSpecReductionEnabled ? Plugins.createDummyPluginsForReducedAppSpec()
+            : Plugins.createDummyPlugins();
     ImmutableList<WorkflowNode> nodes = ImmutableList.of(
         new WorkflowActionNode("mr1",
             new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE, "mr1")),
@@ -1858,7 +1888,7 @@ public abstract class AppMetadataStoreTest {
         ImmutableMap.of(appId.workflow("wf1").getProgram(), wfSpec), Collections.emptyMap(),
         Collections.emptyMap(),
         Collections.emptyMap(),
-        Collections.emptyMap());
+        plugins);
   }
 
   private void runConcurrentOperation(String name, int numThreads, Runnable runnable) throws Exception {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/plugin/Plugins.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/plugin/Plugins.java
@@ -95,6 +95,44 @@ public final class Plugins {
     return plugins;
   }
 
+  public static Map<String, Plugin> createDummyPluginsForReducedAppSpec() {
+    Map<String, Plugin> plugins = new HashMap<>();
+
+    Gson gson = new Gson();
+    Map<String, String> childProperties = ImmutableMap.of("child1", "childVal1", "child2",
+        "${secure(acc)}", "child3", "val3");
+    Map<String, String> properties = ImmutableMap.of("key2", gson.toJson(childProperties), "key1",
+        "val1");
+
+    PluginClass wranglerPluginClass = new PluginClass("transform", "Wrangler", null, null,
+        Collections.emptyMap(), new Requirements(Collections.emptySet()), "");
+    Plugin wranglerPlugin = new Plugin(Collections.emptyList(),
+        NamespaceId.DEFAULT.artifact("wrangler-transform", "1.0").toApiArtifactId(),
+        wranglerPluginClass, PluginProperties.builder().addAll(properties).build());
+    plugins.put("p1", wranglerPlugin);
+
+    PluginClass directivePluginClass = new PluginClass("directive", "now", null, null,
+        Collections.emptyMap(), new Requirements(Collections.emptySet()), "");
+    ArtifactId parent = NamespaceId.DEFAULT.artifact("Wrangler", "1.0").toApiArtifactId();
+    Plugin directivePlugin = new Plugin(Collections.singleton(parent),
+        NamespaceId.DEFAULT.artifact("wrangler", "1.0").toApiArtifactId(), directivePluginClass,
+        PluginProperties.builder().addAll(properties).build());
+    plugins.put("p2", directivePlugin);
+
+    PluginClass gCloudFormatTextPluginClass = PluginClass.builder()
+        .setClassName("io.cdap.plugin.format.text.input.TextInputFormatProvider").setName("text")
+        .setRequirements(Requirements.EMPTY).setType("validatingInputFormat")
+        .setDescription("Plugin for reading files in text format.").setConfigFieldName("conf")
+        .build();
+    parent = NamespaceId.DEFAULT.artifact("google-cloud", "1.0").toApiArtifactId();
+    Plugin gCloudFormatTextPlugin = new Plugin(Collections.singleton(parent),
+        NamespaceId.DEFAULT.artifact("format-text", "1.0").toApiArtifactId(),
+        gCloudFormatTextPluginClass, PluginProperties.builder().addAll(properties).build());
+    plugins.put("p3", gCloudFormatTextPlugin);
+
+    return plugins;
+  }
+
   private static void addPluginEntryToTable(StructuredTable pluginDataTable,
       String parentContextName, String pluginType, String pluginName, String artifactName,
       String pluginDataJson) throws IOException {


### PR DESCRIPTION
### Background
When a driver used by a deployed pipeline is deleted, subsequent AppSpec deserialization attempts (e.g., during list apps, deployment, or system startup) throw a PluginNotFoundException, which can lead to service crashes or make the instance unusable.

### Fix details
Trace log the exception and ignore during AppSpec deserialization.

### Testing Details
- Pipeline deploy failure 
<img width="3426" height="182" alt="image" src="https://github.com/user-attachments/assets/01663f86-f3d7-449c-b8ca-70d2d6e079af" />

- Pipeline run failure 
<img width="3438" height="1132" alt="image" src="https://github.com/user-attachments/assets/b00d2c44-ff18-41f9-b1f0-d6c602ec8b12" />

The behavior is same as that seen in 6.10.
Opened a JIRA to track better user-friendly error message in case of pipeline failures due to missing drivers : https://cdap.atlassian.net/browse/CDAP-21226

- List Pipelines UI
Before : 
<img width="2932" height="1246" alt="image" src="https://github.com/user-attachments/assets/95850fe2-8d39-41b1-be7d-1cdd2081c8da" />
After : 
<img width="2596" height="584" alt="image" src="https://github.com/user-attachments/assets/8da92dcc-6cfa-462d-89b2-7f9653ed735d" />
