### PR TITLE
[CDAP-21244] Optimize pipeline listing queries on PostgreSQL using UNION/UNION ALL

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -71,6 +71,7 @@ import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.PreferUnionForDisjunctionOption;
 import io.cdap.cdap.spi.data.table.options.StaleReadOption;
 import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
@@ -415,7 +416,8 @@ public class AppMetadataStore {
       Collection<Field<?>> filterIndexes =
           ImmutableList.of(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true),
               Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null));
-      return table.scan(range, Integer.MAX_VALUE, filterIndexes, sortOrder);
+      return table.scan(range, Integer.MAX_VALUE, filterIndexes, sortOrder,
+          PreferUnionForDisjunctionOption.INSTANCE);
     }
     if (sortCreationTime) {
       // sort on Creation Time

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.QueryOption;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
@@ -204,6 +205,14 @@ public class MetricStructuredTable implements StructuredTable {
       Collection<Field<?>> filterIndexes, SortOrder sortOrder)
       throws InvalidFieldException, IOException {
     return scan(() -> structuredTable.scan(keyRange, limit, filterIndexes, sortOrder),
+        "sort.index.range.scan.");
+  }
+
+  @Override
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
+      Collection<Field<?>> filterIndexes, SortOrder sortOrder, QueryOption... options)
+      throws InvalidFieldException, IOException {
+    return scan(() -> structuredTable.scan(keyRange, limit, filterIndexes, sortOrder, options),
         "sort.index.range.scan.");
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
@@ -29,6 +29,8 @@ import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.FieldValidator;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.PreferUnionForDisjunctionOption;
+import io.cdap.cdap.spi.data.table.options.QueryOption;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -368,8 +370,16 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     return scan(keyRange, limit, filterIndexes, tableSchema.getPrimaryKeys(), sortOrder);
   }
 
+  @Override
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
+      Collection<Field<?>> filterIndexes, SortOrder sortOrder, QueryOption... options)
+      throws InvalidFieldException, IOException {
+    return scan(keyRange, limit, filterIndexes, tableSchema.getPrimaryKeys(), sortOrder, options);
+  }
+
   private CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
