### PR TITLE
[CDAP-21245] Fix: Propagate parent logging context to asynchronous action and fork threads

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -62,6 +62,7 @@ import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.Exceptions;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
+import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.service.Retries;
@@ -328,29 +329,36 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     ExecutorService executorService = createExecutor(1, executorTerminateLatch,
         "action-" + node.getNodeId() + "-%d");
 
+    // Capture context for propagation
+    final LoggingContext parentLoggingContext = LoggingContextAccessor.getLoggingContext();
+
     try {
       // Run the action in new thread
       Future<?> future = executorService.submit(new Callable<Void>() {
         @Override
         public Void call() throws Exception {
-          SchedulableProgramType programType = node.getProgram().getProgramType();
-          String programName = node.getProgram().getProgramName();
-          String prettyProgramType = ProgramType.valueOf(programType.name()).getPrettyName();
-          ProgramWorkflowRunner programWorkflowRunner =
-              workflowProgramRunnerFactory.getProgramWorkflowRunner(programType, token,
-                  node.getNodeId(), nodeStates);
+          try (LoggingContextAccessor.LoggingContextRestorer ignored =
+              parentLoggingContext != null ? LoggingContextAccessor.setLoggingContext(parentLoggingContext)
+                  : null) {
+            SchedulableProgramType programType = node.getProgram().getProgramType();
+            String programName = node.getProgram().getProgramName();
+            String prettyProgramType = ProgramType.valueOf(programType.name()).getPrettyName();
+            ProgramWorkflowRunner programWorkflowRunner =
+                workflowProgramRunnerFactory.getProgramWorkflowRunner(programType, token,
+                    node.getNodeId(), nodeStates);
 
-          // this should not happen, since null is only passed in from WorkflowDriver, only when calling configure
-          if (programWorkflowRunner == null) {
-            throw new UnsupportedOperationException("Operation not allowed.");
+            // this should not happen, since null is only passed in from WorkflowDriver, only when calling configure
+            if (programWorkflowRunner == null) {
+              throw new UnsupportedOperationException("Operation not allowed.");
+            }
+
+            Runnable programRunner = programWorkflowRunner.create(programName);
+            LOG.info("Starting {} Program '{}' in workflow", prettyProgramType, programName);
+            programRunner.run();
+
+            LOG.info("{} Program '{}' in workflow completed", prettyProgramType, programName);
+            return null;
           }
-
-          Runnable programRunner = programWorkflowRunner.create(programName);
-          LOG.info("Starting {} Program '{}' in workflow", prettyProgramType, programName);
-          programRunner.run();
-
-          LOG.info("{} Program '{}' in workflow completed", prettyProgramType, programName);
-          return null;
         }
       });
       future.get();
@@ -376,14 +384,22 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     CompletionService<Map.Entry<String, WorkflowToken>> completionService =
         new ExecutorCompletionService<>(executorService);
 
+    // Capture the logging context from the parent thread to propagate to fork branches
+    final LoggingContext parentLoggingContext = LoggingContextAccessor.getLoggingContext();
+
     try {
       for (final List<WorkflowNode> branch : fork.getBranches()) {
         completionService.submit(new Callable<Map.Entry<String, WorkflowToken>>() {
           @Override
           public Map.Entry<String, WorkflowToken> call() throws Exception {
-            WorkflowToken copiedToken = ((BasicWorkflowToken) token).deepCopy();
-            executeAll(branch.iterator(), appSpec, instantiator, classLoader, copiedToken);
-            return Maps.immutableEntry(branch.toString(), copiedToken);
+            // Set the logging context on the worker thread
+            try (LoggingContextAccessor.LoggingContextRestorer ignored =
+                parentLoggingContext != null ? LoggingContextAccessor.setLoggingContext(parentLoggingContext)
+                    : null) {
+              WorkflowToken copiedToken = ((BasicWorkflowToken) token).deepCopy();
+              executeAll(branch.iterator(), appSpec, instantiator, classLoader, copiedToken);
+              return Maps.immutableEntry(branch.toString(), copiedToken);
+            }
           }
         });
       }


### PR DESCRIPTION
### Summary

Issue:
Logging Context doesn't get propagated in parallel branches in pipelines.

Solution:
Ensures that the `LoggingContext` from the current workflow thread is correctly captured and propagated to background worker threads when running asynchronous action nodes and parallel fork branches.

### Changes
- Captured the current thread's `LoggingContext` before spinning up new threads in `executeAction` and `executeFork`.
- Used a try-with-resources pattern to apply the context inside the worker threads and guarantee its cleanup/restoration once execution completes.

### Testing
Pipeline execution successful:       

<img width="2560" height="1174" alt="image" src="https://github.com/user-attachments/assets/86544a65-4410-4323-b6fa-b04747ee6dda" />


#### Before changes:
All labels aren't propagated in parallel branches.       

**parallel:**          

<img width="2364" height="1564" alt="image" src="https://github.com/user-attachments/assets/4f395a16-35f5-49f8-863c-dd8066df49d7" />


#### After changes:
All 10 labels are propagated.     


**linear**       

<img width="2630" height="1678" alt="image" src="https://github.com/user-attachments/assets/2d1704d5-2a8c-49b6-9230-27ea25d44fb3" />    

**parallel:**
        
 <img width="2654" height="1546" alt="image" src="https://github.com/user-attachments/assets/3e07fbcf-a4f0-484a-bea1-b5c8e7b05328" />