### PR TITLE
CDAP-21265 : adding support for TTL in adding secret.

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/security/store/SecureStoreManager.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/security/store/SecureStoreManager.java
@@ -42,6 +42,23 @@ public interface SecureStoreManager {
       Map<String, String> properties) throws Exception;
 
   /**
+   * Stores an element in the secure store with a Time-to-Live (TTL).
+   * The default implementation delegates to the standard put, ignoring the TTL.
+   *
+   * @param namespace The namespace that this key belongs to
+   * @param name This is the identifier that will be used to retrieve this element
+   * @param data The sensitive data that has to be securely stored
+   * @param description User provided description of the entry
+   * @param properties associated with this element
+   * @param ttlInSeconds Time-To-Live for the secret in seconds.
+   * @throws Exception If the attempt to store the element failed
+   */
+  default void put(String namespace, String name, String data, @Nullable String description,
+      Map<String, String> properties, long ttlInSeconds) throws Exception {
+    put(namespace, name, data, description, properties);
+  }
+
+  /**
    * Deletes the element with the given name.
    *
    * @param namespace The namespace that this key belongs to

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultAdmin.java
@@ -79,6 +79,14 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
   }
 
   @Override
+  public void put(String namespace, String name, String data,
+      @Nullable String description, Map<String, String> properties, long ttlInSeconds) throws Exception {
+    Retries.runWithRetries(
+        () -> secureStoreManager.put(namespace, name, data, description, properties, ttlInSeconds),
+        retryStrategy);
+  }
+
+  @Override
   public void delete(String namespace, String name) throws Exception {
     Retries.runWithRetries(() -> secureStoreManager.delete(namespace, name), retryStrategy);
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/SecureKeyCreateRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/SecureKeyCreateRequest.java
@@ -28,12 +28,22 @@ public class SecureKeyCreateRequest {
   private final String description;
   private final String data;
   private final Map<String, String> properties;
+  private final long ttlInSeconds;
 
   public SecureKeyCreateRequest(@Nullable String description, String data,
       Map<String, String> properties) {
+    this(description, data, properties, 0L);
+  }
+
+  public SecureKeyCreateRequest(@Nullable String description, String data,
+      Map<String, String> properties, long ttlInSeconds) {
+    if (ttlInSeconds < 0) {
+      throw new IllegalArgumentException("TTL cannot be negative");
+    }
     this.description = description;
     this.data = data;
     this.properties = properties;
+    this.ttlInSeconds = ttlInSeconds;
   }
 
   @Nullable
@@ -47,6 +57,10 @@ public class SecureKeyCreateRequest {
 
   public Map<String, String> getProperties() {
     return properties == null ? Collections.emptyMap() : properties;
+  }
+
+  public long getTtlInSeconds() {
+    return ttlInSeconds;
   }
 
   @Override

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
@@ -76,14 +76,14 @@ public class CloudSecretManagerClient {
    *
    * @throws ApiException if Google API call fails.
    */
-  public void createSecret(WrappedSecret wrappedSecret) {
+  public void createSecret(WrappedSecret wrappedSecret, long ttlInSeconds) {
     CreateSecretRequest request =
       CreateSecretRequest.newBuilder()
         .setParent(projectResourceName)
         .setSecretId(
           getSecretId(
             wrappedSecret.getNamespace(), wrappedSecret.getCdapSecretMetadata().getName()))
-        .setSecret(wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret)))
+        .setSecret(wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret), ttlInSeconds))
         .build();
 
     secretManager.createSecret(request);
