### PR TITLE
Enforce system-app authorization on OAuth provider endpoints

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -36,6 +36,10 @@ import io.cdap.cdap.datapipeline.oauth.OAuthStoreException;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthCredentialRequest;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthProviderRequest;
 import io.cdap.cdap.datapipeline.oauth.RefreshTokenResponse;
+import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
@@ -71,11 +75,25 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     .create();
 
   private OAuthStore oauthStore;
+  private ContextAccessEnforcer contextAccessEnforcer;
 
   @Override
   public void initialize(SystemHttpServiceContext context) throws Exception {
     super.initialize(context);
     this.oauthStore = new OAuthStore(context, context, context.getAdmin());
+    this.contextAccessEnforcer = context.getContextAccessEnforcer();
+  }
+
+  /**
+   * OAuth providers and credentials are a cluster-wide resource managed by the
+   * data pipeline system app. Gate every endpoint on the caller having the
+   * matching permission on the system-app parent in the system namespace, so
+   * only users authorized to administer system apps can list, read, create,
+   * update or delete OAuth providers and credentials.
+   */
+  private void enforceSystemAppPermission(StandardPermission permission) {
+    contextAccessEnforcer.enforceOnParent(
+        EntityType.SYSTEM_APP_ENTITY, NamespaceId.SYSTEM, permission);
   }
 
   @GET
@@ -85,6 +103,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                          @QueryParam("redirect_uri") String redirectURI,
                          @QueryParam("redirect_url") String redirectURL) {
     try {
+      enforceSystemAppPermission(StandardPermission.GET);
       OAuthProvider oauthProvider = getProvider(provider);
 
       String formatURL = "%s";
@@ -116,6 +135,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                @QueryParam("reuse_client_credentials") @DefaultValue("false")
                                Boolean reuseClientCredentials) {
     try {
+      enforceSystemAppPermission(StandardPermission.UPDATE);
       try {
         PutOAuthProviderRequest putOAuthProviderRequest = GSON.fromJson(
             StandardCharsets.UTF_8.decode(request.getContent()).toString(),
@@ -163,6 +183,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
   public void deleteOAuthProvider(HttpServiceRequest request, HttpServiceResponder responder,
                                @PathParam("provider") String oauthProvider) {
     try {
+      enforceSystemAppPermission(StandardPermission.DELETE);
       try {
         oauthStore.deleteProvider(oauthProvider);
         responder.sendStatus(HttpURLConnection.HTTP_OK);
@@ -182,6 +203,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                  @PathParam("provider") String provider,
                                  @PathParam("credential") String credentialId) {
     try {
+      enforceSystemAppPermission(StandardPermission.UPDATE);
       PutOAuthCredentialRequest putOAuthCredentialRequest;
       try {
         putOAuthCredentialRequest = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
@@ -291,6 +313,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                  @PathParam("provider") String provider,
                                  @PathParam("credential") String credentialId) {
     try {
+      enforceSystemAppPermission(StandardPermission.GET);
       OAuthProvider oauthProvider = getProvider(provider);
       Optional<OAuthAccessToken> oAuthAccessToken = getAccessToken(provider, credentialId);
 
@@ -371,6 +394,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                          @PathParam("provider") String provider,
                                          @PathParam("credential") String credentialId) {
     try {
+      enforceSystemAppPermission(StandardPermission.GET);
       OAuthProvider oauthProvider = getProvider(provider);
       Optional<OAuthAccessToken> oAuthAccessToken = getAccessToken(provider, credentialId);
 


### PR DESCRIPTION
## Summary

The data pipeline `StudioService`'s `OAuthHandler` exposes PUT/DELETE/GET endpoints for managing OAuth providers and stored credentials under `v1/oauth/provider/...`. OAuth providers are a cluster-wide resource — the stored `loginURL`, `tokenRefreshURL`, and client credentials are shared across the instance — but the handler previously performed no authorization check beyond the CDAP baseline, so any authenticated user of the instance could register, modify, delete or fetch OAuth providers and their credentials.

This PR wires the existing `ContextAccessEnforcer` from the `SystemHttpServiceContext` and gates every endpoint on `enforceOnParent(SYSTEM_APP_ENTITY, SYSTEM, permission)`:

- Read endpoints (`getAuthURL`, `getOAuthCredential`, `getOAuthCredentialValidity`) enforce `StandardPermission.GET`.
- Mutating endpoints (`putOAuthProvider`, `putOAuthCredential`) enforce `StandardPermission.UPDATE`.
- `deleteOAuthProvider` enforces `StandardPermission.DELETE`.

After this change, only users with system-app administration permissions in the system namespace can call these endpoints.

This mirrors the `ContextAccessEnforcer` usage already adopted by `ConnectionHandler` and `DraftHandler` in the same module.

## Test plan

- [ ] Existing `data-pipeline-base` tests still pass.
- [ ] Manual check: with authorization enabled, a user who holds system-app permissions in the system namespace can PUT/GET/DELETE an OAuth provider as before.
- [ ] Manual check: a user without those permissions receives a 403 from the same endpoints.