### PR TITLE
[CDAP-21237] Upgrade commons-configuration2 version to fix vulnerability in cdap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.compress.version>1.22</commons.compress.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
+    <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <dropwizard.version>3.1.2</dropwizard.version>
     <fastutil.version>6.5.6</fastutil.version>
     <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
@@ -182,6 +183,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>${commons-configuration2.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
Need to fix  language package vulnerabilities in lib directory by upgrading commons-configuration2 version.

Before making the fix, checking dependency tree:

```
mvn dependency:tree -Dincludes=org.apache.commons:commons-configuration2 -pl cdap-common
...
[INFO] --- dependency:3.7.0:tree (default-cli) @ cdap-common ---
[INFO] io.cdap.cdap:cdap-common:jar:6.12.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-common:jar:3.3.6:compile
[INFO]    \- org.apache.commons:commons-configuration2:jar:2.8.0:compile
```

After making the fix, checking mvn dependency tree: ` mvn dependency:tree -Dincludes=org.apache.commons:commons-configuration2 -pl cdap-common`

```
[INFO] --- dependency:3.7.0:tree (default-cli) @ cdap-common ---
[INFO] io.cdap.cdap:cdap-common:jar:6.12.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-common:jar:3.3.6:compile
[INFO]    \- org.apache.commons:commons-configuration2:jar:2.10.1:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
```

Checked the commons-configuration2 version across all modules and it has been upgraded to commons-configuration2:jar:2.10.1

After running `mvn clean package` checking the lib directory:
```
~/cdap/cdap-master/target/stage-packaging/opt/cdap/master/lib$ pwd
/usr/local/google/home/adrikagupta/cdap/cdap-master/target/stage-packaging/opt/cdap/master/lib
~/cdap/cdap-master/target/stage-packaging/opt/cdap/master/lib$ ls | grep "commons-config"
org.apache.commons.commons-configuration2-2.10.1.jar
```

Testing:
- Created an image with the fix and integrated it to an instance. Successfully deployed and ran quickstart pipeline.