### PR TITLE
 CDAP-21265 : Add support for PKCE

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
@@ -214,4 +214,9 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
   public ContextAccessEnforcer getContextAccessEnforcer() {
     return contextAccessEnforcer;
   }
+
+  @Override
+  public Map<String ,String> getConfiguration(String prefix) {
+    return cConf.getPropsWithPrefix(prefix);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/AuthType.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/AuthType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.oauth;
+
+/**
+ * The type of OAuth 2.0 authorization flow to use.
+ */
+public enum AuthType {
+  /**
+   * Standard OAuth 2.0 Authorization Code flow.
+   */
+  STANDARD,
+
+  /**
+   * OAuth 2.0 Authorization Code flow with Proof Key for Code Exchange (PKCE).
+   * Provides enhanced security by dynamically generating a code challenge and verifier.
+   */
+  PKCE
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
@@ -33,18 +33,23 @@ public class OAuthProvider {
   @Nullable
   private final String userAgent;
 
+  @Nullable
+  private final AuthType authType;
+
   public OAuthProvider(String name,
                        String loginURL,
                        String tokenRefreshURL,
                        @Nullable OAuthClientCredentials clientCreds,
                        @Nullable CredentialEncodingStrategy strategy,
-                       @Nullable String userAgent) {
+                       @Nullable String userAgent,
+                       @Nullable AuthType authType) {
     this.name = name;
     this.loginURL = loginURL;
     this.tokenRefreshURL = tokenRefreshURL;
     this.clientCreds = clientCreds;
     this.strategy = strategy;
     this.userAgent = userAgent;
+    this.authType = authType != null ? authType : AuthType.STANDARD;
   }
 
   public String getName() {
@@ -74,6 +79,10 @@ public class OAuthProvider {
     return userAgent;
   }
 
+  public AuthType getAuthType() {
+    return authType;
+  }
+
   public enum CredentialEncodingStrategy {
     // (default) Sends client ID & secret as part of the POST request body
     FORM_BODY,
@@ -95,6 +104,7 @@ public class OAuthProvider {
     private OAuthClientCredentials clientCreds;
     private CredentialEncodingStrategy strategy;
     private String userAgent;
+    private AuthType authType;
 
     public Builder() {}
 
@@ -128,6 +138,11 @@ public class OAuthProvider {
       return this;
     }
 
+    public Builder withAuthType(@Nullable AuthType authType) {
+      this.authType = authType;
+      return this;
+    }
+
     public OAuthProvider build() {
       Preconditions.checkNotNull(name, "OAuth provider name missing");
       Preconditions.checkNotNull(loginURL, "Login URL missing");
@@ -136,7 +151,7 @@ public class OAuthProvider {
       if (strategy == null) {
         this.strategy = CredentialEncodingStrategy.FORM_BODY;
       }
-      return new OAuthProvider(name, loginURL, tokenRefreshURL, clientCreds, strategy, userAgent);
+      return new OAuthProvider(name, loginURL, tokenRefreshURL, clientCreds, strategy, userAgent, authType);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
@@ -14,6 +14,8 @@
 
 package io.cdap.cdap.datapipeline.oauth;
 
+import static io.cdap.cdap.datapipeline.service.OAuthHandler.PREF_PKCE_CODE_VERIFIER_TTL;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.security.store.SecureStore;
@@ -35,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -46,13 +49,16 @@ public class OAuthStore {
   private static final String TOKEN_REFRESH_URL_COL = "tokenrefreshurl";
   private static final String CREDENTIAL_ENCODING_STRATEGY_COL = "credentialencodingstrategy";
   private static final String USER_AGENT_COL = "useragent";
+  private static final String AUTH_TYPE_COL = "authtype";
   private static final String CLIENT_CREDS_KEY_PREFIX = "oauthclientcreds";
   private static final String ACCESS_TOKEN_KEY_PREFIX = "oauthaccesstoken";
   private static final String REFRESH_TOKEN_KEY_PREFIX = "oauthrefreshtoken";
+  private static final String PKCE_KEY_PREFIX = "oauth-pkce";
   private static final Gson GSON = new Gson();
   private final TransactionRunner transactionRunner;
   private final SecureStore secureStore;
   private final SecureStoreManager secureStoreManager;
+  private final long codeVerifierTTL;
 
   public static final StructuredTableId TABLE_ID = new StructuredTableId("oauth");
   public static final StructuredTableSpecification TABLE_SPEC = new StructuredTableSpecification.Builder()
@@ -61,17 +67,20 @@ public class OAuthStore {
                   Fields.stringType(LOGIN_URL_COL),
                   Fields.stringType(TOKEN_REFRESH_URL_COL),
                   Fields.stringType(CREDENTIAL_ENCODING_STRATEGY_COL),
-                  Fields.stringType(USER_AGENT_COL))
+                  Fields.stringType(USER_AGENT_COL),
+                  Fields.stringType(AUTH_TYPE_COL))
       .withPrimaryKeys(OAUTH_PROVIDER_COL)
       .build();
 
   public OAuthStore(
       TransactionRunner transactionRunner,
       SecureStore secureStore,
-      SecureStoreManager secureStoreManager) {
+      SecureStoreManager secureStoreManager,
+      Map<String, String> oauthConf) {
     this.transactionRunner = transactionRunner;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
+    this.codeVerifierTTL = Long.parseLong(oauthConf.get(PREF_PKCE_CODE_VERIFIER_TTL));
   }
 
   /**
@@ -299,6 +308,10 @@ public class OAuthStore {
     return String.format("%s-%s-%s", ACCESS_TOKEN_KEY_PREFIX, oauthProvider.toLowerCase(), credentialId.toLowerCase());
   }
 
+  private static String getPKCEKey(String oauthProvider, String state) {
+    return String.format("%s-%s-%s", PKCE_KEY_PREFIX, oauthProvider.toLowerCase(), state.toLowerCase());
+  }
+
   private static List<Field<?>> getKey(String name) {
     List<Field<?>> keyFields = new ArrayList<>(1);
     keyFields.add(Fields.stringField(OAUTH_PROVIDER_COL, name));
@@ -311,6 +324,7 @@ public class OAuthStore {
     String tokenRefreshURL = row.getString(TOKEN_REFRESH_URL_COL);
     String credentialEncodingStrategy = row.getString(CREDENTIAL_ENCODING_STRATEGY_COL);
     String userAgent = row.getString(USER_AGENT_COL);
+    String authTypeStr = row.getString(AUTH_TYPE_COL);
 
     return OAuthProvider.newBuilder()
         .withName(name)
@@ -321,6 +335,7 @@ public class OAuthStore {
             Optional.ofNullable(credentialEncodingStrategy)
                 .map(OAuthProvider.CredentialEncodingStrategy::valueOf).orElse(null))
         .withUserAgent(userAgent)
+        .withAuthType(authTypeStr != null ? AuthType.valueOf(authTypeStr) : AuthType.STANDARD)
         .build();
   }
 
@@ -333,6 +348,36 @@ public class OAuthStore {
             CREDENTIAL_ENCODING_STRATEGY_COL,
             oauthProvider.getCredentialEncodingStrategy().toString()));
     fields.add(Fields.stringField(USER_AGENT_COL, oauthProvider.getUserAgent()));
+    fields.add(Fields.stringField(AUTH_TYPE_COL, oauthProvider.getAuthType().toString()));
     return fields;
+  }
+
+  public void writePKCECodeVerifier(String provider, String state, String codeVerifier) throws Exception {
+    String key = getPKCEKey(provider, state);
+    secureStoreManager.put(NamespaceId.SYSTEM.getNamespace(), key, codeVerifier,
+        "PKCE Code Verifier", Collections.emptyMap(), codeVerifierTTL);
+  }
+
+  public String getPKCECodeVerifier(String provider, String state) throws OAuthStoreException {
+    String key = getPKCEKey(provider, state);
+    try {
+      return new String(secureStore.getData(NamespaceId.SYSTEM.getNamespace(), key), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new OAuthStoreException("Failed to read PKCE code verifier from secure storage", e);
+    }
+  }
+
+  public void deletePKCECodeVerifier(String provider, String state) throws OAuthStoreException {
+    String key = getPKCEKey(provider, state);
+    try {
+      secureStoreManager.delete(NamespaceId.SYSTEM.getNamespace(), key);
+    } catch (IOException e) {
+      throw new OAuthStoreException("Failed to delete PKCE code verifier from secure storage", e);
+    } catch (Exception e) {
+      // Ignore if not found. For any other exception, throw it.
+      if (!e.getClass().getName().contains("NotFoundException")) {
+        throw new OAuthStoreException("Failed to delete PKCE code verifier from secure storage", e);
+      }
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthCredentialRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthCredentialRequest.java
@@ -17,16 +17,21 @@
 
 package io.cdap.cdap.datapipeline.oauth;
 
+import javax.annotation.Nullable;
+
 /**
  * OAuth credential REST PUT request body.
  */
 public class PutOAuthCredentialRequest {
   private final String oneTimeCode;
   private final String redirectURI;
+  @Nullable
+  private final String state;
 
-  public PutOAuthCredentialRequest(String oneTimeCode, String redirectURI) {
+  public PutOAuthCredentialRequest(String oneTimeCode, String redirectURI, @Nullable String state) {
     this.oneTimeCode = oneTimeCode;
     this.redirectURI = redirectURI;
+    this.state = state;
   }
 
   public String getOneTimeCode() {
@@ -35,5 +40,10 @@ public class PutOAuthCredentialRequest {
 
   public String getRedirectURI() {
     return redirectURI;
+  }
+
+  @Nullable
+  public String getState() {
+    return state;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthProviderRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthProviderRequest.java
@@ -27,6 +27,7 @@ public class PutOAuthProviderRequest {
   private final String clientSecret;
   private final OAuthProvider.CredentialEncodingStrategy strategy;
   private final String userAgent;
+  private final AuthType authType;
 
   public PutOAuthProviderRequest(
           String loginURL,
@@ -34,13 +35,15 @@ public class PutOAuthProviderRequest {
           String clientId,
           String clientSecret,
           OAuthProvider.CredentialEncodingStrategy strategy,
-          String userAgent) {
+          String userAgent,
+          AuthType authType) {
     this.loginURL = loginURL;
     this.tokenRefreshURL = tokenRefreshURL;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.strategy = strategy;
     this.userAgent = userAgent;
+    this.authType = authType;
   }
 
   public String getLoginURL() {
@@ -65,5 +68,9 @@ public class PutOAuthProviderRequest {
 
   public String getUserAgent() {
     return userAgent;
+  }
+
+  public AuthType getAuthType() {
+    return authType;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -23,12 +23,14 @@ import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.service.http.AbstractSystemHttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.cdap.datapipeline.oauth.CredentialIsValidResponse;
 import io.cdap.cdap.datapipeline.oauth.GetAccessTokenResponse;
 import io.cdap.cdap.datapipeline.oauth.OAuthAccessToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthClientCredentials;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
+import io.cdap.cdap.datapipeline.oauth.AuthType;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider.CredentialEncodingStrategy;
 import io.cdap.cdap.datapipeline.oauth.OAuthRefreshToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthStore;
@@ -36,6 +38,7 @@ import io.cdap.cdap.datapipeline.oauth.OAuthStoreException;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthCredentialRequest;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthProviderRequest;
 import io.cdap.cdap.datapipeline.oauth.RefreshTokenResponse;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
@@ -45,8 +48,12 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -69,13 +76,22 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     .setPrettyPrinting()
     .registerTypeAdapterFactory(new ErrorHandlingGsonTypeAdapterFactory())
     .create();
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+
+  // The following OAuth settings can be configured via the system configuration(Cconf)
+  // All properties related to OAuth should be prefixed with this value.
+  private static final String OAUTH_CONF_PREFIX = "security.auth.oauth.";
+  // Time To Live in seconds for PCKE based code verifier in Secure Store.
+  public static final String PREF_PKCE_CODE_VERIFIER_TTL = "pkce.code.verifier.ttl.sec";
 
   private OAuthStore oauthStore;
 
   @Override
   public void initialize(SystemHttpServiceContext context) throws Exception {
     super.initialize(context);
-    this.oauthStore = new OAuthStore(context, context, context.getAdmin());
+    Map<String, String> oauthConf = context.getConfiguration(OAUTH_CONF_PREFIX);
+    this.oauthStore = new OAuthStore(context, context, context.getAdmin(), oauthConf);
   }
 
   @GET
@@ -103,6 +119,22 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
       String response = String.format(
           formatURL, loginUrl, oauthProvider.getClientCredentials().getClientId(), redirectURI);
+
+      if (oauthProvider.getAuthType() == AuthType.PKCE) {
+        String state = UUID.randomUUID().toString();
+        String codeVerifier = generateCodeVerifier();
+        String codeChallenge = generateCodeChallenge(codeVerifier);
+
+        try {
+          oauthStore.writePKCECodeVerifier(provider, state, codeVerifier);
+        } catch (Exception e) {
+          throw new OAuthServiceException(
+              HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to store PKCE code verifier", e);
+        }
+
+        response += String.format("&state=%s&code_challenge=%s&code_challenge_method=S256", state, codeChallenge);
+      }
+
       responder.sendString(response);
     } catch (OAuthServiceException e) {
       e.respond(responder);
@@ -141,6 +173,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                               .withClientCredentials(clientCredentials)
                                               .withCredentialEncodingStrategy(strategy)
                                               .withUserAgent(userAgent)
+                                              .withAuthType(putOAuthProviderRequest.getAuthType())
                                               .build();
         oauthStore.writeProvider(provider, reuseClientCredentials);
         responder.sendStatus(HttpURLConnection.HTTP_OK);
@@ -190,7 +223,8 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                 PutOAuthCredentialRequest.class);
         if (putOAuthCredentialRequest.getOneTimeCode() == null
             || putOAuthCredentialRequest.getOneTimeCode().isEmpty()) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing one-time code");
+          throw new OAuthServiceException(
+              HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing one-time code");
         }
         if (putOAuthCredentialRequest.getRedirectURI() == null
             || putOAuthCredentialRequest.getRedirectURI().isEmpty()) {
@@ -202,14 +236,33 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
       OAuthProvider oauthProvider = getProvider(provider);
 
+      String state = putOAuthCredentialRequest.getState();
+      String codeVerifier = null;
+      if (oauthProvider.getAuthType() == AuthType.PKCE) {
+        if (state == null || state.isEmpty() || !state.matches("^[a-zA-Z0-9-]+$")) {
+          throw new OAuthServiceException(
+              HttpURLConnection.HTTP_BAD_REQUEST, "State is required and must be valid for "
+              + "PKCE authentication");
+        }
+        try {
+          codeVerifier = oauthStore.getPKCECodeVerifier(provider, state);
+          oauthStore.deletePKCECodeVerifier(provider, state);
+        } catch (OAuthStoreException e) {
+          throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR,
+              "Failed to process PKCE code verifier", e);
+        }
+      }
+
       HttpResponse response;
       try {
         response = HttpRequests.execute(createGetRefreshTokenRequest(
             oauthProvider,
             putOAuthCredentialRequest.getOneTimeCode(),
-            putOAuthCredentialRequest.getRedirectURI()));
+            putOAuthCredentialRequest.getRedirectURI(),
+            codeVerifier));
       } catch (IOException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
+        throw new OAuthServiceException(
+              HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
       }
 
       if (response.getResponseCode() != 200) {
@@ -387,7 +440,8 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
       try {
         response = HttpRequests.execute(createGetAccessTokenRequest(oauthProvider, refreshToken.getRefreshToken()));
       } catch (IOException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
+        throw new OAuthServiceException(
+              HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
       }
 
       responder.sendString(GSON.toJson(new CredentialIsValidResponse(checkCredIsValid(response))));
@@ -427,20 +481,28 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                   String code,
                                   String redirectURI,
                                   String refreshToken,
-                                  OAuthClientCredentials clientCreds) {
+                                  OAuthClientCredentials clientCreds,
+                                  String codeVerifier) {
+    String body;
     switch (strategy) {
       case BASIC_AUTH:
-        return grantType.equals("authorization_code")
+        body = grantType.equals("authorization_code")
                 ? String.format("code=%s&redirect_uri=%s&grant_type=%s", code, redirectURI, grantType)
                 : String.format("grant_type=%s&refresh_token=%s", grantType, refreshToken);
+        break;
       case FORM_BODY: // fall-through
       default:
-        return grantType.equals("authorization_code")
+        body = grantType.equals("authorization_code")
                 ? String.format("code=%s&redirect_uri=%s&client_id=%s&client_secret=%s&grant_type=%s",
                 code, redirectURI, clientCreds.getClientId(), clientCreds.getClientSecret(), grantType)
                 : String.format("grant_type=%s&client_id=%s&client_secret=%s&refresh_token=%s",
                 grantType, clientCreds.getClientId(), clientCreds.getClientSecret(), refreshToken);
+        break;
     }
+    if (codeVerifier != null && !codeVerifier.isEmpty()) {
+      body += "&code_verifier=" + codeVerifier;
+    }
+    return body;
   }
 
   /** Build HTTP request for getting tokens */
@@ -468,18 +530,36 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     return requestBuilder;
   }
 
+  private String generateCodeVerifier() {
+    byte[] codeVerifierBytes = new byte[32];
+    SECURE_RANDOM.nextBytes(codeVerifierBytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(codeVerifierBytes);
+  }
+
+  private String generateCodeChallenge(String codeVerifier) throws OAuthServiceException {
+    try {
+      MessageDigest md = MessageDigest.getInstance("SHA-256");
+      md.update(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(md.digest());
+    } catch (Exception e) {
+      throw new OAuthServiceException(
+              HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to generate SHA-256 code challenge", e);
+    }
+  }
+
   /**
    * Build the HttpRequest to request a refresh token from the OAuth provider
    * @param provider
    * @param code the authorization code given after the user accepts OAuth from the provider
    * @param redirectURI
    */
-  private HttpRequest createGetRefreshTokenRequest(OAuthProvider provider, String code, String redirectURI)
+  private HttpRequest createGetRefreshTokenRequest(OAuthProvider provider, String code, String redirectURI,
+                                                   String codeVerifier)
       throws OAuthServiceException {
     OAuthClientCredentials clientCreds = provider.getClientCredentials();
     CredentialEncodingStrategy strategy = provider.getCredentialEncodingStrategy();
     String tokenRefreshURL = provider.getTokenRefreshURL();
-    String body = buildRequestBody(strategy, "authorization_code", code, redirectURI, null, clientCreds);
+    String body = buildRequestBody(strategy, "authorization_code", code, redirectURI, null, clientCreds, codeVerifier);
     String userAgent = provider.getUserAgent();
 
     try {
@@ -499,7 +579,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     OAuthClientCredentials clientCreds = provider.getClientCredentials();
     CredentialEncodingStrategy strategy = provider.getCredentialEncodingStrategy();
     String tokenRefreshURL = provider.getTokenRefreshURL();
-    String body = buildRequestBody(strategy, "refresh_token", null, null, refreshToken, clientCreds);
+    String body = buildRequestBody(strategy, "refresh_token", null, null, refreshToken, clientCreds, null);
     String userAgent = provider.getUserAgent();
 
     try {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
@@ -19,8 +19,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
+import io.cdap.cdap.datapipeline.oauth.AuthType;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthProviderRequest;
-import io.cdap.cdap.datapipeline.oauth.PutOAuthCredentialRequest;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
@@ -50,7 +50,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -72,7 +72,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -89,7 +89,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider10?reuse_client_credentials=true", request);
     Assert.assertEquals(500, createResponse.getResponseCode());
   }
@@ -107,7 +107,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider20", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -121,7 +121,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     createResponse = makePutCall("provider/testprovider20?reuse_client_credentials=true", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
   }
@@ -138,7 +138,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider30?reuse_client_credentials=false", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -156,7 +156,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH,
-            null);
+            null, null);
     HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider31", request);
     Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
 
@@ -180,7 +180,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH,
-            "cdap-test");
+            "cdap-test", null);
     HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider32", request);
     Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
 
@@ -189,6 +189,36 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     Assert.assertEquals(200, getAuthUrlResponse.getResponseCode());
     String authURL = getAuthUrlResponse.getResponseBodyAsString();
     Assert.assertEquals("http://www.example.com/login32?client_id=clientid&redirect_uri=null", authURL);
+  }
+
+  @Test
+  public void testCreateProviderWithPkceAuthType() throws IOException {
+    String loginURL = "http://www.example.com/login_pkce";
+    String tokenRefreshURL = "http://www.example.com/token_pkce";
+    String clientId = "clientid";
+    String clientSecret = "clientsecret";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
+            loginURL,
+            tokenRefreshURL,
+            clientId,
+            clientSecret,
+            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
+            null, AuthType.PKCE);
+    HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider_pkce", request);
+    Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
+
+    // Grab OAuth login URL to verify write succeeded
+    HttpResponse getAuthUrlResponse = makeGetCall("provider/testprovider_pkce/authurl");
+    Assert.assertEquals(200, getAuthUrlResponse.getResponseCode());
+    String authURL = getAuthUrlResponse.getResponseBodyAsString();
+    
+    // Verify base URL
+    Assert.assertTrue(authURL.startsWith("http://www.example.com/login_pkce?client_id=clientid&redirect_uri=null"));
+    
+    // Verify PKCE specific query params
+    Assert.assertTrue(authURL.contains("&state="));
+    Assert.assertTrue(authURL.contains("&code_challenge="));
+    Assert.assertTrue(authURL.contains("&code_challenge_method=S256"));
   }
 
   @Test
@@ -203,7 +233,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider40?reuse_client_credentials=false", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
 
@@ -225,7 +255,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider50", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -245,7 +275,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             null,
             null,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     createResponse = makePutCall("provider/testprovider50?reuse_client_credentials=true", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -269,7 +299,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -287,7 +317,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
             clientId,
             clientSecret,
             OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null);
+            null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthStoreTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthStoreTest.java
@@ -12,7 +12,10 @@
  *
  */
 
+package io.cdap.cdap.datapipeline;
+
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -65,7 +68,8 @@ public class OAuthStoreTest {
     mockTable = mock(StructuredTable.class);
     mockRow = mock(StructuredRow.class);
 
-    oauthStore = new OAuthStore(mockTransactionRunner, mockSecureStore, mockSecureStoreManager);
+    oauthStore = new OAuthStore(mockTransactionRunner, mockSecureStore,
+        mockSecureStoreManager, Collections.singletonMap("pkce.code.verifier.ttl.sec", "900"));
   }
 
   @Test

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5190,6 +5190,17 @@
     </description>
   </property>
 
+  <!-- Oauth Configurations -->
+  <property>
+    <name>security.auth.oauth.pkce.code.verifier.ttl.sec</name>
+    <value>900</value>
+    <description>
+      Time-To-Live (TTL) in seconds for the OAuth 2.0 PKCE code verifier stored in the 
+      system secure store. This determines how long a user has to complete the OAuth 
+      consent flow before the authorization attempt expires.
+    </description>
+  </property>
+
   <!-- UI Configuration -->
 
   <property>

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
@@ -105,4 +105,16 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
    * Returns boolean indicating whether remote task execution is enabled
    */
   boolean isRemoteTaskEnabled();
+
+  /**
+   * Returns a map of configuration properties that match the specified prefix from the
+   * system configuration (Cconf).
+   * The keys in the returned map will have the prefix removed.
+   *
+   * @param prefix the prefix to filter configuration properties by
+   * @return a map of configuration properties matching the prefix
+   */
+  default Map<String, String> getConfiguration(String prefix) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }


### PR DESCRIPTION

### **Title:** 
feat: Add PKCE support for OAuth providers

### **Description:**
This PR introduces Proof Key for Code Exchange (PKCE) support for OAuth providers in CDAP data pipelines.

**Key Changes:**
* **PKCE Flow Support:** Updates the `OAuthStore` schema to include `authType` (expanding the table spec to 6 columns) to properly identify and route PKCE-enabled providers. 
* **Secure State & TTLs:** Adds endpoints to generate the `code_challenge` and securely store the `code_verifier` with a configurable time-to-live (`security.auth.oauth.pkce.code.verifier.ttl.sec`) 

### **TESTING:**

Tested the following cases for a secure store as GCP SECRET MANAGER and the default CDAP secure store. 

### 1. PKCE Flow (AuthType = PKCE)
Tests specifically targeting the Proof Key for Code Exchange logic and the new 10-minute Secure Store TTL.

| Phase | Test Scenario | Action | Expected Result |
| :--- | :--- | :--- | :--- |
| **Config** | Provider Creation | Call `PutOAuthProvider` with `authType = PKCE`. | Provider is saved successfully with PKCE enabled. |
| **Auth URL** | URL Generation | Generate Auth URL for the PKCE provider. | URL contains `code_challenge` and `code_challenge_method=S256`. A `code_verifier` is generated internally. |
| **Storage** | Verifier Persistence | Check Secure Store after Auth URL generation. | The `code_verifier` is saved under the system namespace using the `state` as the key, with a 10-minute TTL. |
| **256 SHA check** | `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))` | Take the `code_challenge` from step 2, and `code_verifier` from step 3 and Verify. | It should match perfectly. |
| **Callback** | Valid Exchange Payload | Trigger the OAuth callback (mocking the IdP). | The POST body to `tokenRefreshURL` contains `grant_type=authorization_code`, `code`, and the retrieved `code_verifier`. |
| **Storage** | Missing Verifier | Check Secure Store after successful callback. | The `code_verifier` should be deleted. |
| **TTL** | Expiration (Timeout) | Trigger Auth URL generation, wait > 10 minutes, then attempt Token Exchange callback. | Secure Store throws NotFound/null. Token exchange fails gracefully. |
| **TTL** | Success (Within window) | Trigger Auth URL generation, attempt callback within 10 minutes. | The `code_verifier` is retrieved successfully and token exchange proceeds. |

---

### 2. Standard Flow (AuthType = STANDARD or default)
Tests to ensure existing integrations without PKCE continue to work perfectly.

| Phase | Test Scenario | Action | Expected Result |
| :--- | :--- | :--- | :--- |
| **Config** | Provider Creation | Call `PutOAuthProvider` with `authType = STANDARD` (or missing). | Provider is saved successfully without PKCE flags. |
| **Auth URL** | URL Generation | Generate Auth URL for the `STANDARD` provider. | URL does not contain `code_challenge` or `code_challenge_method`. |
| **Storage** | No Verifier Persistence | Check Secure Store after Auth URL generation. | Secure Store is not hit; no `code_verifier` is stored. |
| **Callback** | Valid Exchange Payload | Trigger the OAuth callback (mocking the IdP). | The POST body to `tokenRefreshURL` contains `grant_type=authorization_code` and `code`, but no `code_verifier`. |


### 3. Parsing of Config from CCONF / cdap-default. 

- Tested with default value of 900 seconds 
- Tested with manual edit of cdap master to 300 seconds

> **Note:** 
> PKCE support is currently introduced for internal use. The time-to-live (TTL) auto-cleanup for `code_verifier`s relies on a Secure Store implementation that natively supports TTL (such as GCP Secret Manager). 
> 
> If the default Secure Store implementation is used, unused `code_verifier`s will not be automatically cleaned up upon expiration. However, this is entirely harmless from a security perspective, and the resulting storage footprint is negligible.
> Follow up Jira : https://cdap.atlassian.net/browse/CDAP-21266