### PR TITLE
Enforce namespace authorization on pipeline draft read endpoints

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/DraftHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/DraftHandler.java
@@ -83,6 +83,7 @@ public class DraftHandler extends AbstractDataPipelineHandler {
                          @QueryParam("sortOrder") @DefaultValue("ASC") String sortOrder,
                          @QueryParam("filter") @Nullable String filter) {
 
+    contextAccessEnforcer.enforce(new NamespaceId(namespaceName), StandardPermission.LIST);
     respond(namespaceName, responder, (namespace) -> {
       if (!draftService.fieldExists(sortBy)) {
         throw new IllegalArgumentException(String.format(
@@ -103,6 +104,7 @@ public class DraftHandler extends AbstractDataPipelineHandler {
   public void getDraft(HttpServiceRequest request, HttpServiceResponder responder,
                        @PathParam("context") String namespaceName,
                        @PathParam("draft") String draftId) {
+    contextAccessEnforcer.enforce(new NamespaceId(namespaceName), StandardPermission.GET);
     respond(namespaceName, responder, (namespace) -> {
       String userId = "";
       DraftId id = new DraftId(namespace, draftId, userId);


### PR DESCRIPTION
## Summary

The pipeline-studio `DraftHandler` read endpoints do not authorize the requested namespace, while the write endpoints on the same resource do:

- `GET listDrafts` and `GET getDraft` call `draftService` directly with **no** `contextAccessEnforcer.enforce(...)`.
- `PUT putDraft` and `DELETE deleteDraft` enforce `new NamespaceId(namespaceName), StandardPermission.UPDATE`.

Because the namespace comes from the `{context}` path parameter and `DraftService.listDrafts`/`getDraft` perform no internal authorization, a user with access to one namespace can read the pipeline drafts of any other namespace — disclosing that namespace's source/sink configuration (connection hosts, JDBC URLs, database names, usernames, and any inlined credentials). `getDraft` returns the full `ETLConfig` and `listDrafts?includeConfig=true` includes configs as well.

The sibling handler in the same `StudioService`, `ConnectionHandler`, already enforces on every read (`listConnections` → `enforceOnParent(..., StandardPermission.LIST)`, `getConnection` → `enforce(..., StandardPermission.GET)`), so this is an omission rather than an intended difference. PRs #13436 and #13463 added enforcement to the draft **write** path only.

## Change

Mirror the write path and `ConnectionHandler`: enforce namespace authorization before serving draft reads.

- `listDrafts` → `contextAccessEnforcer.enforce(new NamespaceId(namespaceName), StandardPermission.LIST)`
- `getDraft` → `contextAccessEnforcer.enforce(new NamespaceId(namespaceName), StandardPermission.GET)`

No behavior change for callers already authorized on the namespace.
