### PR TITLE
[CDAP-21257]Capturing  Dataproc operations

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocMetric.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocMetric.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.common;
 
+import com.google.api.gax.rpc.StatusCode;
 import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.runtimejob.LaunchMode;
 import javax.annotation.Nullable;
@@ -32,14 +33,21 @@ public class DataprocMetric {
   private final LaunchMode launchMode;
   @Nullable
   private final String imageVersion;
+  @Nullable
+  private final String method;
+  @Nullable
+  private final StatusCode.Code statusCode;
 
   private DataprocMetric(String metricName, String region, @Nullable Exception exception,
-      @Nullable LaunchMode launchMode, @Nullable String imageVersion) {
+      @Nullable LaunchMode launchMode, @Nullable String imageVersion, @Nullable String method,
+                         @Nullable StatusCode.Code statusCode) {
     this.metricName = metricName;
     this.region = region;
     this.exception = exception;
     this.launchMode = launchMode;
     this.imageVersion = imageVersion;
+    this.method = method;
+    this.statusCode = statusCode;
   }
 
   public String getMetricName() {
@@ -72,6 +80,16 @@ public class DataprocMetric {
     return launchMode;
   }
 
+  @Nullable
+  public StatusCode.Code  getStatusCode() {
+    return statusCode;
+  }
+
+  @Nullable
+  public String getMethod() {
+    return method;
+  }
+
   /**
    * Returns a builder to create a DataprocMetric.
    *
@@ -93,6 +111,10 @@ public class DataprocMetric {
     private Exception exception;
     @Nullable
     private LaunchMode launchMode;
+    @Nullable
+    private String method;
+    @Nullable
+    private StatusCode.Code statusCode;
 
     private Builder(String metricName) {
       this.metricName = metricName;
@@ -113,8 +135,18 @@ public class DataprocMetric {
       return this;
     }
 
+    public Builder setStatusCode(@Nullable StatusCode.Code statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    }
+
     public Builder setImageVersion(String imageVersion) {
       this.imageVersion = imageVersion;
+      return this;
+    }
+
+    public Builder setMethod(@Nullable String method) {
+      this.method = method;
       return this;
     }
 
@@ -128,7 +160,7 @@ public class DataprocMetric {
         // region should always be set unless there is a bug in the code
         throw new IllegalStateException("Dataproc metric is missing the region");
       }
-      return new DataprocMetric(metricName, region, exception, launchMode, imageVersion);
+      return new DataprocMetric(metricName, region, exception, launchMode, imageVersion, method, statusCode);
     }
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -375,19 +375,7 @@ public final class DataprocUtils {
    * Emit a dataproc metric.
    **/
   public static void emitMetric(ProvisionerContext context, DataprocMetric dataprocMetric) {
-    StatusCode.Code statusCode;
-    Exception e = dataprocMetric.getException();
-    if (e == null) {
-      statusCode = StatusCode.Code.OK;
-    } else {
-      Throwable cause = e.getCause();
-      if (cause instanceof ApiException) {
-        ApiException apiException = (ApiException) cause;
-        statusCode = apiException.getStatusCode().getCode();
-      } else {
-        statusCode = StatusCode.Code.INTERNAL;
-      }
-    }
+    StatusCode.Code statusCode = getCode(dataprocMetric);
     ImmutableMap.Builder<String, String> tags = ImmutableMap.<String, String>builder()
         .put("reg", dataprocMetric.getRegion())
         .put("sc", statusCode.toString());
@@ -397,8 +385,28 @@ public final class DataprocUtils {
     if (!Strings.isNullOrEmpty(dataprocMetric.getImageVersion())) {
       tags.put("imgVer", dataprocMetric.getImageVersion());
     }
+    if (!Strings.isNullOrEmpty(dataprocMetric.getMethod())) {
+      tags.put("method", dataprocMetric.getMethod());
+    }
     ProvisionerMetrics metrics = context.getMetrics(tags.build());
     metrics.count(dataprocMetric.getMetricName(), 1);
+  }
+
+  private static StatusCode.Code getCode(DataprocMetric dataprocMetric) {
+    StatusCode.Code statusCode = StatusCode.Code.OK;
+    Exception e = dataprocMetric.getException();
+    if (dataprocMetric.getStatusCode() != null) {
+      statusCode = dataprocMetric.getStatusCode();
+    } else if (e != null) {
+      Throwable cause = e.getCause();
+      if (cause instanceof ApiException) {
+        ApiException apiException = (ApiException) cause;
+        statusCode = apiException.getStatusCode().getCode();
+      } else {
+        statusCode = StatusCode.Code.INTERNAL;
+      }
+    }
+    return statusCode;
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -47,6 +47,7 @@ import com.google.cloud.dataproc.v1.UpdateClusterRequest;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.protobuf.Duration;
@@ -820,6 +821,26 @@ abstract class DataprocClient implements AutoCloseable {
       return errorMsg;
     }
     return "";
+  }
+
+  /**
+   * Get the latest operation by cluster name and operation type.
+   */
+  public Optional<Operation> getLatestOperation(String clusterName, String operationType)
+    throws RetryableProvisionException {
+    String operationName = String.format("projects/%s/regions/%s/operations", conf.getProjectId(), conf.getRegion());
+    String filter = String.format("clusterName=\"%s\" AND operationType=\"%s\"", clusterName, operationType);
+
+    try {
+      OperationsClient.ListOperationsPagedResponse response =
+        client.getOperationsClient().listOperations(operationName, filter);
+
+      return Optional.ofNullable(Iterables.getFirst(response.getPage().getValues(), null));
+
+    } catch (ApiException e) {
+      throw DataprocUtils.handleApiException(null, e,
+        "Failed to retrieve latest operation metadata for cluster " + clusterName, errorCategory);
+    }
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -16,16 +16,21 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
 import com.google.cloud.dataproc.v1.ClusterStatus.State;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
+import com.google.longrunning.Operation;
 import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
+import io.cdap.cdap.runtime.spi.common.DataprocMetric;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
@@ -38,10 +43,12 @@ import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
 import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -49,6 +56,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+
+import io.grpc.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +81,9 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   //A lock to use for cluster reuse
   private static final String REUSE_LOCK = "reuse";
+
+  private static final Set<ClusterStatus> TERMINAL_STATES =
+    EnumSet.of(ClusterStatus.RUNNING, ClusterStatus.FAILED, ClusterStatus.NOT_EXISTS);
 
   private final DataprocClientFactory clientFactory;
 
@@ -471,16 +483,21 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
     String clusterName = cluster.getName();
 
-    ClusterStatus status = cluster.getStatus();
+    ClusterStatus previousStatus = cluster.getStatus();
     // if we are skipping the delete, need to avoid checking the real cluster status and pretend like it is deleted.
-    if (conf.isSkipDelete() && status == ClusterStatus.DELETING) {
+    if (conf.isSkipDelete() && previousStatus == ClusterStatus.DELETING) {
       return ClusterStatus.NOT_EXISTS;
     }
 
+    ClusterStatus status;
     try (DataprocClient client = clientFactory.create(conf, context.getErrorCategory())) {
       status = client.getClusterStatus(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(), getImageVersion(context, conf),
           "provisioner.clusterStatus.response.count");
+
+      if (hasReachedTerminalState(previousStatus, status)) {
+        emitLroMetric(context, client, conf, previousStatus, clusterName);
+      }
       return status;
     } catch (Exception e) {
       DataprocUtils.emitMetric(context, conf.getRegion(), getImageVersion(context, conf),
@@ -488,6 +505,68 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       throw e;
     }
   }
+
+  private boolean hasReachedTerminalState(ClusterStatus previous, ClusterStatus current) {
+    return !TERMINAL_STATES.contains(previous) && TERMINAL_STATES.contains(current);
+  }
+
+  /**
+   * Emits a metric for the outcome of a Long Running Operation (LRO) when a cluster
+   * transitions to a terminal status.
+   *
+   * @param context the provisioner context
+   * @param client the dataproc client
+   * @param conf the dataproc configuration
+   * @param previousStatus the status of the cluster before the transition
+   * @param clusterName the name of the cluster
+   */
+  private void emitLroMetric(ProvisionerContext context, DataprocClient client, DataprocConf conf,
+                             ClusterStatus previousStatus, String clusterName) {
+    String method = getMethod(previousStatus);
+    if (method == null) {
+      return;
+    }
+
+    try {
+      Optional<Operation> operation = client.getLatestOperation(clusterName, method);
+
+      if (!operation.isPresent() || !operation.get().getDone()) {
+        return;
+      }
+
+      Operation op = operation.get();
+      String metricName = "provisioner.operation.response.count";
+      String imageVersion = getImageVersion(context, conf);
+
+      DataprocMetric.Builder builder = DataprocMetric.builder(metricName)
+        .setRegion(conf.getRegion())
+        .setImageVersion(imageVersion)
+        .setMethod(method);
+
+      if (op.hasError()) {
+        Status.Code grpcCode = Status.fromCodeValue(op.getError().getCode()).getCode();
+        StatusCode gaxStatusCode = GrpcStatusCode.of(grpcCode);
+        builder.setStatusCode(gaxStatusCode.getCode());
+      }
+
+      DataprocUtils.emitMetric(context, builder.build());
+    } catch (RetryableProvisionException | RuntimeException ex) {
+      LOG.warn("Failed to retrieve LRO operation metadata for metric emission on cluster {}", clusterName, ex);
+    }
+  }
+
+  @Nullable
+  private String getMethod(ClusterStatus status) {
+    switch (status) {
+      case CREATING:
+        return "CREATE";
+      case DELETING:
+        return "DELETE";
+      default:
+        return null;
+    }
+  }
+
 
   @Override
   public String getClusterFailureMsg(ProvisionerContext context, Cluster cluster) throws Exception {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
@@ -33,6 +33,7 @@ import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.NotFoundException;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.api.services.compute.Compute;
 import com.google.cloud.dataproc.v1.Cluster;
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
@@ -59,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
@@ -377,5 +379,113 @@ public class DataprocClientTest {
       Collections.emptyList(), null);
     String errorMsgRet = client.getClusterFailureMsg(cdapCluster.getName());
     Assert.assertTrue(errorMsgRet.contains(errorMsg));
+  }
+
+  @Test
+  public void testGetLatestOperation() throws Exception {
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf,
+                                                            new ErrorCategory(ErrorCategoryEnum.OTHERS));
+
+    OperationsClient operationsClient = PowerMockito.mock(OperationsClient.class);
+    PowerMockito.when(clusterControllerClientMock.getOperationsClient()).thenReturn(operationsClient);
+
+    OperationsClient.ListOperationsPagedResponse listOperationsPagedResponse =
+      PowerMockito.mock(OperationsClient.ListOperationsPagedResponse.class);
+    PowerMockito.when(operationsClient.listOperations(
+        Mockito.eq("projects/dummy-project/regions/us-test1/operations"),
+        Mockito.eq("clusterName=\"mycluster\" AND operationType=\"CREATE\"")))
+      .thenReturn(listOperationsPagedResponse);
+
+    OperationsClient.ListOperationsPage page = Mockito.mock(OperationsClient.ListOperationsPage.class);
+    Mockito.when(listOperationsPagedResponse.getPage()).thenReturn(page);
+
+    Operation operation = Operation.newBuilder().setName("op-name").setDone(true).build();
+    List<Operation> operations = Collections.singletonList(operation);
+    Mockito.when(page.getValues()).thenReturn(operations);
+
+    Optional<Operation> result = client.getLatestOperation("mycluster", "CREATE");
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals("op-name", result.get().getName());
+  }
+
+  @Test
+  public void testGetLatestOperationReturnsEmpty() throws Exception {
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf,
+                                                            new ErrorCategory(ErrorCategoryEnum.OTHERS));
+
+    OperationsClient operationsClient = PowerMockito.mock(OperationsClient.class);
+    PowerMockito.when(clusterControllerClientMock.getOperationsClient()).thenReturn(operationsClient);
+
+    OperationsClient.ListOperationsPagedResponse listOperationsPagedResponse =
+      Mockito.mock(OperationsClient.ListOperationsPagedResponse.class);
+    Mockito.when(operationsClient.listOperations(
+        Mockito.eq("projects/dummy-project/regions/us-test1/operations"),
+        Mockito.eq("clusterName=\"mycluster\" AND operationType=\"CREATE\"")))
+      .thenReturn(listOperationsPagedResponse);
+
+    OperationsClient.ListOperationsPage page = Mockito.mock(OperationsClient.ListOperationsPage.class);
+    Mockito.when(listOperationsPagedResponse.getPage()).thenReturn(page);
+
+    List<Operation> operations = Collections.emptyList();
+    Mockito.when(page.getValues()).thenReturn(operations);
+
+    Optional<Operation> result = client.getLatestOperation("mycluster", "CREATE");
+    Assert.assertFalse(result.isPresent());
+  }
+
+  @Test
+  public void testGetLatestOperationThrowsException() throws Exception {
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf,
+                                                            new ErrorCategory(ErrorCategoryEnum.OTHERS));
+
+    OperationsClient operationsClient = PowerMockito.mock(OperationsClient.class);
+    PowerMockito.when(clusterControllerClientMock.getOperationsClient()).thenReturn(operationsClient);
+
+    StatusCode statusCode = Mockito.mock(StatusCode.class);
+    StatusCode.Code realCode = StatusCode.Code.UNAVAILABLE;
+    Mockito.when(statusCode.getCode()).thenReturn(realCode);
+
+    ApiException mockException = Mockito.mock(ApiException.class);
+    Mockito.when(mockException.getStatusCode()).thenReturn(statusCode);
+
+    PowerMockito.when(operationsClient.listOperations(Mockito.anyString(), Mockito.anyString()))
+      .thenThrow(mockException);
+
+    try {
+      client.getLatestOperation("mycluster", "CREATE");
+      Assert.fail("Expected RetryableProvisionException to be thrown");
+    } catch (RetryableProvisionException e) {
+      Assert.assertEquals(mockException, e.getCause());
+    }
+  }
+
+  @Test
+  public void testGetLatestOperationReturnsMultiple() throws Exception {
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf,
+                                                            new ErrorCategory(ErrorCategoryEnum.OTHERS));
+
+    OperationsClient operationsClient = PowerMockito.mock(OperationsClient.class);
+    PowerMockito.when(clusterControllerClientMock.getOperationsClient()).thenReturn(operationsClient);
+
+    OperationsClient.ListOperationsPagedResponse listOperationsPagedResponse =
+      PowerMockito.mock(OperationsClient.ListOperationsPagedResponse.class);
+    PowerMockito.when(operationsClient.listOperations(
+        Mockito.eq("projects/dummy-project/regions/us-test1/operations"),
+        Mockito.eq("clusterName=\"mycluster\" AND operationType=\"CREATE\"")))
+      .thenReturn(listOperationsPagedResponse);
+
+    OperationsClient.ListOperationsPage page = Mockito.mock(OperationsClient.ListOperationsPage.class);
+    Mockito.when(listOperationsPagedResponse.getPage()).thenReturn(page);
+
+    Operation latestOp = Operation.newBuilder().setName("latest-op").setDone(true).build();
+    Operation olderOp = Operation.newBuilder().setName("older-op").setDone(true).build();
+
+    List<Operation> operations = java.util.Arrays.asList(latestOp, olderOp);
+    Mockito.when(page.getValues()).thenReturn(operations);
+
+    Optional<Operation> result = client.getLatestOperation("mycluster", "CREATE");
+
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals("latest-op", result.get().getName());
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -16,15 +16,20 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
 import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
 import com.google.cloud.dataproc.v1.ClusterStatus.State;
 import com.google.common.collect.ImmutableMap;
+import com.google.longrunning.Operation;
 import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
 import io.cdap.cdap.runtime.spi.MockVersionInfo;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
+import io.cdap.cdap.runtime.spi.common.DataprocMetric;
+import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import java.util.Collections;
@@ -493,5 +498,199 @@ public class DataprocProvisionerTest {
     context.addProperty("labels", "email|user@cdapio");
     Map<String, String> labels = provisioner.getCommonDataprocLabels(context);
     Assert.assertNull(labels.get("email"));
+  }
+
+  @Test
+  public void testGetClusterStatusEmitLroMetricOnCreate() throws Exception {
+    MockProvisionerContext localContext = new MockProvisionerContext();
+    localContext.addProperty("accountKey", "testKey");
+    localContext.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
+    localContext.addProperty("region", "testRegion");
+    localContext.setErrorCategory(new ErrorCategory(ErrorCategoryEnum.PROVISIONING));
+    localContext.setProgramRunInfo(new ProgramRunInfo.Builder()
+                                     .setNamespace("ns").setApplication("app").setVersion("1.0")
+                                     .setProgramType("workflow").setProgram("program").setRun("runId").build());
+
+    Cluster cdapClusterInput = new Cluster("mycluster", ClusterStatus.CREATING,
+                                           Collections.emptyList(), Collections.emptyMap());
+
+    Mockito.when(dataprocClient.getClusterStatus(Mockito.anyString()))
+      .thenReturn(ClusterStatus.RUNNING);
+
+    Operation operation = Operation.newBuilder()
+      .setName("op-create")
+      .setDone(true)
+      .build();
+
+    Mockito.when(dataprocClient.getLatestOperation(Mockito.anyString(), Mockito.anyString()))
+      .thenReturn(Optional.of(operation));
+
+    ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
+    Assert.assertEquals(ClusterStatus.RUNNING, currentStatus);
+
+    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
+    Assert.assertEquals(1, count.intValue());
+  }
+
+  @Test
+  public void testGetClusterStatusEmitLroMetricOnDelete() throws Exception {
+    MockProvisionerContext localContext = new MockProvisionerContext();
+    localContext.addProperty("accountKey", "testKey");
+    localContext.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
+    localContext.addProperty("region", "testRegion");
+    localContext.setErrorCategory(new ErrorCategory(ErrorCategoryEnum.DEPROVISIONING));
+    localContext.setProgramRunInfo(new ProgramRunInfo.Builder()
+                                     .setNamespace("ns").setApplication("app").setVersion("1.0")
+                                     .setProgramType("workflow").setProgram("program").setRun("runId").build());
+
+    Cluster cdapClusterInput = new Cluster("mycluster", ClusterStatus.DELETING,
+                                           Collections.emptyList(), Collections.emptyMap());
+
+    Mockito.when(dataprocClient.getClusterStatus(Mockito.anyString()))
+      .thenReturn(ClusterStatus.NOT_EXISTS);
+
+    Operation operation = Operation.newBuilder()
+      .setName("op-delete")
+      .setDone(true)
+      .build();
+    Mockito.when(dataprocClient.getLatestOperation(Mockito.anyString(), Mockito.anyString()))
+      .thenReturn(Optional.of(operation));
+
+    ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
+    Assert.assertEquals(ClusterStatus.NOT_EXISTS, currentStatus);
+
+    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
+    Assert.assertEquals(1, count.intValue());
+  }
+
+  @Test
+  public void testGetClusterStatusEmitLroMetricOnError() throws Exception {
+    MockProvisionerContext localContext = new MockProvisionerContext();
+    localContext.addProperty("accountKey", "testKey");
+    localContext.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
+    localContext.addProperty("region", "testRegion");
+    localContext.setErrorCategory(new ErrorCategory(ErrorCategoryEnum.PROVISIONING));
+    localContext.setProgramRunInfo(new ProgramRunInfo.Builder()
+                                     .setNamespace("ns").setApplication("app").setVersion("1.0")
+                                     .setProgramType("workflow").setProgram("program").setRun("runId").build());
+
+    Cluster cdapClusterInput = new Cluster("mycluster", ClusterStatus.CREATING,
+                                           Collections.emptyList(), Collections.emptyMap());
+
+    Mockito.when(dataprocClient.getClusterStatus(Mockito.anyString()))
+      .thenReturn(ClusterStatus.FAILED);
+
+    com.google.rpc.Status statusError = com.google.rpc.Status.newBuilder()
+      .setCode(3)
+      .setMessage("Invalid resource configuration")
+      .build();
+    Operation operation = Operation.newBuilder()
+      .setName("op-create")
+      .setDone(true)
+      .setError(statusError)
+      .build();
+    Mockito.when(dataprocClient.getLatestOperation(Mockito.anyString(), Mockito.anyString()))
+      .thenReturn(Optional.of(operation));
+
+    ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
+    Assert.assertEquals(ClusterStatus.FAILED, currentStatus);
+
+    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
+    Assert.assertEquals(1, count.intValue());
+  }
+
+  @Test
+  public void testGetClusterStatusEmitLroMetricOperationNotDone() throws Exception {
+    MockProvisionerContext localContext = new MockProvisionerContext();
+    localContext.addProperty("accountKey", "testKey");
+    localContext.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
+    localContext.addProperty("region", "testRegion");
+    localContext.setErrorCategory(new ErrorCategory(ErrorCategoryEnum.PROVISIONING));
+    localContext.setProgramRunInfo(new ProgramRunInfo.Builder()
+                                     .setNamespace("ns").setApplication("app").setVersion("1.0")
+                                     .setProgramType("workflow").setProgram("program").setRun("runId").build());
+
+    Cluster cdapClusterInput = new Cluster("mycluster", ClusterStatus.CREATING,
+                                           Collections.emptyList(), Collections.emptyMap());
+
+    Mockito.when(dataprocClient.getClusterStatus("mycluster"))
+      .thenReturn(ClusterStatus.RUNNING);
+
+    Operation operation = Operation.newBuilder()
+      .setName("op-create")
+      .setDone(false)
+      .build();
+    Mockito.when(dataprocClient.getLatestOperation("mycluster", "CREATE"))
+      .thenReturn(Optional.of(operation));
+
+    ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
+    Assert.assertEquals(ClusterStatus.RUNNING, currentStatus);
+
+    Integer count = localContext.getMetricCounts().get("provisioner.cluster.operation.response.count");
+    Assert.assertNull(count);
+  }
+
+  @Test
+  public void testGetClusterStatusEmitLroMetricClientThrowsException() throws Exception {
+    MockProvisionerContext localContext = new MockProvisionerContext();
+    localContext.addProperty("accountKey", "testKey");
+    localContext.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
+    localContext.addProperty("region", "testRegion");
+    localContext.setErrorCategory(new ErrorCategory(ErrorCategoryEnum.PROVISIONING));
+    localContext.setProgramRunInfo(new ProgramRunInfo.Builder()
+                                     .setNamespace("ns").setApplication("app").setVersion("1.0")
+                                     .setProgramType("workflow").setProgram("program").setRun("runId").build());
+
+    Cluster cdapClusterInput = new Cluster("mycluster", ClusterStatus.CREATING,
+                                           Collections.emptyList(), Collections.emptyMap());
+
+    Mockito.when(dataprocClient.getClusterStatus("mycluster"))
+      .thenReturn(ClusterStatus.RUNNING);
+
+    Mockito.when(dataprocClient.getLatestOperation("mycluster", "CREATE"))
+      .thenThrow(new RuntimeException("API connection failure"));
+
+    ClusterStatus status = provisioner.getClusterStatus(localContext, cdapClusterInput);
+    Assert.assertEquals(ClusterStatus.RUNNING, status);
+
+    Integer count = localContext.getMetricCounts().get("provisioner.cluster.operation.response.count");
+    Assert.assertNull(count);
+  }
+
+  @Test
+  public void testDataprocUtilsEmitMetricWithExceptionBranches(){
+    MockProvisionerContext localContext = new MockProvisionerContext();
+
+    StatusCode statusCode = Mockito.mock(StatusCode.class);
+    StatusCode.Code realCode = StatusCode.Code.ALREADY_EXISTS;
+    Mockito.when(statusCode.getCode()).thenReturn(realCode);
+
+    ApiException apiException = Mockito.mock(ApiException.class);
+    Mockito.when(apiException.getStatusCode()).thenReturn(statusCode);
+
+    DataprocMetric metricWithApiExp = DataprocMetric.builder("test.api.metric")
+      .setRegion("us-test1")
+      .setException(new Exception(apiException))
+      .build();
+
+    DataprocUtils.emitMetric(localContext, metricWithApiExp);
+
+    DataprocMetric metricWithGenericExp = DataprocMetric.builder("test.generic.metric")
+      .setRegion("us-test1")
+      .setException(new RuntimeException("Generic connection failure"))
+      .build();
+
+    DataprocUtils.emitMetric(localContext, metricWithGenericExp);
+
+    Integer apiCount = localContext.getMetricCounts().get("test.api.metric");
+    Integer genericCount = localContext.getMetricCounts().get("test.generic.metric");
+
+    Assert.assertNotNull(apiCount);
+    Assert.assertNotNull(genericCount);
+    Assert.assertEquals(1, apiCount.intValue());
+    Assert.assertEquals(1, genericCount.intValue());
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.twill.filesystem.LocationFactory;
 
@@ -37,6 +38,7 @@ import org.apache.twill.filesystem.LocationFactory;
 public class MockProvisionerContext implements ProvisionerContext {
 
   private final Map<String, String> properties;
+  private final Map<String, Integer> metricCounts = new ConcurrentHashMap<>();
   private ProgramRunInfo programRunInfo;
   private SparkCompat sparkCompat;
   private VersionInfo appCDAPVersionInfo;
@@ -141,11 +143,17 @@ public class MockProvisionerContext implements ProvisionerContext {
     this.profileName = profileName;
   }
 
+  public Map<String, Integer> getMetricCounts() {
+    return metricCounts;
+  }
+
   @Override
   public ProvisionerMetrics getMetrics(Map<String, String> context) {
     return new ProvisionerMetrics() {
       @Override
-      public void count(String metricName, int delta) {}
+      public void count(String metricName, int delta) {
+        metricCounts.merge(metricName, delta, Integer::sum);
+      }
 
       @Override
       public void gauge(String metricName, long value) {}


### PR DESCRIPTION
This pull request introduces background Long-Running Operation (LRO) tracking within the Dataproc Provisioner to record the final, asynchronous outcomes of cluster creations and deletions.

###  Code Changes 
* **DataprocClient.java:** Implemented `getLatestOperation` to fetch background operation details from the `regional projects.regions.operations` endpoint using cluster and task-type filters.
* **DataprocProvisioner.java:** Added a low-complexity state observer to detect terminal transitions and emit the custom provisioner.operation.response.count metric. Error payloads are mapped cleanly to `ApiException` wrappers.
* **DataprocUtils.java:** Refactored the metric tag registration to export dimensions under the standard "method" key.

### Testing Evidence
* **DataprocClientTest.java:** Verify successful operations queries and clean ApiException propagation.
* **DataprocProvisionerTest.java:**  Asserted that background operation metrics are successfully captured exactly once when the cluster transitions to terminal states (CREATING -> RUNNING and DELETING -> NOT_EXISTS).
* **MockProvisionerContext.java:** Validated that metrics are recorded and aggregated accurately without race conditions in concurrent testing scenarios.