### PR TITLE
[CDAP-21237] Exclude commons-configuration2 package from hadoop-common library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,6 +617,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
           </exclusion>


### PR DESCRIPTION
Need to fix  language package vulnerabilities in lib directory for commons-configuration2 dependency.

Before making the fix, checking dependency tree:

```
mvn dependency:tree -Dincludes=org.apache.commons:commons-configuration2 -pl cdap-common
...
[INFO] --- dependency:3.7.0:tree (default-cli) @ cdap-common ---
[INFO] io.cdap.cdap:cdap-common:jar:6.12.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-common:jar:3.3.6:compile
[INFO]    \- org.apache.commons:commons-configuration2:jar:2.8.0:compile
```

After making the fix, checking mvn dependency tree: ` mvn dependency:tree -Dincludes=org.apache.commons:commons-configuration2 -pl cdap-common`

```
[INFO] --- dependency:3.7.0:tree (default-cli) @ cdap-common ---
[INFO] io.cdap.cdap:cdap-common:jar:6.12.0-SNAPSHOT
[INFO] \- org.apache.hadoop:hadoop-minicluster:jar:3.3.6:test
[INFO]    \- org.apache.hadoop:hadoop-common:test-jar:tests:3.3.6:test
[INFO]       \- org.apache.commons:commons-configuration2:jar:2.8.0:test
[INFO] ------------------------------------------------------------------------
```
Here org.apache.commons:commons-configuration2:jar:2.8.0 is being brought in under the test scope. Dependencies in the test scope are only available for compiling and running tests. They are not included in the final packaged artifact (the JAR inside /lib). They are not transitive for compile or runtime scopes.


After running `mvn clean package` checking the lib directory:
```
.../lib$ ls | grep "commons-config"
.../lib$
```

Testing:
- Created an image with the fix and integrated it to an instance. Successfully deployed and ran quickstart pipeline. Also preview run was successful as well.