### PR TITLE
CDAP-21219 : Handle force killing remote job more gracefully to avoid race condition

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
@@ -67,6 +67,7 @@ class RemoteExecutionTwillController implements TwillController {
   private final RemoteProcessController remoteProcessController;
   private final RemoteExecutionService executionService;
   private final long pollCompletedMillis;
+  private final long stopDelayMillis;
   private final boolean terminateWithController;
   private volatile boolean terminateOnServiceStop;
 
@@ -78,6 +79,7 @@ class RemoteExecutionTwillController implements TwillController {
     this.programRunId = programRunId;
     this.runId = RunIds.fromString(programRunId.getRun());
     this.pollCompletedMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
+    this.stopDelayMillis = cConf.getLong(Constants.RuntimeMonitor.REMOTE_STOP_DELAY_SECS, 10) * 1000;
 
     // On start up task succeeded, complete the started stage to unblock the onRunning()
     // On start up task failure, mark this controller as terminated with exception
@@ -122,15 +124,18 @@ class RemoteExecutionTwillController implements TwillController {
     try {
       RuntimeJobStatus status;
       RetryStrategy retryStrategy = RetryStrategies.timeLimit(
-          5, TimeUnit.SECONDS, RetryStrategies.exponentialDelay(500, 2000, TimeUnit.MILLISECONDS));
+          stopDelayMillis, TimeUnit.MILLISECONDS, RetryStrategies.exponentialDelay(500, 2000,
+              TimeUnit.MILLISECONDS));
 
-      // Make sure the remote execution is completed
-      // Give 5 seconds for the remote process to shutdown. After 5 seconds, issues a kill.
+      // Wait for the remote process (e.g. Dataproc job) to complete.
+      // We give 5 sec for the remote process (e.g. DP's master process) to shutdown and another
+      // 5 sec to account for DP's backend propagation delays (CDAP-21219). If we kill/cancel too
+      // early while the job is finishing, it can transition the Dataproc job to an ERROR state .
       long startTime = System.currentTimeMillis();
       while ((status = Retries.callWithRetries(
           remoteProcessController::getStatus, retryStrategy, Exception.class::isInstance))
           == RuntimeJobStatus.RUNNING) {
-        if (System.currentTimeMillis() - startTime >= 5000) {
+        if (System.currentTimeMillis() - startTime >= stopDelayMillis) {
           throw new IllegalStateException(
               "Remote process for " + programRunId + " is still running");
         }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1506,6 +1506,8 @@ public final class Constants {
         "app.program.runtime.monitor.metrics.aggregation.window.secs";
     public static final String METRICS_AGGREGATION_POLL_TIME_MS =
         "app.program.runtime.monitor.metrics.aggregation.polltime.ms";
+    public static final String REMOTE_STOP_DELAY_SECS =
+        "app.program.runtime.monitor.remote.stop.delay.secs";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3367,6 +3367,14 @@
   </property>
 
   <property>
+    <name>app.program.runtime.monitor.remote.stop.delay.secs</name>
+    <value>10</value>
+    <description>
+      Time to wait in seconds for a remote process to shut down before forcing a kill during program completion.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.monitor.batch.size</name>
     <value>1000</value>
     <description>


### PR DESCRIPTION
# Description

This PR fixes a race condition where Dataproc jobs are incorrectly marked as `ERROR` on the Dataproc Console UI (even though they executed and finished successfully on the cluster). 

## Problem & Root Cause
When a Dataproc job completes, there is a **~5-10 second propagation delay** on the Dataproc control plane before the Job status API reflects that the job has terminated. 

During program completion/teardown, the `RemoteExecutionTwillController` polls the remote process status. It had a hardcoded **5-second timeout** to wait for the job to stop. First the CDF master process on Dataproc takes few seconds to exit and **now there is a new Dataproc control plane delay for job status** ,because of which the status query still returned `RUNNING` after 5 seconds. This timed out the loop and triggered the force-kill flow (`cancelJob`).

Because the job was actually already finished (or finishing) on the cluster, calling `cancelJob` resulted in a state conflict on Dataproc's end. Dataproc's control plane handled this conflict by transitioning the job to an `ERROR` state with details:
* `Cancellation for task ... is not supported in the current state: DONE`
* `Failed to cancel task ... Task doesn't exist` (in case the cluster was already deleted).

## Solution
1. **Configurable Wait Timeout**: Introduced a new configuration property `app.program.runtime.monitor.remote.stop.wait.timeout.secs` (defaulting to `10` seconds, up from the hardcoded `5` seconds) to give the Dataproc control plane enough time to propagate the terminated status.
2. **Synchronized Retry Strategy**: Updated the `RetryStrategies.timeLimit` in `RemoteExecutionTwillController.complete()` to match the new configured timeout so that transient API/network retries don't trigger a premature kill.

> [!NOTE]
> * In most cases (approx. 9 out of 10 runs), the Dataproc job will already be in a completed state when we query it, allowing us to exit the retry loop early (we check the status every 0.5s to 2 s) .
> * Increasing the timeout to 10 seconds will not impact the performance of most runs, as the full 10-second delay is rarely encountered.

### Testing 

- Ran 250 runs , and all the dataproc jobs were successful. 
- before fix : 50 runs would result in at least 6-7 failures 
---
