### PR TITLE
Require a process-local shared token on sidecar context endpoints

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.utils.SidecarAuthToken;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import io.cdap.http.NettyHttpService;
 import java.net.InetAddress;
@@ -56,6 +57,10 @@ public class ArtifactLocalizerService extends AbstractIdleService {
       RemoteClientFactory remoteClientFactory, RemoteAuthenticator remoteAuthenticator) {
     this.cConf = cConf;
     this.artifactLocalizer = artifactLocalizer;
+    // Install a fresh process-local shared token for the sidecar's
+    // context-management endpoints before the HTTP service is built, so
+    // that the handler observes a non-null token for every inbound request.
+    SidecarAuthToken.installIfAbsent();
     this.httpService = commonNettyHttpServiceFactory.builder(Constants.Service.TASK_WORKER, false)
         .setHost(InetAddress.getLoopbackAddress().getHostName())
         .setPort(cConf.getInt(Constants.ArtifactLocalizer.PORT))

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.utils.SidecarAuthToken;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.namespace.credential.RemoteNamespaceCredentialProvider;
 import io.cdap.cdap.proto.BasicThrowable;
@@ -230,12 +231,27 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
   @PUT
   @Path("/set-context")
   public void setContext(FullHttpRequest request, HttpResponder responder)
-      throws BadRequestException {
+      throws BadRequestException, ForbiddenException {
+    requireSidecarAuthToken(request);
     this.gcpMetadataTaskContext = getGcpMetadataTaskContext(request);
     this.gcpWorkloadIdentityInternalAuthenticator.setGcpMetadataTaskContext(gcpMetadataTaskContext);
     responder.sendJson(HttpResponseStatus.OK,
         String.format("Context was set successfully with namespace '%s'.",
             gcpMetadataTaskContext.getNamespace()));
+  }
+
+  /**
+   * Rejects context-management calls that are missing the process-local
+   * shared token installed by the sidecar service at startup. The token is
+   * generated once per JVM and only the framework components that install it
+   * can produce matching requests.
+   */
+  private void requireSidecarAuthToken(HttpRequest request) throws ForbiddenException {
+    String supplied = request.headers().get(SidecarAuthToken.HEADER);
+    if (!SidecarAuthToken.matches(supplied)) {
+      throw new ForbiddenException(
+          "Request is missing a valid task worker sidecar auth token.");
+    }
   }
 
   /**
@@ -246,7 +262,9 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
    */
   @DELETE
   @Path("/clear-context")
-  public void clearContext(HttpRequest request, HttpResponder responder) {
+  public void clearContext(HttpRequest request, HttpResponder responder)
+      throws ForbiddenException {
+    requireSidecarAuthToken(request);
     this.gcpMetadataTaskContext = null;
     this.gcpWorkloadIdentityInternalAuthenticator.setGcpMetadataTaskContext(gcpMetadataTaskContext);
     this.credentialLoadingCache.invalidateAll();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
+import io.cdap.cdap.common.utils.SidecarAuthToken;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -62,6 +63,10 @@ public class GcpMetadataHttpHandlerInternalTest {
   public static void init() throws Exception {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    // Install the process-local sidecar token the handler will use to gate
+    // the context-management endpoints.
+    SidecarAuthToken.installIfAbsent();
 
     NamespaceAdmin namespaceAdmin = new InMemoryNamespaceAdmin();
     namespaceAdmin.create(NamespaceMeta.SYSTEM);
@@ -114,19 +119,32 @@ public class GcpMetadataHttpHandlerInternalTest {
         new GcpMetadataTaskContext(namespaceId.getNamespace(),
             "alice", "0.0.0.0", null);
 
-    // set context
+    String token = SidecarAuthToken.get();
+
+    // set context without the sidecar auth token is rejected
     URL url = new URL(String.format("%s/set-context", endpoint));
     HttpRequest httpRequest = HttpRequest.put(url).withBody(GSON.toJson(gcpMetadataTaskContext,
         GcpMetadataTaskContext.class)).build();
     HttpResponse httpResponse = HttpRequests.execute(httpRequest);
+    Assert.assertEquals(403, httpResponse.getResponseCode());
+
+    // set context with the sidecar auth token succeeds
+    httpRequest = HttpRequest.put(url).withBody(GSON.toJson(gcpMetadataTaskContext,
+        GcpMetadataTaskContext.class)).addHeader(SidecarAuthToken.HEADER, token).build();
+    httpResponse = HttpRequests.execute(httpRequest);
     Assert.assertEquals(200, httpResponse.getResponseCode());
     String expectedResponse = String.format("Context was set successfully with namespace '%s'.",
         namespaceId.getNamespace());
     Assert.assertEquals(expectedResponse, httpResponse.getResponseBodyAsString());
 
-    //clear context
+    // clear context without the sidecar auth token is rejected
     url = new URL(String.format("%s/clear-context", endpoint));
     httpRequest = HttpRequest.delete(url).build();
+    httpResponse = HttpRequests.execute(httpRequest);
+    Assert.assertEquals(403, httpResponse.getResponseCode());
+
+    // clear context with the sidecar auth token succeeds
+    httpRequest = HttpRequest.delete(url).addHeader(SidecarAuthToken.HEADER, token).build();
     httpResponse = HttpRequests.execute(httpRequest);
     Assert.assertEquals(200, httpResponse.getResponseCode());
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/GcpMetadataTaskContextUtil.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/GcpMetadataTaskContextUtil.java
@@ -71,11 +71,15 @@ public final class GcpMetadataTaskContextUtil {
         SecurityRequestContext.getUserCredential());
     String setContextEndpoint = String.format("%s/set-context",
         getSidecarMetadataServiceEndpoint(cConf));
-    HttpRequest httpRequest =
+    HttpRequest.Builder setContextBuilder =
         HttpRequest.put(new URL(setContextEndpoint))
             .withBody(GSON.toJson(gcpMetadataTaskContext))
-            .addHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-            .build();
+            .addHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+    String sidecarToken = SidecarAuthToken.get();
+    if (sidecarToken != null) {
+      setContextBuilder.addHeader(SidecarAuthToken.HEADER, sidecarToken);
+    }
+    HttpRequest httpRequest = setContextBuilder.build();
     HttpResponse tokenResponse = HttpRequests.execute(httpRequest);
     LOG.debug("Set namespace '{}' response: {}", namespaceId.getNamespace(),
         tokenResponse.getResponseCode());
@@ -93,7 +97,13 @@ public final class GcpMetadataTaskContextUtil {
     }
     String clearContextEndpoint = String.format("%s/clear-context",
         getSidecarMetadataServiceEndpoint(cConf));
-    HttpRequest httpRequest = HttpRequest.delete(new URL(clearContextEndpoint)).build();
+    HttpRequest.Builder clearContextBuilder =
+        HttpRequest.delete(new URL(clearContextEndpoint));
+    String sidecarToken = SidecarAuthToken.get();
+    if (sidecarToken != null) {
+      clearContextBuilder.addHeader(SidecarAuthToken.HEADER, sidecarToken);
+    }
+    HttpRequest httpRequest = clearContextBuilder.build();
     HttpResponse tokenResponse = HttpRequests.execute(httpRequest);
     LOG.debug("Clear context response: {}", tokenResponse.getResponseCode());
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/SidecarAuthToken.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/SidecarAuthToken.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.utils;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Process-local shared bearer token used by the task worker sidecar to
+ * correlate legitimate in-process callers with its context-management
+ * endpoints (e.g. {@code /set-context}, {@code /clear-context}).
+ *
+ * <p>The sidecar HTTP service is bound to loopback and was previously
+ * reachable by any code able to make an HTTP request to the loopback port,
+ * including anything co-resident in the same JVM. The token is generated
+ * once per JVM before the sidecar starts accepting connections and is
+ * required on every call to the context-management endpoints. Only the
+ * framework components that install the token can produce matching
+ * requests, so an HTTP caller that does not know the token is rejected
+ * before it can change the sidecar's per-task context.
+ *
+ * <p>The token is a 256-bit random value and is compared in constant time.
+ */
+public final class SidecarAuthToken {
+
+  /**
+   * HTTP header name clients must send with the token on context-management
+   * endpoints.
+   */
+  public static final String HEADER = "X-CDAP-Sidecar-Auth";
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static volatile String token;
+
+  private SidecarAuthToken() {
+  }
+
+  /**
+   * Generates and installs a fresh random token if one has not already been
+   * installed for this JVM. Returns the current token either way.
+   *
+   * <p>Intended to be called once at sidecar startup before the HTTP service
+   * begins accepting requests. Subsequent calls are no-ops so that components
+   * that initialize independently observe the same value.
+   */
+  public static synchronized String installIfAbsent() {
+    if (token == null) {
+      byte[] bytes = new byte[32];
+      RANDOM.nextBytes(bytes);
+      token = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+    return token;
+  }
+
+  /**
+   * Returns the current token, or {@code null} if none has been installed
+   * (e.g. when the sidecar is not running in this JVM). Callers that receive
+   * {@code null} should treat the token header as unavailable rather than
+   * sending an empty string.
+   */
+  public static String get() {
+    return token;
+  }
+
+  /**
+   * Constant-time comparison between a candidate token supplied by a caller
+   * and the installed token. Returns {@code false} if either value is
+   * {@code null} or if the lengths or contents differ.
+   */
+  public static boolean matches(String candidate) {
+    String expected = token;
+    if (expected == null || candidate == null) {
+      return false;
+    }
+    byte[] a = expected.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    byte[] b = candidate.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    if (a.length != b.length) {
+      return false;
+    }
+    int diff = 0;
+    for (int i = 0; i < a.length; i++) {
+      diff |= a[i] ^ b[i];
+    }
+    return diff == 0;
+  }
+}


### PR DESCRIPTION
## Summary

The task worker sidecar `ArtifactLocalizerService` exposes `PUT /set-context` and `DELETE /clear-context` endpoints that mutate the per-task namespace context the `GcpMetadataHttpHandlerInternal` uses to look up credentials. The HTTP service is bound to loopback, but was previously reachable by any code able to make a loopback HTTP request — including anything co-resident in the same JVM. The endpoints performed no authentication, so any such caller could reset the sidecar's context freely.

This PR introduces a process-local shared token (`SidecarAuthToken`) that `ArtifactLocalizerService` installs once at startup before the HTTP service begins accepting connections. Both context-management endpoints now require the token on an `X-CDAP-Sidecar-Auth` header and compare it in constant time; requests without a matching token receive a 403. The legitimate in-process caller `GcpMetadataTaskContextUtil` reads the same token and attaches the header on its set/clear calls, so normal framework flows keep working while unauthenticated loopback callers are rejected before they can touch the sidecar's context.

## Changes

- New `SidecarAuthToken` in `io.cdap.cdap.common.utils`: installs a 256-bit random value once per JVM, exposes a constant-time `matches()` helper.
- `ArtifactLocalizerService` calls `SidecarAuthToken.installIfAbsent()` in its constructor before building the Netty HTTP service.
- `GcpMetadataHttpHandlerInternal.setContext` / `clearContext` now call a new private `requireSidecarAuthToken()` helper that throws `ForbiddenException` when the header is missing or does not match.
- `GcpMetadataTaskContextUtil.setGcpMetadataTaskContext` / `clearGcpMetadataTaskContext` attach the token header when one is installed.
- `GcpMetadataHttpHandlerInternalTest.testSetAndClearContext` is extended to cover both the unauthenticated (403) and authenticated (200) paths.

## Test plan

- [ ] `mvn test -pl cdap-app-fabric -am -Dtest=GcpMetadataHttpHandlerInternalTest` passes locally.
- [ ] Manual check: the sidecar rejects a `curl -X PUT http://127.0.0.1:<port>/set-context` without the token header with 403.
- [ ] Manual check: a task worker running the normal framework flow still succeeds in setting and clearing context.