### PR TITLE
[cherry-pick]Upgrade jose4j dependency to 0.9.6 to resolve security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.io.version>2.15.1</commons.io.version>
     <commons.compress.version>1.26.1</commons.compress.version>
-    <bitbucket.jose4j.version>0.9.3</bitbucket.jose4j.version>
+    <bitbucket.jose4j.version>0.9.6</bitbucket.jose4j.version>
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <dropwizard.version>3.1.2</dropwizard.version>


### PR DESCRIPTION
Cherry-pick : https://github.com/cdapio/cdap/pull/16130