### PR TITLE
security: add authorization checks to TransactionHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/TransactionHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/TransactionHttpHandler.java
@@ -26,6 +26,9 @@ import io.cdap.cdap.common.security.AuditDetail;
 import io.cdap.cdap.common.security.AuditPolicy;
 import io.cdap.cdap.data2.transaction.TransactionSystemClientAdapter;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.proto.id.InstanceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.BodyProducer;
 import io.cdap.http.HandlerContext;
 import io.cdap.http.HttpResponder;
@@ -79,15 +82,17 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   private final Configuration hConf;
   private final CConfiguration cConf;
   private final TransactionSystemClient txClient;
+  private final ContextAccessEnforcer contextAccessEnforcer;
   private final boolean pruneEnable;
   private volatile InvalidListPruningDebug pruningDebug;
 
   @Inject
   public TransactionHttpHandler(Configuration hConf, CConfiguration cConf,
-      TransactionSystemClient txClient) {
+      TransactionSystemClient txClient, ContextAccessEnforcer contextAccessEnforcer) {
     this.hConf = hConf;
     this.cConf = cConf;
     this.txClient = new TransactionSystemClientAdapter(txClient);
+    this.contextAccessEnforcer = contextAccessEnforcer;
     this.pruneEnable = cConf.getBoolean(TxConstants.TransactionPruning.PRUNE_ENABLE,
         TxConstants.TransactionPruning.DEFAULT_PRUNE_ENABLE);
   }
@@ -99,6 +104,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   public void getTxManagerSnapshot(HttpRequest request, HttpResponder responder)
       throws TransactionCouldNotTakeSnapshotException, IOException {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     LOG.trace("Taking transaction manager snapshot at time {}", System.currentTimeMillis());
     LOG.trace("Took and retrieved transaction manager snapshot successfully.");
 
@@ -138,6 +144,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @POST
   public void invalidateTx(HttpRequest request, HttpResponder responder,
       @PathParam("tx-id") String txId) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     try {
       long txIdLong = Long.parseLong(txId);
       boolean success = txClient.invalidate(txIdLong);
@@ -159,6 +166,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @AuditPolicy(AuditDetail.REQUEST_BODY)
   public void truncateInvalidTxBefore(FullHttpRequest request,
       HttpResponder responder) throws InvalidTruncateTimeException {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     Map<String, Long> body;
     try {
       body = parseBody(request, STRING_LONG_MAP_TYPE);
@@ -181,6 +189,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @POST
   @AuditPolicy(AuditDetail.REQUEST_BODY)
   public void truncateInvalidTx(FullHttpRequest request, HttpResponder responder) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     Map<String, Set<Long>> body;
     try {
       body = parseBody(request, STRING_LONG_SET_MAP_TYPE);
@@ -202,6 +211,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/transactions/invalid/size")
   @GET
   public void invalidTxSize(HttpRequest request, HttpResponder responder) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     int invalidSize = txClient.getInvalidSize();
     responder.sendJson(HttpResponseStatus.OK,
         GSON.toJson(Collections.singletonMap("size", invalidSize)));
@@ -211,6 +221,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   public void invalidList(HttpRequest request, HttpResponder responder,
       @QueryParam("limit") @DefaultValue("-1") int limit) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     Transaction tx = txClient.startShort();
     txClient.abort(tx);
     long[] invalids = tx.getInvalids();
@@ -228,6 +239,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/transactions/state")
   @POST
   public void resetTxManagerState(HttpRequest request, HttpResponder responder) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     txClient.resetState();
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -238,6 +250,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/transactions/prune/now")
   @POST
   public void pruneNow(HttpRequest request, HttpResponder responder) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     txClient.pruneNow();
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -247,6 +260,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   public void getPruneInfo(HttpRequest request, HttpResponder responder,
       @PathParam("region-name") String regionName) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     try {
       if (!initializePruningDebug(responder)) {
         return;
@@ -269,6 +283,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   @GET
   public void getTimeRegions(HttpRequest request, HttpResponder responder,
       @QueryParam("time") @DefaultValue("now") String time) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     try {
       if (!initializePruningDebug(responder)) {
         return;
@@ -287,6 +302,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   public void getIdleRegions(HttpRequest request, HttpResponder responder,
       @QueryParam("limit") @DefaultValue("-1") int numRegions,
       @QueryParam("time") @DefaultValue("now") String time) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     try {
       if (!initializePruningDebug(responder)) {
         return;
@@ -306,6 +322,7 @@ public class TransactionHttpHandler extends AbstractAppFabricHttpHandler {
   public void getRegionsToBeCompacted(HttpRequest request, HttpResponder responder,
       @QueryParam("limit") @DefaultValue("-1") int numRegions,
       @QueryParam("time") @DefaultValue("now") String time) {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.GET);
     try {
       if (!initializePruningDebug(responder)) {
         return;


### PR DESCRIPTION
## Summary

`TransactionHttpHandler` exposes 12 transaction management endpoints on the external AppFabric router (port 11015) without any authorization enforcement. Sibling handlers on the same router (`ConfigHandler`, `MonitorHandler`) correctly call `contextAccessEnforcer.enforce()` on every endpoint.

This adds `ContextAccessEnforcer` checks to all 12 endpoints:
- **GET** endpoints → `StandardPermission.GET`
- **POST** endpoints (invalidate, reset, truncate, prune) → `StandardPermission.UPDATE`

## Inconsistency addressed

| Handler | Operation | Auth Check |
|---------|-----------|------------|
| ConfigHandler | GET system config | `enforce(InstanceId.SELF, GET)` ✓ |
| MonitorHandler | Restart service | `enforce(systemServiceId, UPDATE)` ✓ |
| TransactionHttpHandler | Reset ALL tx state | **NONE** ✗ (before this PR) |

## Changes

- Added `ContextAccessEnforcer` dependency via constructor injection
- Added `enforce()` calls to all 12 handler methods
- Follows the exact same pattern as `ConfigHandler` and `MonitorHandler`