### PR TITLE
Require UPDATE permission for markAppsAsLatest and updateSourceControlMeta

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -1682,6 +1682,11 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       }
     }
 
+    Principal principal = authenticationContext.getPrincipal();
+    for (ApplicationId appId : appIds) {
+      accessEnforcer.enforce(appId, principal, StandardPermission.UPDATE);
+    }
+
     store.markApplicationsLatest(appIds);
   }
 
@@ -1698,6 +1703,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   public void updateSourceControlMeta(NamespaceId namespace, UpdateMultiSourceControlMetaReqeust appsRequest)
       throws IOException, BadRequestException {
     Map<ApplicationId, SourceControlMeta> updateScmMetaRequests = new HashMap<>();
+    Principal principal = authenticationContext.getPrincipal();
     for (UpdateSourceControlMetaRequest appRequest : appsRequest.getApps()) {
       ApplicationId appId;
       try {
@@ -1705,6 +1711,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       } catch (IllegalArgumentException | NullPointerException e) {
         throw new BadRequestException(e.getMessage(), e);
       }
+      accessEnforcer.enforce(appId, principal, StandardPermission.UPDATE);
 
       if (appRequest.getGitFileHash() == null || appRequest.getGitFileHash().isEmpty()) {
         throw new BadRequestException(String.format(

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceMarkLatestAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceMarkLatestAuthorizationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import static org.mockito.Mockito.mock;
+
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.metrics.MetricsSystemClient;
+import io.cdap.cdap.app.deploy.ManagerFactory;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
+import io.cdap.cdap.data2.registry.UsageRegistry;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
+import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
+import io.cdap.cdap.internal.capability.CapabilityReader;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.app.AppVersion;
+import io.cdap.cdap.proto.app.MarkLatestAppsRequest;
+import io.cdap.cdap.proto.app.UpdateMultiSourceControlMetaReqeust;
+import io.cdap.cdap.proto.app.UpdateSourceControlMetaRequest;
+import io.cdap.cdap.proto.id.InstanceId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.Authorizable;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.impersonation.Impersonator;
+import io.cdap.cdap.security.impersonation.OwnerAdmin;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
+import io.cdap.cdap.security.authorization.DefaultContextAccessEnforcer;
+import io.cdap.cdap.security.authorization.InMemoryAccessController;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import java.util.Collections;
+import java.util.HashSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * {@link ApplicationLifecycleService#markAppsAsLatest} and {@link
+ * ApplicationLifecycleService#updateSourceControlMeta} are reachable from any authenticated
+ * caller via {@code AppLifecycleHttpHandlerInternal}, which is registered on the same
+ * general-purpose APP_FABRIC_HTTP surface as every public v3 handler (see
+ * AppFabricServiceRuntimeModule). Unlike every other mutating method on this class
+ * (deleteAllStates, removeApplication, deleteApplication, scanApplications), neither method
+ * enforced any permission on the applications it touches, so a caller with zero access to a
+ * namespace could flip which app version is treated as "latest" (the version used when a run
+ * is triggered without an explicit version) or overwrite another tenant's git source-control
+ * metadata.
+ */
+public class ApplicationLifecycleServiceMarkLatestAuthorizationTest {
+
+  private static final Principal UNPRIVILEGED_PRINCIPAL = new Principal("unprivileged",
+      Principal.PrincipalType.USER);
+  private static final NamespaceId VICTIM_NAMESPACE = new NamespaceId("victim-tenant");
+
+  private ApplicationLifecycleService service;
+  private Store store;
+
+  @Before
+  public void setup() {
+    // Real enforcement stack (same utility classes used by
+    // FileFetcherHttpHandlerInternalAuthorizationTest / ConfigHandlerAuthorizationTest):
+    // nobody has been granted anything, so any enforce() call must reject
+    // UNPRIVILEGED_PRINCIPAL.
+    InMemoryAccessController inMemoryAccessController = new InMemoryAccessController();
+    inMemoryAccessController.grant(Authorizable.fromEntityId(InstanceId.SELF),
+        new Principal("master", Principal.PrincipalType.USER),
+        Collections.unmodifiableSet(new HashSet<>(Collections.singletonList(
+            StandardPermission.GET))));
+    AuthenticationContext authenticationContext = new AuthenticationTestContext();
+    DefaultContextAccessEnforcer accessEnforcer = new DefaultContextAccessEnforcer(
+        authenticationContext, inMemoryAccessController);
+
+    store = mock(Store.class);
+
+    CConfiguration cConf = CConfiguration.create();
+    service = new ApplicationLifecycleService(cConf, store, mock(ScheduleManager.class),
+        mock(UsageRegistry.class), mock(PreferencesService.class),
+        mock(MetricsSystemClient.class), mock(OwnerAdmin.class),
+        mock(ArtifactRepository.class),
+        mock(ManagerFactory.class),
+        mock(MetadataServiceClient.class), accessEnforcer, authenticationContext,
+        mock(MessagingService.class), mock(Impersonator.class), mock(CapabilityReader.class),
+        mock(MetricsCollectionService.class));
+
+    AuthenticationTestContext.actAsPrincipal(UNPRIVILEGED_PRINCIPAL);
+  }
+
+  @Test
+  public void testMarkAppsAsLatestRejectsUnprivilegedCaller() throws Exception {
+    MarkLatestAppsRequest request = new MarkLatestAppsRequest(
+        Collections.singletonList(new AppVersion("billing-pipeline", "1.0")));
+
+    try {
+      service.markAppsAsLatest(VICTIM_NAMESPACE, request);
+      Assert.fail("an unprivileged caller must not be able to mark an application as latest "
+          + "in a namespace they have no access to");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    Mockito.verifyNoInteractions(store);
+  }
+
+  @Test
+  public void testUpdateSourceControlMetaRejectsUnprivilegedCaller() throws Exception {
+    UpdateMultiSourceControlMetaReqeust request = new UpdateMultiSourceControlMetaReqeust(
+        Collections.singletonList(
+            new UpdateSourceControlMetaRequest("billing-pipeline", "1.0", "deadbeef")),
+        "commit-id");
+
+    try {
+      service.updateSourceControlMeta(VICTIM_NAMESPACE, request);
+      Assert.fail("an unprivileged caller must not be able to overwrite another tenant's "
+          + "source control metadata");
+    } catch (UnauthorizedException expected) {
+      // expected
+    }
+    Mockito.verifyNoInteractions(store);
+  }
+}


### PR DESCRIPTION
ApplicationLifecycleService.markAppsAsLatest() and updateSourceControlMeta() (cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java) mutate application state with no authorization check at all, unlike every other mutating method on this class: deleteAllStates and removeApplication both call accessEnforcer.enforce() before touching the store, these two didn't call it anywhere.

Both are reachable from any authenticated principal via AppLifecycleHttpHandlerInternal (POST /v3Internal/namespaces/{namespace-id}/apps/markLatest and .../apps/updateSourceControlMeta). That handler is registered on the exact same APP_FABRIC_HTTP server / SERVER_HANDLERS_BINDING Guice multibinder as every public v3 handler (AppFabricServiceRuntimeModule.java:539-541), so it's reachable on the general HTTP surface, not some network-isolated internal-only service. The handler itself only checks namespaceQueryAdmin.exists(namespaceId), namespace existence, not caller access to that namespace.

Impact: markAppsAsLatest flips which application version is treated as "latest", the version used when a program run is triggered without an explicit version pinned (this is the same isLatest flag AppMetadataStore/DefaultStore use to resolve the default version for a run). updateSourceControlMeta overwrites an application's git commit hash / source-control metadata. A caller with zero access to a namespace, someone who only knows or guesses that namespace exists, can perform either mutation against applications they don't own.

Fix adds a StandardPermission.UPDATE enforce() call per ApplicationId before either mutation, mirroring the existing deleteAllStates/removeApplication pattern, plus a regression test (ApplicationLifecycleServiceMarkLatestAuthorizationTest) built on the same real InMemoryAccessController/DefaultContextAccessEnforcer/AuthenticationTestContext stack used by ConfigHandlerAuthorizationTest and FileFetcherHttpHandlerInternalAuthorizationTest, verifying both methods now reject an unprivileged caller and never touch the store.

Verification note: the full Maven reactor build is too slow to complete in this environment (same caveat as #16188/#16191/#16192). The fix was checked against the real source and sibling enforce() call sites line by line; the vulnerable control flow (both methods having zero enforcement while sibling methods in the same class have it) was independently reproduced in a standalone JDK harness that copies the real method bodies verbatim against a stub AccessEnforcer, confirming an unprivileged principal is rejected by the sibling method but not by the two unfixed ones. The new test was checked for type/signature correctness against the real constructor and utility classes but not executed locally; correctness will be confirmed by CI.
