### PR TITLE
CDAP-21249 : Add optimistic locking with default false.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1307,6 +1307,14 @@
   </property>
 
   <property>
+    <name>data.storage.properties.gcp-spanner.tx.runner.optimistic.lock.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable optimistic locking for Spanner transactions.
+    </description>
+  </property>
+
+  <property>
     <name>data.storage.properties.gcp-spanner.partitioned.dml.timeout.hours</name>
     <value>${app.run.records.ttl.frequency.hours}</value>
     <description>

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
@@ -87,7 +87,7 @@ public class SqlStructuredTableTest extends StructuredTableTest {
    * populate retry settings in cConf used by {@link SqlStructuredTableRetryTest}
    */
   private static void populateCConf(CConfiguration cConf) {
-    cConf.setInt(Constants.Dataset.DATA_STORAGE_SQL_TRANSACTION_RUNNER_MAX_RETRIES, 2);
+    cConf.setInt(Constants.Dataset.DATA_STORAGE_SQL_TRANSACTION_RUNNER_MAX_RETRIES, 10);
     cConf.setLong(Constants.Dataset.DATA_STORAGE_SQL_TRANSACTION_RUNNER_TRANSACTION_FAILURE_DELAY_MILLIS, 0);
     cConf.setLong(Constants.Dataset.DATA_STORAGE_SQL_TRANSACTION_RUNNER_CONNECTION_FAILURE_DELAY_MILLIS, 0);
   }

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/RetryingSpannerTransactionRunner.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/RetryingSpannerTransactionRunner.java
@@ -17,6 +17,8 @@
 package io.cdap.cdap.storage.spanner;
 
 import com.google.api.client.util.ExponentialBackOff;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.transaction.TransactionException;
@@ -36,6 +38,7 @@ public class RetryingSpannerTransactionRunner implements TransactionRunner {
   private static final Logger LOG = LoggerFactory.getLogger(RetryingSpannerTransactionRunner.class);
   static final String MAX_RETRIES = "tx.runner.max.retries";
   static final String INITIAL_DELAY_MILLIS = "tx.runner.initial.delay.ms";
+  static final String OPTIMISTIC_LOCK_ENABLED = "tx.runner.optimistic.lock.enabled";
   private final int maxRetries;
   private final int initialDelayMs;
   private final SpannerTransactionRunner transactionRunner;
@@ -43,7 +46,11 @@ public class RetryingSpannerTransactionRunner implements TransactionRunner {
   RetryingSpannerTransactionRunner(Map<String, String> conf, SpannerStructuredTableAdmin admin) {
     this.maxRetries = Integer.parseInt(conf.get(MAX_RETRIES));
     this.initialDelayMs = Integer.parseInt(conf.get(INITIAL_DELAY_MILLIS));
-    this.transactionRunner = new SpannerTransactionRunner(admin);
+    boolean optimisticLockEnabled = Boolean.parseBoolean(conf.getOrDefault(OPTIMISTIC_LOCK_ENABLED, "false"));
+    TransactionOption[] txOptions = optimisticLockEnabled
+        ? new TransactionOption[] { Options.optimisticLock() }
+        : new TransactionOption[0];
+    this.transactionRunner = new SpannerTransactionRunner(admin, txOptions);
   }
 
   @Override

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
@@ -17,6 +17,8 @@
 package io.cdap.cdap.storage.spanner;
 
 import com.google.cloud.spanner.ErrorCode;
+import com.google.cloud.spanner.Options;
+import com.google.cloud.spanner.Options.TransactionOption;
 import com.google.cloud.spanner.SpannerException;
 import io.cdap.cdap.spi.data.transaction.TransactionException;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -28,15 +30,27 @@ import io.cdap.cdap.spi.data.transaction.TxRunnable;
 public class SpannerTransactionRunner implements TransactionRunner {
 
   private final SpannerStructuredTableAdmin admin;
+  private final TransactionOption[] txOptions;
 
   public SpannerTransactionRunner(SpannerStructuredTableAdmin admin) {
+    this(admin, new TransactionOption[0]);
+  }
+
+  /**
+   * Constructs a new instance with the specified transaction options.
+   *
+   * @param admin the Spanner structured table admin to get the database client
+   * @param txOptions the transaction options to apply to read-write transactions
+   */
+  public SpannerTransactionRunner(SpannerStructuredTableAdmin admin, TransactionOption... txOptions) {
     this.admin = admin;
+    this.txOptions = txOptions;
   }
 
   @Override
   public void run(TxRunnable runnable) throws TransactionException {
     try {
-      admin.getDatabaseClient().readWriteTransaction().allowNestedTransaction().run(context -> {
+      admin.getDatabaseClient().readWriteTransaction(txOptions).allowNestedTransaction().run(context -> {
         runnable.run(new SpannerStructuredTableContext(context, admin));
         return null;
       });

--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableTest.java
@@ -74,6 +74,7 @@ public class SpannerStructuredTableTest extends StructuredTableTest {
     configs.put(SpannerStorageProvider.PROJECT, project);
     configs.put(SpannerStorageProvider.INSTANCE, instance);
     configs.put(SpannerStorageProvider.DATABASE, database);
+    configs.put(RetryingSpannerTransactionRunner.OPTIMISTIC_LOCK_ENABLED, "true");
 
     if (credentialsPath != null) {
       configs.put(SpannerStorageProvider.CREDENTIALS_PATH, credentialsPath);

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -42,6 +42,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -2252,5 +2255,57 @@ public abstract class StructuredTableTest {
       }
     });
     return actual;
+  }
+
+  /**
+   * Tests that concurrent increment operations on the same row resolve correctly
+   * without data loss. This stresses the transaction runner's conflict resolution
+   * and retry mechanism (e.g., Spanner's optimistic locking or SQL serialization).
+   */
+  @Test
+  public void testConcurrentIncrement() throws Exception {
+    Collection<Field<?>> keys = Arrays.asList(
+        Fields.intField(KEY, 999),
+        Fields.longField(KEY2, 999L),
+        Fields.stringField(KEY3, "key3")
+    );
+
+    // Initialize row using the existing keys collection
+    getTransactionRunner().run(context -> {
+      List<Field<?>> rowFields = new ArrayList<>(keys);
+      rowFields.add(Fields.longField(LONG_COL, 0L));
+      context.getTable(SIMPLE_TABLE).upsert(rowFields);
+    });
+
+    int numThreads = 3;
+    int incrementsPerThread = 10;
+
+    ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+    try {
+      List<CompletableFuture<Void>> futures = IntStream.range(0, numThreads)
+          .mapToObj(i -> CompletableFuture.runAsync(() -> {
+            for (int j = 0; j < incrementsPerThread; j++) {
+              try {
+                getTransactionRunner().run(context ->
+                    context.getTable(SIMPLE_TABLE).increment(keys, LONG_COL, 1L));
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            }
+          }, executor))
+          .collect(Collectors.toList());
+
+      // Wait for all threads to complete successfully
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+    } finally {
+      executor.shutdown();
+    }
+
+    // Verify final value
+    getTransactionRunner().run(context -> {
+      Optional<StructuredRow> row = context.getTable(SIMPLE_TABLE).read(keys);
+      Assert.assertTrue(row.isPresent());
+      Assert.assertEquals(Long.valueOf(numThreads * incrementsPerThread), row.get().getLong(LONG_COL));
+    });
   }
 }


### PR DESCRIPTION
#### Introduces support for Optimistic Locking in Google Cloud Spanner read-write transactions.

#### Why Optimistic Locking?

In Google Cloud Spanner, read-write transactions default to pessimistic locking, which acquires shared read locks during transaction execution. While safe, this can block concurrent writes and increase latency for read-mostly or low-to-medium contention workloads.

By utilizing Options.optimisticLock(), Spanner transactions bypass lock acquisition during reads, instead validating that no concurrent modifications occurred at commit time. This yields significant performance benefits:

- Higher Concurrency: Reads do not block writes, allowing better parallel execution.
- Lower Latency: Eliminates the overhead of acquiring and holding locks during the transaction lifecycle.
- Better Throughput: Dramatically improves throughput for read-heavy, low-contention workloads.


#### Testing 

- Added Unit Test with high concurrently to test aborts , retried and it's final success. 
- Testing in combination with #16125 in a TEST GCP Environment 
  - Tested with 3 pipelines per second deployment + run until it reaches 220000 pipelines, ran for 20 Hours and completed with 0.004% failures only. 
  - ran the above test twice. 