### PR TITLE
Do not route the internal (v3Internal) API through the external router

### DIFF
--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -76,6 +76,9 @@ public final class RouterPathLookup extends AbstractHttpHandler {
           .stream(Splitter.on('/').omitEmptyStrings().split(requestPath).spliterator(), false)
           .toArray(String[]::new);
 
+      if (uriParts.length == 0) {
+        return APP_FABRIC_HTTP;
+      }
       if (uriParts[0].equals(Constants.Gateway.INTERNAL_API_VERSION_3_TOKEN)) {
         // The internal API is for service-to-service calls over internal service
         // discovery and must never be reachable through the external router.

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -76,6 +76,11 @@ public final class RouterPathLookup extends AbstractHttpHandler {
           .stream(Splitter.on('/').omitEmptyStrings().split(requestPath).spliterator(), false)
           .toArray(String[]::new);
 
+      if (uriParts[0].equals(Constants.Gateway.INTERNAL_API_VERSION_3_TOKEN)) {
+        // The internal API is for service-to-service calls over internal service
+        // discovery and must never be reachable through the external router.
+        return DONT_ROUTE;
+      }
       if (uriParts[0].equals(Constants.Gateway.API_VERSION_3_TOKEN)) {
         return getV3RoutingService(uriParts, requestMethod);
       }

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -426,8 +426,13 @@ public class RouterPathLookupTest {
 
   @Test
   public void testProgramLifecycleInternalAndAppLifecycleInternalPaths() {
+    // The internal (v3Internal) API is for service-to-service calls over internal
+    // discovery and must not be routed from the external router.
     assertRouting("v3Internal/namespaces//apps//versions//workflows/DataPipelineWorkflow/runs/",
-        RouterPathLookup.APP_FABRIC_HTTP);
+        RouterPathLookup.DONT_ROUTE);
+    assertRouting("v3Internal/namespaces/default/apps/app/states/key", RouterPathLookup.DONT_ROUTE);
+    assertRouting("v3Internal/namespaces/default/apps/app/preferences", RouterPathLookup.DONT_ROUTE);
+    assertRouting("v3Internal/location/some/abs/path", RouterPathLookup.DONT_ROUTE);
   }
 
   @Test


### PR DESCRIPTION
## Problem

The `/v3Internal` API is an internal, service-to-service surface: its handlers (for example `FileFetcherHttpHandlerInternal`, `AppStateHandler`, `PreferencesHttpHandlerInternal`, `AppLifecycleHttpHandlerInternal`) do not call `accessEnforcer.enforce(...)` and rely on callers presenting an internal credential.

`RouterPathLookup.getRoutingService` only special-cases the public `/v3` prefix and otherwise falls through to `return APP_FABRIC_HTTP`. The external `NettyRouter` therefore forwards `/v3Internal/...` requests to app-fabric for any authenticated external user, and the app-fabric pipeline does not require an internal credential for those paths. A low-privileged user can then call the internal API across namespaces — for example `GET /v3Internal/location/<absolute-path>` (`FileFetcherHttpHandlerInternal` → `Locations.getLocationFromAbsolutePath`) reads files rooted at the filesystem root, and the app-state / preferences / app-lifecycle internal handlers read or modify another namespace's data.

Internal callers do not use the external router for these paths — they go through service discovery (`RemoteClient` against `Constants.Service.APP_FABRIC_HTTP`, e.g. `RemoteArtifactManager`), so the router can stop routing `/v3Internal` without affecting internal traffic.

## Change

`RouterPathLookup` returns `DONT_ROUTE` for any path whose first segment is `v3Internal`, mirroring the existing treatment of `/v3/metadata-internals`. `RouterPathLookupTest` is updated accordingly.