@@ -164,11 +164,15 @@ public class CloudSecretManagerClient {
    *
    * @throws ApiException if Google API call fails.
    */
-  public void updateSecret(WrappedSecret wrappedSecret) {
+  public void updateSecret(WrappedSecret wrappedSecret, long ttlInSeconds) {
     // Update all fields.
+    FieldMask.Builder fieldMask = FieldMask.newBuilder().addPaths("annotations");
+    if (ttlInSeconds > 0) {
+      fieldMask.addPaths("ttl");
+    }
     secretManager.updateSecret(
-      wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret)),
-      FieldMask.newBuilder().addPaths("annotations").build());
+      wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret), ttlInSeconds),
+      fieldMask.build());
   }
 
   /**

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManager.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManager.java
@@ -63,12 +63,17 @@ public class GcpSecretManager implements SecretManager {
 
   @Override
   public void store(String namespace, Secret secret) throws IOException {
+    store(namespace, secret, 0L);
+  }
+
+  @Override
+  public void store(String namespace, Secret secret, long ttlInSeconds) throws IOException {
     WrappedSecret wrappedSecret = WrappedSecret.fromMetadata(namespace, secret.getMetadata());
 
     try {
       Secret existingSecret = get(namespace, secret.getMetadata().getName());
       // 'update' only if 'get' request succeeds, otherwise 'create'.
-      client.updateSecret(wrappedSecret);
+      client.updateSecret(wrappedSecret, ttlInSeconds);
 
       // Add a new secret version only if the secret payload has changed.
       if (!Arrays.equals(existingSecret.getData(), secret.getData())) {
@@ -76,7 +81,7 @@ public class GcpSecretManager implements SecretManager {
       }
     } catch (SecretNotFoundException unused) {
       try {
-        client.createSecret(wrappedSecret);
+        client.createSecret(wrappedSecret, ttlInSeconds);
         client.addSecretVersion(wrappedSecret, secret.getData());
       } catch (ApiException e) {
         throw new IOException("Secret Manager create API call failed", e);

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/WrappedSecret.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/WrappedSecret.java
@@ -22,6 +22,7 @@ import com.google.cloud.secretmanager.v1.Secret;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.protobuf.Duration;
 import com.google.protobuf.util.Timestamps;
 import io.cdap.cdap.securestore.spi.secret.SecretMetadata;
 
@@ -76,8 +77,8 @@ public final class WrappedSecret {
    *
    * @param resourceName Value to set for the "name" field needed for update operations.
    */
