### PR TITLE
Enforce authorization on field-lineage getEndpointSummary endpoint

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LineageHTTPHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LineageHTTPHandler.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.data2.metadata.lineage.field.EndPointField;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.codec.NamespacedEntityIdCodec;
 import io.cdap.cdap.proto.id.DatasetId;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.metadata.lineage.CollapseType;
@@ -142,6 +143,8 @@ public class LineageHTTPHandler extends AbstractHttpHandler {
       @PathParam("program-type") String programType,
       @PathParam("program-name") String programName,
       @PathParam("run-id") String runId) throws Exception {
+    accessEnforcer.enforce(new NamespaceId(namespaceId), authenticationContext.getPrincipal(),
+        StandardPermission.GET);
     ProgramReference programReference = null;
     try {
       RunIds.fromString(runId);


### PR DESCRIPTION
## Summary

`LineageHTTPHandler.getEndpointSummary` (`GET /v3/namespaces/{namespace-id}/apps/{app-name}/{program-type}/{program-name}/runs/{run-id}/endpoints`) returns a program run's field-lineage source/sink endpoints **without any authorization check**, while every other read method in the same handler enforces on the requested resource:

- `datasetLineage` → `accessEnforcer.enforce(datasetInstance, ..., StandardPermission.GET)`
- `datasetFields`, `datasetFieldLineage`, `datasetFieldLineageSummary`, `datasetFieldLineageDetails` → enforce on the `DatasetId`

`getEndpointSummary` calls `fieldLineageAdmin.getEndpoints(...)` directly, and `FieldLineageAdmin.getEndpoints` performs no internal authorization, so the namespace in the `{namespace-id}` path parameter is never checked against the caller. A user with access to one namespace can read another namespace's program-run lineage endpoints.

## Change

Enforce `StandardPermission.GET` on the requested namespace at the start of `getEndpointSummary`, consistent with the other read endpoints in this handler.

No behavior change for callers already authorized on the namespace.
