### PR TITLE
[CDAP-21227] Make CDAP sandbox run in java 11 - support uploading java11 based plugins

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/startup/ConfigurationLogger.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/startup/ConfigurationLogger.java
@@ -17,8 +17,6 @@ package io.cdap.cdap.common.startup;
 
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import java.net.URL;
-import java.net.URLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,17 +28,10 @@ public class ConfigurationLogger {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLogger.class);
 
   public static void logImportantConfig(CConfiguration cConf) {
-    ClassLoader cl = ClassLoader.getSystemClassLoader();
 
-    URL[] urls = ((URLClassLoader) cl).getURLs();
+    String classPath = System.getProperty("java.class.path");
 
-    StringBuilder classPath = new StringBuilder();
-    LOG.info("Master classpath:");
-    for (URL url : urls) {
-      classPath.append(url.getFile()).append(":");
-    }
-    classPath.deleteCharAt(classPath.length() - 1);
-    LOG.info(classPath.toString());
+    LOG.info("Master classpath: {}", classPath);
 
     LOG.info("Important config settings:");
     for (String featureToggleProp : Constants.FEATURE_TOGGLE_PROPS) {


### PR DESCRIPTION
Needed to support running Sandbox with Java 11, so that we can easily test out java 11 based plugins. 

---

Changes : 
- minor change in logging [ doesn't affect any code logic ] 

---

### Testing 

#### 1. The logging change 
verified the out put of java 8 based log vs java 11 based log is exactly the same when running in java 11. 

#### 2. Actual runtime testing with plugin 

- Downloaded latest cdap-sandbox ( cdap-sandbox-6.12.0-SNAPSHOT ) 
- `setting java 11`  and starting the sandbox failed. ( `AppClassLoader cannot be cast to class java.net.URLClassLoader` )
- from this branch compiled cdap-common and replaced the jars in 2 locations with the extracted cdap-sandbox-6.12.0-SNAPSHOT folder. 
- sandbox start up was successful with java 11
- Built a plugin ( data-generator ) with compile time java 11 
- Was able to upload successfully 
- Preview was Success : 
<img width="928" height="434" alt="Screenshot 2026-01-20 at 2 12 32 AM" src="https://github.com/user-attachments/assets/6486bbb8-0f1f-4575-8c6c-51a6ba772168" />

- Pipeline Run was success : 
<img width="1197" height="513" alt="Screenshot 2026-01-20 at 2 21 03 AM" src="https://github.com/user-attachments/assets/e739051c-9bf4-4be0-ab4e-da3948ed7980" />

- Ensuring CDAP SANDOX process is on java 11  : 
```
jps -l | grep "io.cdap.cdap.StandaloneMain"
2574 io.cdap.cdap.StandaloneMain
sanketsahu-mac:bin sanketsahu$ jcmd 2574 VM.version
2574:
OpenJDK 64-Bit Server VM version 11.0.27+6-LTS
JDK 11.0.27
```
- Ensuring `datagen-plugins-0.3.0-SNAPSHOT.jar` is compiled with java 11  : 
```
javap -verbose -cp datagen-plugins-0.3.0-SNAPSHOT.jar io.cdap.plugin.datagen.DataGenerator | grep "major version"
  major version: 55
```

55 corresponds to java 11. 
  
