### PR TITLE
Enforce authorization on the /v3/bootstrap endpoint

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/BootstrapHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/BootstrapHttpHandler.java
@@ -20,6 +20,9 @@ package io.cdap.cdap.gateway.handlers;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.bootstrap.BootstrapService;
+import io.cdap.cdap.proto.id.InstanceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
@@ -34,15 +37,19 @@ import javax.ws.rs.Path;
 public class BootstrapHttpHandler extends AbstractHttpHandler {
 
   private final BootstrapService bootstrapService;
+  private final ContextAccessEnforcer contextAccessEnforcer;
 
   @Inject
-  BootstrapHttpHandler(BootstrapService bootstrapService) {
+  BootstrapHttpHandler(BootstrapService bootstrapService,
+      ContextAccessEnforcer contextAccessEnforcer) {
     this.bootstrapService = bootstrapService;
+    this.contextAccessEnforcer = contextAccessEnforcer;
   }
 
   @POST
   @Path("/bootstrap")
   public void bootstrap(HttpRequest request, HttpResponder responder) throws InterruptedException {
+    contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE);
     bootstrapService.reload();
     bootstrapService.bootstrap();
     responder.sendStatus(HttpResponseStatus.OK);


### PR DESCRIPTION
## Summary

`BootstrapHttpHandler` currently exposes `POST /v3/bootstrap` without consulting any authorization service. Any authenticated CDAP user can therefore trigger `BootstrapService.reload()` followed by `BootstrapService.bootstrap()`, which reloads the bootstrap configuration and re-runs every bootstrap step (system application redeploy, capability management, system program restart).

This PR brings the handler in line with the pattern already used by sibling instance-level handlers such as `ConfigHandler` and `MonitorHandler`: inject `ContextAccessEnforcer` and enforce `InstanceId.SELF` / `StandardPermission.UPDATE` before executing the bootstrap workflow.

## Changes

- `cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/BootstrapHttpHandler.java`
  - Add imports for `InstanceId`, `StandardPermission`, and `ContextAccessEnforcer`.
  - Add a `ContextAccessEnforcer` field and constructor parameter (`@Inject`-wired, same as `ConfigHandler`).
  - Call `contextAccessEnforcer.enforce(InstanceId.SELF, StandardPermission.UPDATE)` at the top of `bootstrap(...)`.

Guice bindings in `AppFabricServiceRuntimeModule` are unchanged — `ContextAccessEnforcer` is already a singleton there and is auto-resolved into the new constructor parameter.

## Testing

- Pattern mirrors `ConfigHandler` / `MonitorHandler` / `ArtifactHttpHandler` exactly, all of which rely on the same `ContextAccessEnforcer` injection model.
- No behavioral change for an authorized caller; unauthorized callers now receive the standard `UnauthorizedException` response from `ContextAccessEnforcer.enforce(...)`.