### PR TITLE
Add `feature.wrangler.jexl.allowlist.enabled` flag for JEXL expressions allowlisting feature in Wrangler directives

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6774,4 +6774,12 @@
     </description>
   </property>
 
+  <property>
+    <name>feature.wrangler.jexl.allowlist.enabled</name>
+    <value>false</value>
+    <description>
+      If true, admins can define allowlist for JEXL expressions in Wrangler directives.
+      Only the whitelisted classes, methods and properties will be allowed in the JEXL scripts.
+    </description>
+  </property>
 </configuration>

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -20,9 +20,12 @@ import io.cdap.cdap.api.PlatformInfo;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
 
 /**
- * Defines Features Flags to be used in CDAP. Features take the version that they were introduced as
- * a first parameter. Optionally they can take a second parameter to define their default behavior
- * if they are not present in configuration. By default, features default to enabled after they are
+ * Defines Features Flags to be used in CDAP. Features take the version that
+ * they were introduced as
+ * a first parameter. Optionally they can take a second parameter to define
+ * their default behavior
+ * if they are not present in configuration. By default, features default to
+ * enabled after they are
  * introduced, and disabled before they were introduced
  */
 public enum Feature {
@@ -46,8 +49,8 @@ public enum Feature {
   NAMESPACED_SERVICE_ACCOUNTS("6.10.0"),
   WRANGLER_KRYO_SERIALIZATION("6.10.1"),
   SOURCE_CONTROL_MANAGEMENT_GITLAB_BITBUCKET("6.10.1"),
-  DATAPLANE_AUDIT_LOGGING("6.10.1");
-
+  DATAPLANE_AUDIT_LOGGING("6.10.1"),
+  WRANGLER_JEXL_ALLOWLIST("6.12.0", false);
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;
   private final String featureFlagString;
@@ -63,9 +66,12 @@ public enum Feature {
   }
 
   /**
-   * Returns if the feature flag should be enabled. First it checks featureFlagProvider to see if
-   * the feature flag has been defined. If not defined then it uses when the feature flag was first
-   * introduced, if the platform version is before or equal to when it was introduced it returns
+   * Returns if the feature flag should be enabled. First it checks
+   * featureFlagProvider to see if
+   * the feature flag has been defined. If not defined then it uses when the
+   * feature flag was first
+   * introduced, if the platform version is before or equal to when it was
+   * introduced it returns
    * false, otherwise it returns defaultAfterIntroduction.
    *
    * @param featureFlagsProvider provides which feature flags have been set.


### PR DESCRIPTION
This change introduces a feature flag to control enabling of a secure by default model for JEXL scripts in wrangler directives.