### PR TITLE
security: add authorization checks to OperationsDashboardHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
@@ -39,8 +39,10 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.ops.DashboardProgramRunRecord;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.reporting.ProgramHeartbeatService;
 import io.cdap.cdap.scheduler.Scheduler;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -79,14 +81,17 @@ public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler
   private final ProgramHeartbeatService programHeartbeatService;
   private final Scheduler scheduler;
   private final TimeSchedulerService timeSchedulerService;
+  private final ContextAccessEnforcer contextAccessEnforcer;
 
 
   @Inject
   public OperationsDashboardHttpHandler(ProgramHeartbeatService programHeartbeatService,
-      Scheduler scheduler, TimeSchedulerService timeSchedulerService) {
+      Scheduler scheduler, TimeSchedulerService timeSchedulerService,
+      ContextAccessEnforcer contextAccessEnforcer) {
     this.programHeartbeatService = programHeartbeatService;
     this.scheduler = scheduler;
     this.timeSchedulerService = timeSchedulerService;
+    this.contextAccessEnforcer = contextAccessEnforcer;
   }
 
   @GET
@@ -105,6 +110,14 @@ public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler
       throw new BadRequestException(
           "'namespace' cannot be empty, please provide at least one namespace.");
     }
+
+    // Enforce that the caller has GET access on each requested namespace before reading any
+    // program run data for it. Without this check, a caller could read program run records from
+    // arbitrary namespaces it is not authorized to access.
+    for (String namespace : namespaces) {
+      contextAccessEnforcer.enforce(new NamespaceId(namespace), StandardPermission.GET);
+    }
+
     long endTimeSecs = startTimeSecs + durationTimeSecs;
 
     // Get current running timestamp.


### PR DESCRIPTION
### Summary

`GET /v3/dashboard` (`OperationsDashboardHttpHandler.readDashboardDetail`) reads program-run records for every namespace supplied in the `namespace` query parameter, but performs no authorization check on those namespaces. A caller can therefore retrieve program-run data (application, program, run, principal, run status) from namespaces it is not authorized to access.

The sibling program and log handlers already enforce access before returning per-namespace/per-program data (e.g. `ProgramRuntimeHttpHandler` and `LogHttpHandler`'s `ensureVisibilityOnProgram`). This handler was missing the equivalent gate.

### Change

- Inject `ContextAccessEnforcer` into `OperationsDashboardHttpHandler` (already globally bound via `AuthorizationEnforcementModule`, same as the sibling `MonitorHandler` in this package).
- In `readDashboardDetail`, enforce `StandardPermission.GET` on each requested `NamespaceId` before any program-run data is read, so a caller without GET access on a namespace is rejected.

This mirrors the existing namespace/program-level enforcement performed by the other app-fabric handlers and is consistent with the recent authorization-hardening changes in this area.

### Compatibility

No API or response-shape changes for authorized callers. Callers requesting namespaces they are entitled to read are unaffected; requests that include a namespace the caller is not authorized for are now rejected instead of returning that namespace's data.
