### PR TITLE
CDAP-21212 : Preview run fails with private module in Java 11 - Exclude from gson

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultDataTracer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultDataTracer.java
@@ -36,6 +36,20 @@ class DefaultDataTracer implements DataTracer {
 
   private static final Gson GSON = new GsonBuilder().registerTypeAdapter(Schema.class,
           new SchemaTypeAdapter())
+      .setExclusionStrategies(new com.google.gson.ExclusionStrategy() {
+        @Override
+        public boolean shouldSkipField(com.google.gson.FieldAttributes f) {
+          return false;
+        }
+
+        @Override
+        public boolean shouldSkipClass(Class<?> clazz) {
+          String name = clazz.getName();
+          return name.startsWith("java.lang.module") ||
+              name.startsWith("jdk.internal") ||
+              name.startsWith("sun.");
+        }
+      })
       .registerTypeAdapter(StructuredRecord.class, new PreviewJsonSerializer()).create();
 
   private final String tracerName;


### PR DESCRIPTION
Testing : 

- updated image using the change and preview was success. 
- The CHANGE ONLY LIMITS TO PREVIEW ( not pipeline run )