### PR TITLE
Add app.apps.scan.batch.size configuration to control application scan batch size

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -180,6 +180,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   private final Impersonator impersonator;
   private final CapabilityReader capabilityReader;
   private final int batchSize;
+  private final int appsScanBatchSize;
   private final MetricsCollectionService metricsCollectionService;
   private final FeatureFlagsProvider featureFlagsProvider;
 
@@ -202,6 +203,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     this.appUpdateSchedules = cConf.getBoolean(Constants.AppFabric.APP_UPDATE_SCHEDULES,
         Constants.AppFabric.DEFAULT_APP_UPDATE_SCHEDULES);
     this.batchSize = cConf.getInt(AppFabric.STREAMING_BATCH_SIZE);
+    this.appsScanBatchSize = cConf.getInt(AppFabric.APPS_SCAN_BATCH_SIZE);
     this.store = store;
     this.scheduleManager = scheduleManager;
     this.usageRegistry = usageRegistry;
@@ -290,11 +292,11 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
     try (
         BatchingConsumer<Entry<ApplicationId, ApplicationMeta>> batchingConsumer = new BatchingConsumer<>(
-            list -> processApplications(list, consumer), batchSize
+            list -> processApplications(list, consumer), appsScanBatchSize
         )
     ) {
 
-      return store.scanApplications(request, batchSize,
+      return store.scanApplications(request, appsScanBatchSize,
           (appId, appMeta) -> batchingConsumer.accept(new SimpleEntry<>(appId, appMeta)));
     }
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -252,6 +252,7 @@ public final class Constants {
     public static final String PROGRAM_JVM_OPTS_PREFIX = "app.program.jvm.opts.";
     public static final String BACKLOG_CONNECTIONS = "app.connection.backlog";
     public static final String STREAMING_BATCH_SIZE = "app.streaming.batch.size";
+    public static final String APPS_SCAN_BATCH_SIZE = "app.scan.batch.size";
     public static final String EXEC_THREADS = "app.exec.threads";
     public static final String BOSS_THREADS = "app.boss.threads";
     public static final String WORKER_THREADS = "app.worker.threads";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -471,6 +471,16 @@
   </property>
 
   <property>
+    <name>app.scan.batch.size</name>
+    <value>25</value>
+    <description>
+      Batch size for scanning applications in the database. This defines the maximum number of
+      records processed per database transaction chunk when listing applications. This is
+      independent of the pagination page size requested by client APIs.
+    </description>
+  </property>
+
+  <property>
     <name>app.artifact.compute.hash.time.bucket.days</name>
     <value>15</value>
     <description>


### PR DESCRIPTION
Introduces a new configuration property `app.apps.scan.batch.size` 
to control the database batch size strictly during application listings 
(used by the `getAllApps` API via `ApplicationLifecycleService.scanApplications`).

By default, this is set to 30, allowing default UI pagination sizes 
(typically 25) to be fetched in a single database transaction/round-trip.
