### PR TITLE
add property to configure the limit connection browse calls from wrangler

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6750,4 +6750,12 @@
     </description>
   </property>
 
+  <property>
+    <name>ui.wrangler.connections.browse.entities.limit</name>
+    <value>2000</value>
+    <description>
+      Number of entities displayed for a connection in the connections browser.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
Adds property `ui.wrangler.connections.browse.entities.limit` to make the number of rows / entities in the wrangler connections browser configurable.