-  public Secret getGcpSecret(String resourceName) {
-    return Secret.newBuilder()
+  public Secret getGcpSecret(String resourceName, long ttlInSeconds) {
+    Secret.Builder builder = Secret.newBuilder()
       // Set replication policy to automatic (as opposed to user-managed) and do not specify a
       // CMEK (use google-managed key).
       .setReplication(Replication.newBuilder().setAutomatic(Automatic.getDefaultInstance()))
@@ -85,8 +86,12 @@ public final class WrappedSecret {
       .putAnnotations("cdap_namespace", namespace)
       .putAnnotations("cdap_secret_name", secretMetadata.getName())
       .putAnnotations("cdap_description", Optional.ofNullable(secretMetadata.getDescription()).orElse(""))
-      .putAnnotations("cdap_props", serializeProps(secretMetadata.getProperties()))
-      .build();
+      .putAnnotations("cdap_props", serializeProps(secretMetadata.getProperties()));
+      
+    if (ttlInSeconds > 0) {
+      builder.setTtl(Duration.newBuilder().setSeconds(ttlInSeconds).build());
+    }
+    return builder.build();
   }
 
   private static SecretMetadata toSecretMetadata(Secret secret) throws InvalidSecretException {

--- a/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
@@ -67,9 +67,37 @@ public class GcpSecretManagerTest {
 
     secretManager.store(NAMESPACE, createSecret("example"));
 
-    verify(client, times(1)).createSecret(ArgumentMatchers.any());
+    verify(client, times(1)).createSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
     verify(client, times(1)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
-    verify(client, times(0)).updateSecret(ArgumentMatchers.any());
+    verify(client, times(0)).updateSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
+  }
+
+
+  @Test
+  public void store_createWithTtl() throws Exception {
+    ApiException exception = createApiException(Code.NOT_FOUND);
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any())).thenThrow(exception);
+
+    secretManager.store(NAMESPACE, createSecret("example-ttl"), 3600L);
+
+    verify(client, times(1)).createSecret(ArgumentMatchers.any(), eq(3600L));
+    verify(client, times(1)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
+    verify(client, times(0)).updateSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
+  }
+
+  @Test
+  public void store_updateWithTtl() throws Exception {
+    byte[] payload = "Foo".getBytes();
+    SecretMetadata metadata = createMetadata("example-ttl-update");
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
+    when(client.getSecretData(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(payload);
+
+    secretManager.store(NAMESPACE, new Secret(payload, metadata), 1800L);
+
+    verify(client, times(0)).createSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
+    verify(client, times(1)).updateSecret(ArgumentMatchers.any(), eq(1800L));
+    verify(client, times(0)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
   }
 
   @Test
@@ -84,8 +112,8 @@ public class GcpSecretManagerTest {
     secretManager.store(NAMESPACE, new Secret(payload, metadata));
 
     // Update, not create called. No secret version added.
-    verify(client, times(0)).createSecret(ArgumentMatchers.any());
-    verify(client, times(1)).updateSecret(ArgumentMatchers.any());
+    verify(client, times(0)).createSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
+    verify(client, times(1)).updateSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
     verify(client, times(0)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
   }
 
@@ -102,7 +130,7 @@ public class GcpSecretManagerTest {
     secretManager.store(NAMESPACE, new Secret(newPayload, metadata));
 
     // Update called, secret version added.
-    verify(client, times(1)).updateSecret(ArgumentMatchers.any());
+    verify(client, times(1)).updateSecret(ArgumentMatchers.any(), ArgumentMatchers.anyLong());
     verify(client, times(1)).addSecretVersion(ArgumentMatchers.any(), eq(newPayload));
   }
 

--- a/cdap-securestore-spi/src/main/java/io/cdap/cdap/securestore/spi/SecretManager.java
+++ b/cdap-securestore-spi/src/main/java/io/cdap/cdap/securestore/spi/SecretManager.java
@@ -56,6 +56,14 @@ public interface SecretManager {
   void store(String namespace, Secret secret) throws IOException;
 
   /**
+   * Securely stores secret for a given namespace with a Time-To-Live.
+   * By default delegates to store() ignoring the TTL.
+   */
+  default void store(String namespace, Secret secret, long ttlInSeconds) throws IOException {
+    store(namespace, secret);
+  }
+
+  /**
    * Returns securely stored secret along with its metadata as a {@link Secret}.
    *
    * @param namespace the namespace that this secret belongs to

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/DefaultSecureStoreService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/DefaultSecureStoreService.java
@@ -119,11 +119,23 @@ public class DefaultSecureStoreService extends AbstractIdleService implements Se
   public final synchronized void put(String namespace, String name, String value,
       @Nullable String description,
       Map<String, String> properties) throws Exception {
+    enforceUpdateAccess(namespace, name);
+    secureStoreService.put(namespace, name, value, description, properties);
+  }
+
+  @Override
+  public final synchronized void put(String namespace, String name, String value,
+      @Nullable String description,
+      Map<String, String> properties, long ttlInSeconds) throws Exception {
+    enforceUpdateAccess(namespace, name);
+    secureStoreService.put(namespace, name, value, description, properties, ttlInSeconds);
+  }
+
+  private void enforceUpdateAccess(String namespace, String name) throws Exception {
     Principal principal = authenticationContext.getPrincipal();
     NamespaceId namespaceId = new NamespaceId(namespace);
     SecureKeyId secureKeyId = namespaceId.secureKey(name);
     accessEnforcer.enforce(secureKeyId, principal, StandardPermission.UPDATE);
-    secureStoreService.put(namespace, name, value, description, properties);
   }
 
   /**

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/SecureStoreHandler.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/SecureStoreHandler.java
@@ -81,7 +81,7 @@ public class SecureStoreHandler extends AbstractHttpHandler {
       secureKeyCreateRequest = parseBody(httpRequest);
     } catch (IOException e) {
       SecureKeyCreateRequest dummy = new SecureKeyCreateRequest("<description>", "<data>",
-          ImmutableMap.of("key", "value"));
+          ImmutableMap.of("key", "value"), 3600L);
       throw new BadRequestException(
           "Unable to parse the request. The request body should be of the following format."
               + " \n" + GSON.toJson(dummy));
@@ -95,7 +95,8 @@ public class SecureStoreHandler extends AbstractHttpHandler {
     }
 
     secureStoreManager.put(namespace, name, secureKeyCreateRequest.getData(),
-        secureKeyCreateRequest.getDescription(), secureKeyCreateRequest.getProperties());
+        secureKeyCreateRequest.getDescription(), secureKeyCreateRequest.getProperties(),
+        secureKeyCreateRequest.getTtlInSeconds());
     httpResponder.sendStatus(HttpResponseStatus.OK);
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/client/RemoteSecureStore.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/client/RemoteSecureStore.java
@@ -102,8 +102,18 @@ public class RemoteSecureStore implements SecureStoreManager, SecureStore {
   @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
-    SecureKeyCreateRequest createRequest = new SecureKeyCreateRequest(description, data,
-        properties);
+    SecureKeyCreateRequest createRequest = new SecureKeyCreateRequest(description, data, properties);
+    putInternal(namespace, name, createRequest);
+  }
+
+  @Override
+  public void put(String namespace, String name, String data, @Nullable String description,
+      Map<String, String> properties, long ttlInSeconds) throws Exception {
+    SecureKeyCreateRequest createRequest = new SecureKeyCreateRequest(description, data, properties, ttlInSeconds);
+    putInternal(namespace, name, createRequest);
+  }
+
+  private void putInternal(String namespace, String name, SecureKeyCreateRequest createRequest) throws Exception {
     HttpRequest request = remoteClient.requestBuilder(HttpMethod.PUT, createPath(namespace, name))
         .withBody(GSON.toJson(createRequest)).build();
     HttpResponse response = remoteClient.execute(request, Idempotency.IDEMPOTENT);

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
@@ -141,10 +141,25 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
+    putInternal(namespace, name, data, description, properties, null);
+  }
+
+  @Override
+  public void put(String namespace, String name, String data, @Nullable String description,
+      Map<String, String> properties, long ttlInSeconds) throws Exception {
+    putInternal(namespace, name, data, description, properties, ttlInSeconds);
+  }
+
+  private void putInternal(String namespace, String name, String data, @Nullable String description,
+      Map<String, String> properties, @Nullable Long ttlInSeconds) throws Exception {
     validate(namespace);
-    secretManager.store(namespace, new Secret(data.getBytes(StandardCharsets.UTF_8),
-        new SecretMetadata(name, description, System.currentTimeMillis(),
-            ImmutableMap.copyOf(properties))));
+    Secret secret = new Secret(data.getBytes(StandardCharsets.UTF_8),
+        new SecretMetadata(name, description, System.currentTimeMillis(), ImmutableMap.copyOf(properties)));
+    if (ttlInSeconds != null) {
+      secretManager.store(namespace, secret, ttlInSeconds);
+    } else {
+      secretManager.store(namespace, secret);
+    }
   }
 
   @Override

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/SecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/SecureStoreTest.java
@@ -147,6 +147,21 @@ public class SecureStoreTest {
   }
 
   @Test
+  public void testCreateWithTTL() throws Exception {
+    SecureKeyCreateRequest secureKeyCreateRequest = new SecureKeyCreateRequest(DESCRIPTION, DATA,
+                                                                               PROPERTIES, 3600L);
+    HttpResponse response = create("key_with_ttl", secureKeyCreateRequest);
+    Assert.assertEquals(200, response.getResponseCode());
+
+    response = get("key_with_ttl");
+    Assert.assertEquals(200, response.getResponseCode());
+    Assert.assertEquals(DATA, response.getResponseBodyAsString());
+
+    response = delete("key_with_ttl");
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  @Test
   public void testList() throws Exception {
     // Test empty list
     HttpResponse response = list();

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
@@ -122,6 +122,20 @@ public class RemoteSecureStoreTest {
     Assert.assertEquals(0, remoteSecureStore.list(NAMESPACE1).size());
   }
 
+  @Test
+  public void testRemoteSecureStoreWithTTL() throws Exception {
+    SecureStoreMetadata secureStoreMetadata = new SecureStoreMetadata("key_ttl", "description", 1,
+                                                                      ImmutableMap.of("prop1", "value1"));
+    SecureStoreData secureStoreData = new SecureStoreData(secureStoreMetadata,
+                                                          "value".getBytes(StandardCharsets.UTF_8));
+
+    remoteSecureStore.put(NAMESPACE1, "key_ttl", "value", "description", ImmutableMap.of("prop1", "value1"), 600L);
+    SecureStoreData actual = remoteSecureStore.get(NAMESPACE1, "key_ttl");
+    Assert.assertEquals(secureStoreMetadata.getName(), actual.getMetadata().getName());
+    Assert.assertArrayEquals(secureStoreData.get(), actual.get());
+    Assert.assertEquals(secureStoreMetadata.getDescription(), actual.getMetadata().getDescription());
+  }
+
   @Test(expected = SecureKeyNotFoundException.class)
   public void testKeyNotFound() throws Exception {
     remoteSecureStore.get(NAMESPACE1, "nonexistingkey");


### PR DESCRIPTION
As a part of PCKE support, we needed a way to add a secret with TTL. 

This PR focuses on the TTL part only independent of any PCKE or Oauth concepts. 

**Key Changes:**
* **API & SPI Updates:** Added overloaded `put(...)` methods to `SecureStoreManager` and `SecretManager` that accept a `ttlInSeconds` parameter.
* **Core Implementation:** Plumbed the TTL parameter from the HTTP layer (`RemoteSecureStore` / `SecureStoreHandler`) down through the `DefaultAdmin` and `SecretManagerSecureStoreService`.
* **GCP Secret Manager Integration:** Updated the GCP `SecretManager` plugin to natively support TTL. Explicitly handles `FieldMask.addPaths("ttl")` during `UpdateSecretRequest` to ensure Google Cloud does not silently drop TTL updates.
* **Architecture Safety:** Avoided Java 8 `default` method chaining in core classes (e.g. `DefaultAdmin`, `RemoteSecureStore`) to prevent `StackOverflowError` loops in custom subclass implementations.
* **API Discoverability:** Added `ttlInSeconds` to the fallback dummy JSON in `SecureStoreHandler` so developers receive built-in documentation on a `BadRequestException`.
* **Testing:** Added robust unit tests to `GcpSecretManagerTest` to verify TTL translation to GCP gRPC calls.


**Manual Testing**


**CDF Instance with `gcp-secretmanager` (GCP Secret Manager)**
* **Tested directly via `SecureStoreHandler`**
  * ✅ **No TTL:** `namespaces/default/securekeys/my-test-no-ttl` — **PASS**
  * ✅ **With TTL:** `namespaces/default/securekeys/my-test-ttl` — **PASS**


**CDF Instance with Default Secure Store (`kms`)**
* **Tested directly via `SecureStoreHandler`**
  * ✅ **No TTL:** `namespaces/default/securekeys/my-test-no-ttl` — **PASS**
  * ✅ **With TTL:** `namespaces/default/securekeys/my-test-ttl` — **PASS**
    * *(Note: No impact on default store; secret was successfully readable regardless of TTL being passed)*
