### PR TITLE
Fix security vulnerabilities introduced by io.kubernetes:client-java:16.0.2

### DIFF
--- a/cdap-credential-ext-gcp-wi/pom.xml
+++ b/cdap-credential-ext-gcp-wi/pom.xml
@@ -54,6 +54,34 @@
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
       <version>${k8s.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bitbucket.b_c</groupId>
+          <artifactId>jose4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Fixes CVE-2021-35515, CVE-2023-31582, CVE-2024-47554 -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>${bitbucket.jose4j.version}</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -68,6 +68,34 @@
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
       <version>${k8s.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bitbucket.b_c</groupId>
+          <artifactId>jose4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Fixes CVE-2021-35515, CVE-2023-31582, CVE-2024-47554 -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>${bitbucket.jose4j.version}</version>
     </dependency>
     <dependency>
       <groupId>io.kubernetes</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,9 @@
     <cdap.client.version>1.4.0</cdap.client.version>
     <commons.cli.version>1.2</commons.cli.version>
     <commons.collections.version>3.2.2</commons.collections.version>
-    <commons.compress.version>1.22</commons.compress.version>
+    <commons.io.version>2.15.1</commons.io.version>
+    <commons.compress.version>1.26.1</commons.compress.version>
+    <bitbucket.jose4j.version>0.9.3</bitbucket.jose4j.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <dropwizard.version>3.1.2</dropwizard.version>
     <fastutil.version>6.5.6</fastutil.version>
@@ -206,6 +208,16 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jul-to-slf4j</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons.io.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>${commons.compress.version}</version>
       </dependency>
       <dependency>
         <groupId>io.cdap.common</groupId>


### PR DESCRIPTION
### Fixes vulnerabilities 

CVE-2021-35515
CVE-2023-31582
CVE-2024-47554

### Before
```
[INFO] +- io.kubernetes:client-java:jar:16.0.2:compile
[INFO] |  +- io.prometheus:simpleclient:jar:0.15.0:compile
[INFO] |  |  +- io.prometheus:simpleclient_tracer_otel:jar:0.15.0:compile
[INFO] |  |  |  \- io.prometheus:simpleclient_tracer_common:jar:0.15.0:compile
[INFO] |  |  \- io.prometheus:simpleclient_tracer_otel_agent:jar:0.15.0:compile
[INFO] |  +- io.prometheus:simpleclient_httpserver:jar:0.15.0:compile
[INFO] |  |  \- io.prometheus:simpleclient_common:jar:0.15.0:compile
[INFO] |  +- io.kubernetes:client-java-api:jar:16.0.2:compile
[INFO] |  |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] |  |  +- io.swagger:swagger-annotations:jar:1.6.6:compile
[INFO] |  |  \- io.gsonfire:gson-fire:jar:1.8.5:compile
[INFO] |  +- io.kubernetes:client-java-proto:jar:16.0.2:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.33:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.22:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  +- commons-io:commons-io:jar:2.11.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.15:compile
[INFO] |  +- org.bouncycastle:bcpkix-jdk18on:jar:1.71:compile
[INFO] |  |  +- org.bouncycastle:bcprov-jdk18on:jar:1.71:compile
[INFO] |  |  \- org.bouncycastle:bcutil-jdk18on:jar:1.71:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.21.2:compile
[INFO] |  +- org.apache.commons:commons-collections4:jar:4.4:compile
[INFO] |  \- org.bitbucket.b_c:jose4j:jar:0.7.12:compile
```

### After
```
[INFO] +- io.kubernetes:client-java:jar:16.0.2:compile
[INFO] |  +- io.prometheus:simpleclient:jar:0.15.0:compile
[INFO] |  |  +- io.prometheus:simpleclient_tracer_otel:jar:0.15.0:compile
[INFO] |  |  |  \- io.prometheus:simpleclient_tracer_common:jar:0.15.0:compile
[INFO] |  |  \- io.prometheus:simpleclient_tracer_otel_agent:jar:0.15.0:compile
[INFO] |  +- io.prometheus:simpleclient_httpserver:jar:0.15.0:compile
[INFO] |  |  \- io.prometheus:simpleclient_common:jar:0.15.0:compile
[INFO] |  +- io.kubernetes:client-java-api:jar:16.0.2:compile
[INFO] |  |  +- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] |  |  +- io.swagger:swagger-annotations:jar:1.6.6:compile
[INFO] |  |  \- io.gsonfire:gson-fire:jar:1.8.5:compile
[INFO] |  +- io.kubernetes:client-java-proto:jar:16.0.2:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.33:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.26.1:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  +- commons-io:commons-io:jar:2.14.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.15:compile
[INFO] |  +- org.bouncycastle:bcpkix-jdk18on:jar:1.71:compile
[INFO] |  |  +- org.bouncycastle:bcprov-jdk18on:jar:1.71:compile
[INFO] |  |  \- org.bouncycastle:bcutil-jdk18on:jar:1.71:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.21.2:compile
[INFO] |  +- org.apache.commons:commons-collections4:jar:4.4:compile
[INFO] |  \- org.bitbucket.b_c:jose4j:jar:0.9.3:compile
```

### Testing 
- Unit tests
- Distributed docker image