-      Collection<Field<?>> filterIndexes, Collection<String> fieldsToSort, SortOrder sortOrder)
+      Collection<Field<?>> filterIndexes, Collection<String> fieldsToSort, SortOrder sortOrder,
+      QueryOption... options)
       throws InvalidFieldException, IOException {
     fieldValidator.validateScanRange(keyRange);
     filterIndexes.forEach(fieldValidator::validateField);
@@ -382,16 +392,33 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     LOG.trace("Table {}: Scan range {} with filterIndexes {} limit {} sortOrder {}",
         tableSchema.getTableId(), keyRange, filterIndexes, limit, sortOrder);
 
-    String scanQuery = getScanIndexesQuery(keyRange, limit, filterIndexes, fieldsToSort, sortOrder);
-    // Since in getScanIndexesQuery we directly set the NULL checks, we need to skip the null fields
-    filterIndexes = filterIndexes.stream().filter(f -> f.getValue() != null)
+    boolean preferUnion =
+        QueryOption.getOption(PreferUnionForDisjunctionOption.class, options).isPresent()
+            && filterIndexes.size() > 1;
+    String scanQuery = preferUnion
+        ? getUnionQuery(keyRange, limit, filterIndexes, fieldsToSort, sortOrder)
+        : getScanIndexesQuery(keyRange, limit, filterIndexes, fieldsToSort, sortOrder);
+    Collection<Field<?>> nonNullFilterIndexes = filterIndexes.stream()
+        .filter(f -> f.getValue() != null)
         .collect(Collectors.toList());
 
     try {
       PreparedStatement statement = connection.prepareStatement(scanQuery);
       statement.setFetchSize(fetchSize);
-      int nextIndex = setStatementFieldByRange(keyRange, statement, 1);
-      setFields(statement, filterIndexes, nextIndex);
+      if (preferUnion) {
+        // Parameter setting for UNION / UNION ALL
+        int nextIndex = 1;
+        for (Field<?> field : filterIndexes) {
+          nextIndex = setStatementFieldByRange(keyRange, statement, nextIndex);
+          if (field.getValue() != null) {
+            setField(statement, field, nextIndex);
+            nextIndex++;
+          }
+        }
+      } else {
+        int nextIndex = setStatementFieldByRange(keyRange, statement, 1);
+        setFields(statement, nonNullFilterIndexes, nextIndex);
+      }
       LOG.trace("SQL statement: {}", statement);
 
       ResultSet resultSet = statement.executeQuery();
@@ -1006,6 +1033,35 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     queryString.append(getOrderByClause(fieldsToSort, sortOrder));
     queryString.append(" LIMIT ").append(limit).append(";");
     return queryString.toString();
+  }
+
+  private String getUnionQuery(Range range, int limit, Collection<Field<?>> filterIndexes,
+      Collection<String> fieldsToSort, SortOrder sortOrder) {
+    String tableName = tableSchema.getTableId().getName();
+    boolean allSameField = filterIndexes.stream().map(Field::getName).distinct().count() <= 1;
+
+    String unionOperator = allSameField ? " UNION ALL " : " UNION ";
+    String subQueries = filterIndexes.stream()
+        .map(field -> buildWrappedSubQuery(tableName, range, limit, field, fieldsToSort, sortOrder))
+        .collect(Collectors.joining(unionOperator));
+
+    return subQueries + " " + getOrderByClause(fieldsToSort, sortOrder) + " LIMIT " + limit + ";";
+  }
+
+  private String buildWrappedSubQuery(String tableName, Range range, int limit, Field<?> field,
+      Collection<String> fieldsToSort, SortOrder sortOrder) {
+    StringBuilder subQuery = new StringBuilder("(");
+    subQuery.append("SELECT * FROM ").append(tableName).append(" WHERE ");
+    if (!range.getBegin().isEmpty() || !range.getEnd().isEmpty()) {
+      appendRange(subQuery, range);
+      subQuery.append(" AND ");
+    }
+
+    String condition =
+        field.getValue() == null ? field.getName() + " IS NULL" : field.getName() + " = ?";
+    subQuery.append(condition).append(getOrderByClause(fieldsToSort, sortOrder)).append(" LIMIT ")
+        .append(limit).append(")");
+    return subQuery.toString();
   }
 
   private void appendRange(StringBuilder query, Range range) {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
@@ -21,20 +21,35 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.spi.data.SortOrder;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableTest;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.table.options.PreferUnionForDisjunctionOption;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Test for SQL structured table.
@@ -92,5 +107,118 @@ public class SqlStructuredTableTest extends StructuredTableTest {
   @Override
   protected TransactionRunner getTransactionRunner() {
     return transactionRunner;
+  }
+
+  @Test
+  public void testUnionAllOptimization() throws Exception {
+    List<Field<?>> fields1 = Arrays.asList(
+        Fields.intField("key", 1),
+        Fields.longField("key2", 1L),
+        Fields.stringField("key3", "a"),
+        Fields.booleanField("col7", true));
+    List<Field<?>> fields2 = Arrays.asList(
+        Fields.intField("key", 2),
+        Fields.longField("key2", 2L),
+        Fields.stringField("key3", "b"),
+        Fields.booleanField("col7", null));
+    List<Field<?>> fields3 = Arrays.asList(
+        Fields.intField("key", 3),
+        Fields.longField("key2", 3L),
+        Fields.stringField("key3", "c"),
+        Fields.booleanField("col7", false));
+    getTransactionRunner().run(context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      t.upsert(fields1);
+      t.upsert(fields2);
+      t.upsert(fields3);
+    });
+    Collection<Field<?>> filterIndexes = Arrays.asList(
+        Fields.booleanField("col7", true),
+        Fields.booleanField("col7", null));
+
+    List<StructuredRow> result = TransactionRunners.run(getTransactionRunner(), context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      try (CloseableIterator<StructuredRow> iterator = t.scan(Range.all(), Integer.MAX_VALUE,
+          filterIndexes,
+          SortOrder.ASC,
+          PreferUnionForDisjunctionOption.INSTANCE)) {
+        List<StructuredRow> rows = new ArrayList<>();
+        iterator.forEachRemaining(rows::add);
+        return rows;
+      }
+    });
+
+    Assert.assertEquals(2, result.size());
+  }
+
+  @Test
+  public void testUnionOptimizationMultiField() throws Exception {
+    List<Field<?>> fields1 = Arrays.asList(
+        Fields.intField("key", 1),
+        Fields.longField("key2", 1L),
+        Fields.stringField("key3", "a"),
+        Fields.stringField("col1", "val1"),
+        Fields.booleanField("col7", false));
+    List<Field<?>> fields2 = Arrays.asList(
+        Fields.intField("key", 2),
+        Fields.longField("key2", 2L),
+        Fields.stringField("key3", "b"),
+        Fields.stringField("col1", "val2"),
+        Fields.booleanField("col7", true));
+    getTransactionRunner().run(context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      t.upsert(fields1);
+      t.upsert(fields2);
+    });
+    Collection<Field<?>> filterIndexes = Arrays.asList(
+        Fields.stringField("col1", "val1"),
+        Fields.booleanField("col7", true));
+
+    List<StructuredRow> result = TransactionRunners.run(getTransactionRunner(), context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      try (CloseableIterator<StructuredRow> iterator = t.scan(Range.all(), Integer.MAX_VALUE,
+          filterIndexes,
+          SortOrder.ASC,
+          PreferUnionForDisjunctionOption.INSTANCE)) {
+        List<StructuredRow> rows = new ArrayList<>();
+        iterator.forEachRemaining(rows::add);
+        return rows;
+      }
+    });
+
+    Assert.assertEquals(2, result.size());
+  }
+
+  @Test
+  public void testUnionOptimizationSingleField() throws Exception {
+    getTransactionRunner().run(context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      t.upsert(Arrays.asList(
+          Fields.intField("key", 1),
+          Fields.longField("key2", 1L),
+          Fields.stringField("key3", "a"),
+          Fields.stringField("col1", "val1")));
+      t.upsert(Arrays.asList(
+          Fields.intField("key", 2),
+          Fields.longField("key2", 2L),
+          Fields.stringField("key3", "b"),
+          Fields.stringField("col1", "val2")));
+    });
+    Collection<Field<?>> filterIndexes = Collections.singletonList(
+        Fields.stringField("col1", "val1"));
+
+    List<StructuredRow> result = TransactionRunners.run(getTransactionRunner(), context -> {
+      StructuredTable t = context.getTable(SIMPLE_SPEC.getTableId());
+      try (CloseableIterator<StructuredRow> iterator = t.scan(Range.all(), Integer.MAX_VALUE,
+          filterIndexes,
+          SortOrder.ASC,
+          PreferUnionForDisjunctionOption.INSTANCE)) {
+        List<StructuredRow> rows = new ArrayList<>();
+        iterator.forEachRemaining(rows::add);
+        return rows;
+      }
+    });
+
+    Assert.assertEquals(1, result.size());
   }
 }

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -196,6 +196,27 @@ public interface StructuredTable extends Closeable {
   }
 
   /**
+   * Read a set of rows from the table matching the index and the key range, with additional query
+   * options. The rows returned will be sorted on the primary key order.
+   *
+   * @param keyRange      key range for the scan
+   * @param limit         maximum number of rows to return
+   * @param filterIndexes the index to filter upon
+   * @param sortOrder     defined primary key sort order. Note that the comparator used is specific
+   *                      to the underlying store and is not necessarily lexicographic.
+   * @param options       optional {@link QueryOption}s to modify the query behavior
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if the field is not part of the table schema, or is not an
+   *                               indexed column, or the type does not match the schema
+   * @throws IOException           if there is an error scanning the table
+   */
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
+      Collection<Field<?>> filterIndexes, SortOrder sortOrder, QueryOption... options)
+      throws InvalidFieldException, IOException {
+    return scan(keyRange, limit, filterIndexes, sortOrder);
+  }
+
+  /**
    * Read a set of rows from the table matching the key range, return by sortOrder of specified
    * index field.
    *

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/PreferUnionForDisjunctionOption.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/options/PreferUnionForDisjunctionOption.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.table.options;
+
+/**
+ * A {@link QueryOption} to signal that the query should prefer using UNION ALL instead of OR for
+ * conditions on indexed columns in databases that benefit from it (e.g. Postgres).
+ */
+public class PreferUnionForDisjunctionOption implements QueryOption {
+
+  public static final PreferUnionForDisjunctionOption INSTANCE = new PreferUnionForDisjunctionOption();
+
+  private PreferUnionForDisjunctionOption() {
+    // Use INSTANCE
+  }
+}


### PR DESCRIPTION
Avoid sequential scans on PostgreSQL when querying with `latestOnly=true` (which generates `latest = true OR latest IS NULL` filter).

- Extend `StructuredTable.scan` SPI to accept `QueryOption` varargs.
- Create `PreferUnionForDisjunctionOption` as a hint to use UNION instead of OR.
- Implement dynamic choice between `UNION ALL` (when filters are on the same field) and `UNION` (to remove duplicates when filters are on different fields) in `PostgreSqlStructuredTable`.

### Testing
- Tested by deploying the code locally.