### PR TITLE
[cherry-pick][6.11][CDAP-21227] Make CDAP sandbox run in java 11 - support uploading java11 based plugins

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/startup/ConfigurationLogger.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/startup/ConfigurationLogger.java
@@ -17,8 +17,6 @@ package io.cdap.cdap.common.startup;
 
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import java.net.URL;
-import java.net.URLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,17 +28,10 @@ public class ConfigurationLogger {
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationLogger.class);
 
   public static void logImportantConfig(CConfiguration cConf) {
-    ClassLoader cl = ClassLoader.getSystemClassLoader();
 
-    URL[] urls = ((URLClassLoader) cl).getURLs();
+    String classPath = System.getProperty("java.class.path");
 
-    StringBuilder classPath = new StringBuilder();
-    LOG.info("Master classpath:");
-    for (URL url : urls) {
-      classPath.append(url.getFile()).append(":");
-    }
-    classPath.deleteCharAt(classPath.length() - 1);
-    LOG.info(classPath.toString());
+    LOG.info("Master classpath: {}", classPath);
 
     LOG.info("Important config settings:");
     for (String featureToggleProp : Constants.FEATURE_TOGGLE_PROPS) {


### PR DESCRIPTION
Original PR : #16081 

#### Testing : 

- Similar testing as original PR with `cdap-sandbox-6.11.2-SNAPSHOT` 
- replaced cda-common.
- uploaded java11 based data-gen 
- Tested Preview : success 
- Testing pipeline run : success 