### PR TITLE
security: add authorization checks to WorkflowStatsSLAHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowStatsSLAHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowStatsSLAHttpHandler.java
@@ -33,8 +33,12 @@ import io.cdap.cdap.internal.app.store.WorkflowTable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.WorkflowStatistics;
 import io.cdap.cdap.proto.WorkflowStatsComparison;
+import io.cdap.cdap.proto.id.Ids;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
@@ -64,13 +68,26 @@ public class WorkflowStatsSLAHttpHandler extends AbstractHttpHandler {
   private final Store store;
   private final MRJobInfoFetcher mrJobInfoFetcher;
   private final MetricsSystemClient metricsSystemClient;
+  private final ContextAccessEnforcer contextAccessEnforcer;
 
   @Inject
   WorkflowStatsSLAHttpHandler(Store store, MRJobInfoFetcher mrJobInfoFetcher,
-      MetricsSystemClient metricsSystemClient) {
+      MetricsSystemClient metricsSystemClient, ContextAccessEnforcer contextAccessEnforcer) {
     this.store = store;
     this.mrJobInfoFetcher = mrJobInfoFetcher;
     this.metricsSystemClient = metricsSystemClient;
+    this.contextAccessEnforcer = contextAccessEnforcer;
+  }
+
+  /**
+   * Enforces that the requesting principal has {@link StandardPermission#GET} access to the
+   * workflow program identified by the request path before any run statistics are read.
+   */
+  private void enforceWorkflowAccess(String namespaceId, String appId, String workflowId)
+      throws Exception {
+    ProgramReference programReference = Ids.namespace(namespaceId).appReference(appId)
+        .program(ProgramType.WORKFLOW, workflowId);
+    contextAccessEnforcer.enforce(programReference, StandardPermission.GET);
   }
 
   /**
@@ -94,6 +111,7 @@ public class WorkflowStatsSLAHttpHandler extends AbstractHttpHandler {
       @QueryParam("start") @DefaultValue("now-1d") String start,
       @QueryParam("end") @DefaultValue("now") String end,
       @QueryParam("percentile") @DefaultValue("90.0") List<Double> percentiles) throws Exception {
+    enforceWorkflowAccess(namespaceId, appId, workflowId);
     long startTime = TimeMathParser.parseTimeInSeconds(start);
     long endTime = TimeMathParser.parseTimeInSeconds(end);
 
@@ -149,6 +167,7 @@ public class WorkflowStatsSLAHttpHandler extends AbstractHttpHandler {
       @PathParam("run-id") String runId,
       @QueryParam("limit") @DefaultValue("10") int limit,
       @QueryParam("interval") @DefaultValue("10s") String interval) throws Exception {
+    enforceWorkflowAccess(namespaceId, appId, workflowId);
     if (limit <= 0) {
       throw new BadRequestException("Limit has to be greater than 0. Entered value was : " + limit);
     }
@@ -207,6 +226,7 @@ public class WorkflowStatsSLAHttpHandler extends AbstractHttpHandler {
       @PathParam("workflow-id") String workflowId,
       @PathParam("run-id") String runId,
       @QueryParam("other-run-id") String otherRunId) throws Exception {
+    enforceWorkflowAccess(namespaceId, appId, workflowId);
     WorkflowRunMetrics detailedStatistics = getDetailedRecord(new NamespaceId(namespaceId), appId,
         workflowId, runId);
     WorkflowRunMetrics otherDetailedStatistics = getDetailedRecord(new NamespaceId(namespaceId),


### PR DESCRIPTION
## Summary

`WorkflowStatsSLAHttpHandler` serves workflow run statistics, run details, and run comparisons for a namespace/application/workflow selected entirely from the request path, but it did not enforce any access check before reading from the `Store`. The handler only injected `Store`, `MRJobInfoFetcher`, and `MetricsSystemClient`, so a principal could read run statistics for workflows in any namespace without an authorization check.

This change adds `StandardPermission.GET` enforcement on the targeted workflow program before the data read, consistent with the sibling program/workflow handlers in app-fabric.

## Changes

- Inject `ContextAccessEnforcer` via the existing `@Inject` constructor (Guice resolves it from `AuthorizationEnforcementModule`; the handler binding in `AppFabricServiceRuntimeModule` is unchanged).
- Add a small `enforceWorkflowAccess(namespace, app, workflow)` helper that builds the workflow `ProgramReference` and calls `contextAccessEnforcer.enforce(programReference, StandardPermission.GET)`.
- Call the helper at the start of all three read endpoints:
  - `workflowStats` — `.../workflows/{workflow-id}/statistics`
  - `workflowRunDetail` — `.../workflows/{workflow-id}/runs/{run-id}/statistics`
  - `compare` — `.../workflows/{workflow-id}/runs/{run-id}/compare`

All three endpoints are read-only, so `StandardPermission.GET` is the appropriate permission. The enforcement mirrors the idiom already used in `ProgramLifecycleService` and `ArtifactHttpHandler`.

## Testing

- `mvn -o -pl cdap-app-fabric -am compile` — BUILD SUCCESS.