### PR TITLE
Fix Docker build by downloading Chef 13 from Internet Archive mirror

### DIFF
--- a/cdap-distributions/src/Dockerfile
+++ b/cdap-distributions/src/Dockerfile
@@ -49,7 +49,7 @@ COPY packer/scripts /tmp/scripts
 COPY packer/files /tmp/files
 
 # Install Chef, setup APT, run Chef cdap::sdk recipe, then clean up
-RUN curl -O https://packages.chef.io/files/stable/chef/13.8.5/ubuntu/16.04/chef_13.8.5-1_amd64.deb && \
+RUN curl -fL -O https://web.archive.org/web/20190929120928id_/https://packages.chef.io/files/stable/chef/13.8.5/ubuntu/16.04/chef_13.8.5-1_amd64.deb && \
     dpkg-sig --verify chef_13.8.5-1_amd64.deb && \
     dpkg -i chef_13.8.5-1_amd64.deb && \
     for i in apt-setup.sh cookbook-dir.sh cookbook-setup.sh ; do /tmp/scripts/$i ; done && \


### PR DESCRIPTION
**Background / Context:**
Recently, Progress Software (the company behind Chef) placed their entire historical package repository (`packages.chef.io`) behind a commercial authentication wall. 

Current failure https://github.com/cdapio/cdap-build/actions/runs/31320262213

**The Fix:**
To restore the build, this PR updates the `curl` URL to pull from the [Internet Archive (Wayback Machine) snapshot](https://web.archive.org/web/20190929120928id_/https://packages.chef.io/files/stable/chef/13.8.5/ubuntu/16.04/chef_13.8.5-1_amd64.deb). 
