### PR TITLE
[cherry-pick][6.11][CDAP-21219]Make remote execution stop wait timeout configurable to ensure clean job termination

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
@@ -67,6 +67,7 @@ class RemoteExecutionTwillController implements TwillController {
   private final RemoteProcessController remoteProcessController;
   private final RemoteExecutionService executionService;
   private final long pollCompletedMillis;
+  private final long stopDelayMillis;
   private final boolean terminateWithController;
   private volatile boolean terminateOnServiceStop;
 
@@ -78,6 +79,7 @@ class RemoteExecutionTwillController implements TwillController {
     this.programRunId = programRunId;
     this.runId = RunIds.fromString(programRunId.getRun());
     this.pollCompletedMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
+    this.stopDelayMillis = cConf.getLong(Constants.RuntimeMonitor.REMOTE_STOP_DELAY_SECS, 10) * 1000;
 
     // On start up task succeeded, complete the started stage to unblock the onRunning()
     // On start up task failure, mark this controller as terminated with exception
@@ -122,15 +124,18 @@ class RemoteExecutionTwillController implements TwillController {
     try {
       RuntimeJobStatus status;
       RetryStrategy retryStrategy = RetryStrategies.timeLimit(
-          5, TimeUnit.SECONDS, RetryStrategies.exponentialDelay(500, 2000, TimeUnit.MILLISECONDS));
+          stopDelayMillis, TimeUnit.MILLISECONDS, RetryStrategies.exponentialDelay(500, 2000,
+              TimeUnit.MILLISECONDS));
 
-      // Make sure the remote execution is completed
-      // Give 5 seconds for the remote process to shutdown. After 5 seconds, issues a kill.
+      // Wait for the remote process (e.g. Dataproc job) to complete.
+      // We give 5 sec for the remote process (e.g. DP's master process) to shutdown and another
+      // 5 sec to account for DP's backend propagation delays (CDAP-21219). If we kill/cancel too
+      // early while the job is finishing, it can transition the Dataproc job to an ERROR state .
       long startTime = System.currentTimeMillis();
       while ((status = Retries.callWithRetries(
           remoteProcessController::getStatus, retryStrategy, Exception.class::isInstance))
           == RuntimeJobStatus.RUNNING) {
-        if (System.currentTimeMillis() - startTime >= 5000) {
+        if (System.currentTimeMillis() - startTime >= stopDelayMillis) {
           throw new IllegalStateException(
               "Remote process for " + programRunId + " is still running");
         }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1506,6 +1506,8 @@ public final class Constants {
         "app.program.runtime.monitor.metrics.aggregation.window.secs";
     public static final String METRICS_AGGREGATION_POLL_TIME_MS =
         "app.program.runtime.monitor.metrics.aggregation.polltime.ms";
+    public static final String REMOTE_STOP_DELAY_SECS =
+        "app.program.runtime.monitor.remote.stop.delay.secs";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3362,6 +3362,14 @@
   </property>
 
   <property>
+    <name>app.program.runtime.monitor.remote.stop.delay.secs</name>
+    <value>10</value>
+    <description>
+      Time to wait in seconds for a remote process to shut down before forcing a kill during program completion.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.monitor.batch.size</name>
     <value>1000</value>
     <description>


### PR DESCRIPTION
Orignal PR : #16177 