### PR TITLE
security: add authorization checks to MetricsHandler

### DIFF
--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsHandler.java
@@ -19,7 +19,11 @@ package io.cdap.cdap.metrics.query;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
+import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -47,10 +51,42 @@ public class MetricsHandler extends AbstractHttpHandler {
   private static final Gson GSON = new Gson();
 
   private final MetricsQueryHelper metricsQueryHelper;
+  private final ContextAccessEnforcer accessEnforcer;
 
   @Inject
-  public MetricsHandler(MetricsQueryHelper metricsQueryHelper) {
+  public MetricsHandler(MetricsQueryHelper metricsQueryHelper,
+      ContextAccessEnforcer accessEnforcer) {
     this.metricsQueryHelper = metricsQueryHelper;
+    this.accessEnforcer = accessEnforcer;
+  }
+
+  /**
+   * Enforces {@link StandardPermission#GET} for the namespace targeted by the given metric tags.
+   * Metrics are namespace-scoped (the metric store aggregates on the namespace tag), so reading
+   * them requires GET on that namespace. A {@code null} or wildcard ({@code "*"}) namespace means a
+   * cross-namespace read, which requires GET on the system namespace.
+   */
+  private void enforceNamespace(String namespace) throws AccessException {
+    NamespaceId namespaceId = (namespace == null || "*".equals(namespace))
+        ? NamespaceId.SYSTEM : new NamespaceId(namespace);
+    accessEnforcer.enforce(namespaceId, StandardPermission.GET);
+  }
+
+  /**
+   * Extracts the namespace from a list of {@code name:value} tags and enforces access on it.
+   */
+  private void enforceTags(List<String> tags) throws AccessException {
+    String namespace = null;
+    if (tags != null) {
+      for (String tag : tags) {
+        String[] parts = tag.split(":", 2);
+        if (parts.length == 2 && "namespace".equals(parts[0])) {
+          namespace = parts[1];
+          break;
+        }
+      }
+    }
+    enforceNamespace(namespace);
   }
 
   @POST
@@ -62,6 +98,7 @@ public class MetricsHandler extends AbstractHttpHandler {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Required target param is missing");
       return;
     }
+    enforceTags(tags);
     try {
       switch (target) {
         case "tag":
@@ -99,7 +136,7 @@ public class MetricsHandler extends AbstractHttpHandler {
   public void query(FullHttpRequest request, HttpResponder responder,
       @QueryParam("metric") List<String> metrics,
       @QueryParam("groupBy") List<String> groupBy,
-      @QueryParam("tag") List<String> tags) {
+      @QueryParam("tag") List<String> tags) throws Exception {
     try {
       Map<String, List<String>> queryParams = new QueryStringDecoder(request.uri()).parameters();
       if (queryParams.isEmpty()) {
@@ -108,17 +145,24 @@ public class MetricsHandler extends AbstractHttpHandler {
               GSON.fromJson(request.content().toString(StandardCharsets.UTF_8),
                   new TypeToken<Map<String, MetricsQueryHelper.QueryRequestFormat>>() {
                   }.getType());
+          for (MetricsQueryHelper.QueryRequestFormat batchQuery : queries.values()) {
+            enforceNamespace(batchQuery.getTags().get("namespace"));
+          }
           responder.sendJson(HttpResponseStatus.OK,
               GSON.toJson(metricsQueryHelper.executeBatchQueries(queries)));
           return;
         }
         responder.sendJson(HttpResponseStatus.BAD_REQUEST, "Batch request with empty content");
       }
+      enforceTags(tags);
       responder.sendJson(HttpResponseStatus.OK,
           GSON.toJson(metricsQueryHelper.executeTagQuery(tags, metrics, groupBy, queryParams)));
     } catch (IllegalArgumentException e) {
       LOG.warn("Invalid request", e);
       responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+    } catch (AccessException e) {
+      // Let the framework map authorization failures to 403 instead of swallowing them as 500.
+      throw e;
     } catch (Exception e) {
       LOG.error("Exception querying metrics ", e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
### Summary

The Studio metrics endpoints in `MetricsHandler` (`cdap-watchdog`) select metrics by
caller-supplied `tag` values (`namespace`, `app`, `program`, …) but never enforce
authorization, so any authenticated user can read or enumerate the operational metrics
of **any** namespace/app/program:

- `POST /v3/metrics/query` → `MetricsQueryHelper.executeBatchQueries` / `executeTagQuery`
- `POST /v3/metrics/search` → `searchTags` / `searchMetric`

The CDAP router authenticates but does not perform per-resource authorization — that is
the handler's responsibility. The sibling observability handler in the **same module**,
`LogHttpHandler`, already enforces `StandardPermission.GET` on the target program before
returning logs (`ensureVisibilityOnProgram`); `MetricsHandler` was added without the
equivalent check. Metrics are namespace-scoped — `DefaultMetricStore` aggregates on the
namespace tag — so this is a real cross-namespace authorization gap, not just a modeling
concern.

### Fix

Inject `ContextAccessEnforcer` and, before executing any query/search, derive the target
namespace from the request tags and enforce `StandardPermission.GET`:

- a query naming a namespace requires `GET` on that `NamespaceId`;
- a namespace-less (cross-namespace) query requires `GET` on the system namespace;
- for the batch path, each sub-query's tags are enforced individually.

`ContextAccessEnforcer` is already bound in the metrics-query injector
(`MetricsTwillRunnable` / `MetricsServiceMain` / `StandaloneMain` all install
`AuthorizationEnforcementModule`), so no wiring change is needed. This mirrors the
existing `security: add authorization checks to …` handler hardening.

### Testing

I verified the gap and the enforcement points by source inspection (no `AccessEnforcer`
reference existed in `MetricsHandler`, unlike its sibling `LogHttpHandler`). I don't have
a local Apple/CI build environment to run the watchdog suite; happy to add a unit test
(e.g. asserting an unauthorized principal is rejected before the query executes) in the
style the reviewers prefer.
