### PR TITLE
 Fix Dataproc LRO metric emission logic for cluster deletion and corrected the  metric name

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -496,7 +496,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
           "provisioner.clusterStatus.response.count");
 
       if (hasReachedTerminalState(previousStatus, status)) {
-        emitLroMetric(context, client, conf, previousStatus, clusterName);
+        emitLroMetric(context, client, conf, previousStatus, status, clusterName);
       }
       return status;
     } catch (Exception e) {
@@ -521,21 +521,14 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
    * @param clusterName the name of the cluster
    */
   private void emitLroMetric(ProvisionerContext context, DataprocClient client, DataprocConf conf,
-                             ClusterStatus previousStatus, String clusterName) {
+                             ClusterStatus previousStatus, ClusterStatus currentStatus, String clusterName) {
     String method = getMethod(previousStatus);
     if (method == null) {
       return;
     }
 
     try {
-      Optional<Operation> operation = client.getLatestOperation(clusterName, method);
-
-      if (!operation.isPresent() || !operation.get().getDone()) {
-        return;
-      }
-
-      Operation op = operation.get();
-      String metricName = "provisioner.operation.response.count";
+      String metricName = "provisioner.cluster.operation.response.count";
       String imageVersion = getImageVersion(context, conf);
 
       DataprocMetric.Builder builder = DataprocMetric.builder(metricName)
@@ -543,12 +536,25 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
         .setImageVersion(imageVersion)
         .setMethod(method);
 
+      if ("DELETE".equals(method) && currentStatus == ClusterStatus.NOT_EXISTS) {
+        builder.setStatusCode(StatusCode.Code.OK);
+        DataprocUtils.emitMetric(context, builder.build());
+        return;
+      }
+
+      Optional<Operation> operation = client.getLatestOperation(clusterName, method);
+
+      if (!operation.isPresent() || !operation.get().getDone()) {
+        return;
+      }
+
+      Operation op = operation.get();
+
       if (op.hasError()) {
         Status.Code grpcCode = Status.fromCodeValue(op.getError().getCode()).getCode();
         StatusCode gaxStatusCode = GrpcStatusCode.of(grpcCode);
         builder.setStatusCode(gaxStatusCode.getCode());
       }
-
       DataprocUtils.emitMetric(context, builder.build());
     } catch (RetryableProvisionException | RuntimeException ex) {
       LOG.warn("Failed to retrieve LRO operation metadata for metric emission on cluster {}", clusterName, ex);

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -528,7 +528,7 @@ public class DataprocProvisionerTest {
     ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
     Assert.assertEquals(ClusterStatus.RUNNING, currentStatus);
 
-    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Integer count = localContext.getMetricCounts().get("provisioner.cluster.operation.response.count");
     Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
     Assert.assertEquals(1, count.intValue());
   }
@@ -550,17 +550,10 @@ public class DataprocProvisionerTest {
     Mockito.when(dataprocClient.getClusterStatus(Mockito.anyString()))
       .thenReturn(ClusterStatus.NOT_EXISTS);
 
-    Operation operation = Operation.newBuilder()
-      .setName("op-delete")
-      .setDone(true)
-      .build();
-    Mockito.when(dataprocClient.getLatestOperation(Mockito.anyString(), Mockito.anyString()))
-      .thenReturn(Optional.of(operation));
-
     ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
     Assert.assertEquals(ClusterStatus.NOT_EXISTS, currentStatus);
 
-    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Integer count = localContext.getMetricCounts().get("provisioner.cluster.operation.response.count");
     Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
     Assert.assertEquals(1, count.intValue());
   }
@@ -597,7 +590,7 @@ public class DataprocProvisionerTest {
     ClusterStatus currentStatus = provisioner.getClusterStatus(localContext, cdapClusterInput);
     Assert.assertEquals(ClusterStatus.FAILED, currentStatus);
 
-    Integer count = localContext.getMetricCounts().get("provisioner.operation.response.count");
+    Integer count = localContext.getMetricCounts().get("provisioner.cluster.operation.response.count");
     Assert.assertNotNull("The LRO metric was not emitted or recorded in the mock context", count);
     Assert.assertEquals(1, count.intValue());
   }


### PR DESCRIPTION
This PR updates the LRO metric emission logic for Dataproc cluster deletions and corrects the associated metric name mapping.

**Changes:**
- **Bypass API for Deleted Clusters:** Modifies the provisioner to safely bypass the Dataproc `listOperations` API call during `DELETE` operations. 
- **Correct Metric Name:** Corrected the emitted metric name from `provisioner.operation.response.count` to `provisioner.cluster.operation.response.count`.
