### PR TITLE
[CDAP-21240] Optimize getAllApps artifact filtering to avoid unnecessary DB queries

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -373,8 +373,9 @@ public class AppMetadataStore {
             e -> ((ApplicationFilter.ApplicationIdFilter) filter).test(e.getKey()));
       } else if (filter instanceof ApplicationFilter.ArtifactIdFilter) {
         scanEntryPredicate = scanEntryPredicate.and(
-            e -> ((ApplicationFilter.ArtifactIdFilter) filter).test(
-                e.getValue().getSpec().getArtifactId()));
+            e -> e.getArtifactId()
+                .map(((ApplicationFilter.ArtifactIdFilter) filter)::test)
+                .orElse(false));
       } else {
         throw new UnsupportedOperationException(
             "Application filter " + filter + " is not supported");
@@ -3135,6 +3136,9 @@ public class AppMetadataStore {
 
   private static final class AppScanEntry implements Map.Entry<ApplicationId, ApplicationMeta> {
 
+    private static final String SPEC_KEY = "spec";
+    private static final String ARTIFACT_ID_KEY = "artifactId";
+
     private final ApplicationId appId;
     private final String rawAppMeta;
     private volatile ApplicationMeta appMeta;
@@ -3145,6 +3149,7 @@ public class AppMetadataStore {
     private final StructuredTable pluginDataTable;
     private final StructuredTable universalPluginDataTable;
     private final boolean appSpecReductionEnabled;
+    private ArtifactId artifactId;
 
     private AppScanEntry(StructuredRow row, StructuredTable pluginDataTable,
         StructuredTable universalPluginDataTable, boolean appSpecReductionEnabled) {
@@ -3186,6 +3191,46 @@ public class AppMetadataStore {
       appMeta = meta = new ApplicationMeta(tempMeta.getId(), tempMeta.getSpec(), changeDetail,
           sourceControlMeta);
       return meta;
+    }
+
+    /**
+     * Fast-path method to extract the {@link ArtifactId} from the raw application metadata JSON.
+     * This avoids full deserialization of the application specification and loading of plugins,
+     * which is expensive.
+     *
+     * @return the {@link ArtifactId} if found, or empty if not found or parsing fails.
+     */
+    public Optional<ArtifactId> getArtifactId() {
+      ArtifactId id = artifactId;
+      if (id != null) {
+        return Optional.of(id);
+      }
+
+      try (JsonReader reader = new JsonReader(new StringReader(rawAppMeta))) {
+        reader.beginObject();
+
+        while (reader.hasNext()) {
+          if (SPEC_KEY.equals(reader.nextName())) {
+            reader.beginObject();
+            while (reader.hasNext()) {
+              if (ARTIFACT_ID_KEY.equals(reader.nextName())) {
+                id = GSON.fromJson(reader, ArtifactId.class);
+                artifactId = id;
+                return Optional.of(id);
+              } else {
+                reader.skipValue();
+              }
+            }
+            break;
+          } else {
+            reader.skipValue();
+          }
+        }
+      } catch (IOException | IllegalStateException e) {
+        throw new IllegalStateException("Failed to parse artifact ID from app meta", e);
+      }
+
+      return Optional.empty();
     }
 
     @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.api.workflow.ScheduleProgramInfo;
 import io.cdap.cdap.api.workflow.WorkflowActionNode;
 import io.cdap.cdap.api.workflow.WorkflowNode;
 import io.cdap.cdap.api.workflow.WorkflowSpecification;
+import io.cdap.cdap.app.store.ApplicationFilter;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.utils.ProjectInfo;
@@ -1182,7 +1183,185 @@ public abstract class AppMetadataStoreTest {
     Assert.assertEquals(count, apps.size());
   }
 
-    @Test
+  @Test
+  public void testScanApplicationsWithArtifactFilter() {
+    ArtifactId artifactId1 = NamespaceId.DEFAULT.artifact("artifact1", "1.0").toApiArtifactId();
+    ArtifactId artifactId2 = NamespaceId.DEFAULT.artifact("artifact2", "1.0").toApiArtifactId();
+
+    ApplicationSpecification spec1 = createDummyAppSpec("app1", ApplicationId.DEFAULT_VERSION,
+        artifactId1);
+    ApplicationSpecification spec2 = createDummyAppSpec("app2", ApplicationId.DEFAULT_VERSION,
+        artifactId2);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      store.writeApplication(NamespaceId.DEFAULT.getNamespace(), "app1",
+          ApplicationId.DEFAULT_VERSION, spec1,
+          new ChangeDetail(null, null, null, creationTimeMillis), null);
+      store.writeApplication(NamespaceId.DEFAULT.getNamespace(), "app2",
+          ApplicationId.DEFAULT_VERSION, spec2,
+          new ChangeDetail(null, null, null, creationTimeMillis), null);
+    });
+
+    Map<ApplicationId, ApplicationMeta> apps = new LinkedHashMap<>();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      ApplicationFilter filter = new ApplicationFilter.ArtifactNamesInFilter(
+          Collections.singleton("artifact1"));
+      store.scanApplications(ScanApplicationsRequest.builder()
+              .setNamespaceId(NamespaceId.DEFAULT)
+              .addFilters(Collections.singletonList(filter))
+              .build(),
+          entry -> {
+            apps.put(entry.getKey(), entry.getValue());
+            return true;
+          });
+    });
+
+    Assert.assertEquals(1, apps.size());
+    Assert.assertTrue(apps.containsKey(NamespaceId.DEFAULT.app("app1")));
+  }
+
+  @Test
+  public void testScanApplicationsWithArtifactFilterCoverage() {
+    ArtifactId artifactId1 = NamespaceId.DEFAULT.artifact("artifact1", "1.0").toApiArtifactId();
+    ApplicationSpecification spec1 = createDummyAppSpec("app1", ApplicationId.DEFAULT_VERSION,
+        artifactId1);
+
+    // 1. Test Cached Value (Multiple filters)
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      store.writeApplication(NamespaceId.DEFAULT.getNamespace(), "app1",
+          ApplicationId.DEFAULT_VERSION, spec1,
+          new ChangeDetail(null, null, null, creationTimeMillis), null);
+    });
+
+    Map<ApplicationId, ApplicationMeta> apps = new LinkedHashMap<>();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      ApplicationFilter filter1 = new ApplicationFilter.ArtifactNamesInFilter(
+          Collections.singleton("artifact1"));
+      ApplicationFilter filter2 = new ApplicationFilter.ArtifactNamesInFilter(
+          Collections.singleton("artifact1"));
+      store.scanApplications(ScanApplicationsRequest.builder()
+              .setNamespaceId(NamespaceId.DEFAULT)
+              .addFilters(Arrays.asList(filter1, filter2))
+              .build(),
+          entry -> {
+            apps.put(entry.getKey(), entry.getValue());
+            return true;
+          });
+    });
+    Assert.assertEquals(1, apps.size());
+
+    // 2. Test Skip Value in Inner Loop (JSON with other fields in spec)
+    ArtifactId artifactId2 = NamespaceId.DEFAULT.artifact("artifact2", "1.0").toApiArtifactId();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      StructuredTable table = context.getTable(
+          StoreDefinition.AppMetadataStore.APPLICATION_SPECIFICATIONS);
+      List<Field<?>> keys = store.getApplicationPrimaryKeys(NamespaceId.DEFAULT.getNamespace(),
+          "app2", ApplicationId.DEFAULT_VERSION);
+      Gson gson = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+      String artifactJson = gson.toJson(artifactId2);
+      String rawMeta = "{\"spec\":{\"otherField\":\"value\",\"artifactId\":" + artifactJson + "}}";
+      keys.add(
+          Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD, rawMeta));
+      keys.add(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
+      table.upsert(keys);
+    });
+
+    AtomicInteger count = new AtomicInteger();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      ApplicationFilter filter = new ApplicationFilter.ArtifactNamesInFilter(
+          Collections.singleton("artifact2"));
+      store.scanApplications(ScanApplicationsRequest.builder()
+              .setNamespaceId(NamespaceId.DEFAULT)
+              .addFilters(Collections.singletonList(filter))
+              .build(),
+          entry -> {
+            count.incrementAndGet();
+            Assert.assertEquals(NamespaceId.DEFAULT.app("app2"), entry.getKey());
+            return true;
+          });
+    });
+    Assert.assertEquals(1, count.get());
+
+    // 3. Test Artifact Not Found (JSON with empty spec)
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      StructuredTable table = context.getTable(
+          StoreDefinition.AppMetadataStore.APPLICATION_SPECIFICATIONS);
+      List<Field<?>> keys = store.getApplicationPrimaryKeys(NamespaceId.DEFAULT.getNamespace(),
+          "app3", ApplicationId.DEFAULT_VERSION);
+      String rawMeta = "{\"spec\":{}}";
+      keys.add(
+          Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD, rawMeta));
+      keys.add(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
+      table.upsert(keys);
+    });
+
+    count.set(0);
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      ApplicationFilter filter = new ApplicationFilter.ArtifactNamesInFilter(
+          Collections.singleton("artifact3"));
+      store.scanApplications(ScanApplicationsRequest.builder()
+              .setNamespaceId(NamespaceId.DEFAULT)
+              .addFilters(Collections.singletonList(filter))
+              .build(),
+          entry -> {
+            count.incrementAndGet();
+            return true;
+          });
+    });
+    Assert.assertEquals(0, count.get());
+
+    // 4. Test Parsing Exception (Corrupt JSON)
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore store = AppMetadataStore.create(context);
+      StructuredTable table = context.getTable(
+          StoreDefinition.AppMetadataStore.APPLICATION_SPECIFICATIONS);
+      List<Field<?>> keys = store.getApplicationPrimaryKeys(NamespaceId.DEFAULT.getNamespace(),
+          "app4", ApplicationId.DEFAULT_VERSION);
+      String rawMeta = "{\"spec\":\"notAnObject\"}"; // Triggers IllegalStateException in beginObject()
+      keys.add(
+          Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD, rawMeta));
+      keys.add(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
+      table.upsert(keys);
+    });
+
+    try {
+      TransactionRunners.run(transactionRunner, context -> {
+        AppMetadataStore store = AppMetadataStore.create(context);
+        ApplicationFilter filter = new ApplicationFilter.ArtifactNamesInFilter(
+            Collections.singleton("artifact1"));
+        store.scanApplications(ScanApplicationsRequest.builder()
+                .setNamespaceId(NamespaceId.DEFAULT)
+                .addFilters(Collections.singletonList(filter))
+                .build(),
+            entry -> true);
+      });
+      Assert.fail("Expected IllegalStateException");
+    } catch (Exception e) {
+      boolean found = false;
+      Throwable t = e;
+      while (t != null) {
+        if (t instanceof IllegalStateException && t.getMessage()
+            .contains("Failed to parse artifact ID from app meta")) {
+          found = true;
+          break;
+        }
+        t = t.getCause();
+      }
+      Assert.assertTrue(
+          "Expected IllegalStateException with message 'Failed to parse artifact ID from app meta'",
+          found);
+    }
+  }
+
+  @Test
   public void testScanApplicationsReverse() {
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
 


### PR DESCRIPTION
### Problem

When listing applications with an artifactName filter (in getAllApps or similar list operations), CDAP filters rows in memory. Previously, the filter logic called e.getValue().getSpec().getArtifactId() for every application scanned.

This call triggered the full deserialization of the application specification. Because of the "App Spec Reduction" feature, this deserialization triggered additional database queries to load missing plugin details for every application inspected—even those that did not match the filter. In large namespaces with a cold database cache, this caused the API call to take 4 to 5 minutes due to many sequential database queries.

### Solution

- Implemented a fast-path method getArtifactId() in AppScanEntry that uses a streaming JsonReader to extract only the ArtifactId from the raw JSON string without full object reconstruction.
- This prevents triggering the PluginDeserializer and all associated database queries during the scan/filter phase.

### Testing

- Added UT
- 
<img width="2448" height="1810" alt="image" src="https://github.com/user-attachments/assets/d6460ae3-82f7-4638-ad4c-3ba208c88f4f" />
