### PR TITLE
[CDAP-21269] Add support for Dataproc Flexible Machine Types in compute profiles

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -37,6 +37,8 @@ import com.google.cloud.dataproc.v1.EncryptionConfig;
 import com.google.cloud.dataproc.v1.EndpointConfig;
 import com.google.cloud.dataproc.v1.GceClusterConfig;
 import com.google.cloud.dataproc.v1.GetClusterRequest;
+import com.google.cloud.dataproc.v1.InstanceFlexibilityPolicy;
+import com.google.cloud.dataproc.v1.InstanceFlexibilityPolicy.InstanceSelection;
 import com.google.cloud.dataproc.v1.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1.LifecycleConfig;
 import com.google.cloud.dataproc.v1.ListClustersRequest;
@@ -242,6 +244,27 @@ abstract class DataprocClient implements AutoCloseable {
           .setPreemptibility(InstanceGroupConfig.Preemptibility.NON_PREEMPTIBLE)
           .setDiskConfig(workerDiskConfig);
 
+      if (!conf.getWorkerFlexVmMachineTypes().isEmpty()) {
+        InstanceFlexibilityPolicy workerFlexPolicy =
+          createInstanceFlexibilityPolicy(conf.getWorkerFlexVmMachineTypes());
+        primaryWorkerConfig.setInstanceFlexibilityPolicy(workerFlexPolicy);
+        secondaryWorkerConfig.setInstanceFlexibilityPolicy(workerFlexPolicy);
+      }
+
+      InstanceGroupConfig.Builder masterConfig = InstanceGroupConfig.newBuilder()
+          .setNumInstances(conf.getMasterNumNodes())
+          .setMachineTypeUri(conf.getMasterMachineType())
+          .setDiskConfig(DiskConfig.newBuilder()
+                         .setBootDiskType(conf.getMasterDiskType())
+                         .setBootDiskSizeGb(conf.getMasterDiskGb())
+                         .setNumLocalSsds(0)
+                         .build());
+      if (!conf.getMasterFlexVmMachineTypes().isEmpty()) {
+        InstanceFlexibilityPolicy masterFlexPolicy =
+          createInstanceFlexibilityPolicy(conf.getMasterFlexVmMachineTypes());
+        masterConfig.setInstanceFlexibilityPolicy(masterFlexPolicy);
+      }
+
       //Set default concurrency settings for fixed cluster
       if (Strings.isNullOrEmpty(conf.getAutoScalingPolicy())) {
         //Set spark.default.parallelism according to cluster size.
@@ -274,22 +297,14 @@ abstract class DataprocClient implements AutoCloseable {
       }
 
       ClusterConfig.Builder builder = ClusterConfig.newBuilder()
-          .setEndpointConfig(EndpointConfig.newBuilder()
-              .setEnableHttpPortAccess(conf.isComponentGatewayEnabled())
-              .build())
-          .setMasterConfig(InstanceGroupConfig.newBuilder()
-              .setNumInstances(conf.getMasterNumNodes())
-              .setMachineTypeUri(conf.getMasterMachineType())
-              .setDiskConfig(DiskConfig.newBuilder()
-                  .setBootDiskType(conf.getMasterDiskType())
-                  .setBootDiskSizeGb(conf.getMasterDiskGb())
-                  .setNumLocalSsds(0)
-                  .build())
-              .build())
-          .setWorkerConfig(primaryWorkerConfig.build())
-          .setSecondaryWorkerConfig(secondaryWorkerConfig.build())
-          .setGceClusterConfig(clusterConfig.build())
-          .setSoftwareConfig(softwareConfigBuilder);
+        .setEndpointConfig(EndpointConfig.newBuilder()
+            .setEnableHttpPortAccess(conf.isComponentGatewayEnabled())
+            .build())
+        .setMasterConfig(masterConfig.build())
+        .setWorkerConfig(primaryWorkerConfig.build())
+        .setSecondaryWorkerConfig(secondaryWorkerConfig.build())
+        .setGceClusterConfig(clusterConfig.build())
+        .setSoftwareConfig(softwareConfigBuilder);
 
       //Cluster TTL if one should be set
       if (conf.getIdleTtlMinutes() > 0) {
@@ -359,6 +374,13 @@ abstract class DataprocClient implements AutoCloseable {
           cause == null ? e.getMessage() : cause.getMessage(), true, operationId, ErrorType.UNKNOWN,
           cause == null ? e : cause);
     }
+  }
+
+  private InstanceFlexibilityPolicy createInstanceFlexibilityPolicy(List<String> machineTypes) {
+    return InstanceFlexibilityPolicy.newBuilder()
+      .addInstanceSelectionList(
+        InstanceSelection.newBuilder().addAllMachineTypes(machineTypes).build())
+      .build();
   }
 
   protected void setNetworkConfigs(Compute compute, GceClusterConfig.Builder clusterConfig,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import java.io.ByteArrayInputStream;
@@ -27,11 +28,13 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -72,6 +75,7 @@ final class DataprocConf {
   static final String TEMP_BUCKET = "tempBucket";
 
   static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
+  static final String NETWORK_TAGS = "networkTags";
   static final int MAX_NETWORK_TAGS = 64;
 
   static final String SECURE_BOOT_ENABLED = "secureBootEnabled";
@@ -111,6 +115,12 @@ final class DataprocConf {
   private static final String COMPUTE_CREDENTIALS_MAX_RETRIES_KEY = "compute.credentials.max.retries";
   private static final int COMPUTE_CREDENTIALS_MAX_RETRIES_DEFAULT = 50;
 
+  public static final String MASTER_FLEX_VM_MACHINE_TYPES = "masterFlexVmMachineTypes";
+  public static final String WORKER_FLEX_VM_MACHINE_TYPES = "workerFlexVmMachineTypes";
+
+  private static final Splitter COMMA_SPLITTER =
+    Splitter.on(',').trimResults().omitEmptyStrings();
+
   private final String accountKey;
   private final String region;
   private final String zone;
@@ -128,6 +138,7 @@ final class DataprocConf {
   private final int masterDiskGb;
   private final String masterDiskType;
   private final String masterMachineType;
+  private final List<String> masterFlexVmMachineTypes;
 
   private final int workerNumNodes;
   private final int secondaryWorkerNumNodes;
@@ -136,6 +147,7 @@ final class DataprocConf {
   private final int workerDiskGb;
   private final String workerDiskType;
   private final String workerMachineType;
+  private final List<String> workerFlexVmMachineTypes;
 
   private final long pollCreateDelay;
   private final long pollCreateJitter;
@@ -189,8 +201,10 @@ final class DataprocConf {
       @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
       int masterNumNodes, int masterCpus, int masterMemoryMb,
       int masterDiskGb, String masterDiskType, @Nullable String masterMachineType,
+      List<String> masterFlexVmMachineTypes,
       int workerNumNodes, int secondaryWorkerNumNodes, int workerCpus, int workerMemoryMb,
       int workerDiskGb, String workerDiskType, @Nullable String workerMachineType,
+      List<String> workerFlexVmMachineTypes,
       long pollCreateDelay, long pollCreateJitter, long pollDeleteDelay, long pollInterval,
       @Nullable String encryptionKeyName, @Nullable String gcsBucket,
       @Nullable String tempBucket, @Nullable String serviceAccount, boolean preferExternalIp,
@@ -230,6 +244,7 @@ final class DataprocConf {
     this.masterDiskGb = masterDiskGb;
     this.masterDiskType = masterDiskType;
     this.masterMachineType = masterMachineType;
+    this.masterFlexVmMachineTypes = masterFlexVmMachineTypes;
     this.workerNumNodes = workerNumNodes;
     this.secondaryWorkerNumNodes = secondaryWorkerNumNodes;
     this.workerCpus = workerCpus;
@@ -237,6 +252,7 @@ final class DataprocConf {
     this.workerDiskGb = workerDiskGb;
     this.workerDiskType = workerDiskType;
     this.workerMachineType = workerMachineType;
+    this.workerFlexVmMachineTypes = workerFlexVmMachineTypes;
     this.pollCreateDelay = pollCreateDelay;
     this.pollCreateJitter = pollCreateJitter;
     this.pollDeleteDelay = pollDeleteDelay;
@@ -337,6 +353,14 @@ final class DataprocConf {
 
   String getWorkerMachineType() {
     return getMachineType(workerMachineType, workerCpus, workerMemoryMb);
+  }
+
+  public List<String> getMasterFlexVmMachineTypes() {
+    return formatMachineType(masterFlexVmMachineTypes, masterCpus, masterMemoryMb);
+  }
+
+  public List<String> getWorkerFlexVmMachineTypes() {
+    return formatMachineType(workerFlexVmMachineTypes, workerCpus, workerMemoryMb);
   }
 
   int getTotalWorkerCpus() {
@@ -667,12 +691,14 @@ final class DataprocConf {
     if (masterDiskType == null) {
       masterDiskType = "pd-standard";
     }
+    final List<String> masterFlexVmMachineTypes = getStringList(properties, MASTER_FLEX_VM_MACHINE_TYPES);
     final int workerDiskGb = getInt(properties, "workerDiskGB", 1000);
     String workerDiskType = getString(properties, "workerDiskType");
     final String workerMachineType = getString(properties, "workerMachineType");
     if (workerDiskType == null) {
       workerDiskType = "pd-standard";
     }
+    final List<String> workerFlexVmMachineTypes = getStringList(properties, WORKER_FLEX_VM_MACHINE_TYPES);
 
     final long pollCreateDelay = getLong(properties, "pollCreateDelay", 60);
     final long pollCreateJitter = getLong(properties, "pollCreateJitter", 20);
@@ -712,14 +738,7 @@ final class DataprocConf {
     final Map<String, String> clusterLabels = Collections.unmodifiableMap(
         DataprocUtils.parseKeyValueConfig(getString(properties, CLUSTER_LABELS), ";", "\\|"));
 
-    final String networkTagsProperty = Optional.ofNullable(getString(properties, "networkTags"))
-        .orElse("");
-    final List<String> networkTags = Collections.unmodifiableList(
-        Arrays.stream(networkTagsProperty.split(","))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(Collectors.toList()));
-
+    final List<String> networkTags = getStringList(properties, NETWORK_TAGS);
     if (networkTags.size() > MAX_NETWORK_TAGS) {
       throw new IllegalArgumentException(
           "Number of network tags cannot be more than " + MAX_NETWORK_TAGS);
@@ -781,21 +800,16 @@ final class DataprocConf {
         Boolean.parseBoolean(properties.getOrDefault(DataprocUtils.LOCAL_CACHE_DISABLED,
             "false"));
 
-    final String scopesProperty = String.format("%s,%s",
-        Optional.ofNullable(getString(properties, SCOPES)).orElse(""), CLOUD_PLATFORM_SCOPE);
-    List<String> scopes = Collections.unmodifiableList(
-        Arrays.stream(scopesProperty.split(","))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .distinct()
-            .collect(Collectors.toList()));
+    Set<String> scopesSet = new LinkedHashSet<>(getStringList(properties, SCOPES));
+    scopesSet.add(CLOUD_PLATFORM_SCOPE);
+    final List<String> scopes = Collections.unmodifiableList(new ArrayList<>(scopesSet));
 
     return new DataprocConf(accountKey, region, zone, projectId, networkHostProjectId, network,
         subnet,
         masterNumNodes, masterCpus, masterMemoryMb, masterDiskGb,
-        masterDiskType, masterMachineType,
+        masterDiskType, masterMachineType, masterFlexVmMachineTypes,
         workerNumNodes, secondaryWorkerNumNodes, workerCpus, workerMemoryMb, workerDiskGb,
-        workerDiskType, workerMachineType,
+        workerDiskType, workerMachineType, workerFlexVmMachineTypes,
         pollCreateDelay, pollCreateJitter, pollDeleteDelay, pollInterval,
         gcpCmekKeyName, gcpCmekBucket, tempBucket, serviceAccount, preferExternalIp,
         stackdriverLoggingEnabled, stackdriverMonitoringEnabled,
@@ -855,5 +869,24 @@ final class DataprocConf {
           String.format("Invalid config '%s' = '%s'. Must be a valid, positive long.", key,
               valStr));
     }
+  }
+
+  private List<String> formatMachineType(List<String> flexTypes, int cpus, int memoryMb) {
+    List<String> result = flexTypes.stream()
+      .map(type -> getMachineType(type, cpus, memoryMb))
+      .collect(Collectors.toList());
+
+    return Collections.unmodifiableList(result);
+  }
+
+  /**
+   * Parses a comma-separated string property into a trimmed list of strings,
+   * or returns an empty list if null/empty.
+   */
+  private static List<String> getStringList(Map<String, String> properties, String key) {
+    String val = getString(properties, key);
+    return Strings.isNullOrEmpty(val)
+      ? Collections.emptyList()
+      : COMMA_SPLITTER.splitToList(val);
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -45,6 +45,7 @@ import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -85,6 +86,9 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   private static final Set<ClusterStatus> TERMINAL_STATES =
     EnumSet.of(ClusterStatus.RUNNING, ClusterStatus.FAILED, ClusterStatus.NOT_EXISTS);
 
+  private static final Pattern MACHINE_TYPE_PATTERN =
+    Pattern.compile("^[a-z\\d]+(-[a-z\\d]+)*$");
+
   private final DataprocClientFactory clientFactory;
 
   @SuppressWarnings("WeakerAccess")
@@ -103,6 +107,24 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
     DataprocConf conf = DataprocConf.create(properties);
     boolean privateInstance = Boolean.parseBoolean(
         getSystemContext().getProperties().get(PRIVATE_INSTANCE));
+    Set<String> allFlexTypes = new HashSet<>();
+    allFlexTypes.addAll(conf.getMasterFlexVmMachineTypes());
+    allFlexTypes.addAll(conf.getWorkerFlexVmMachineTypes());
+
+    for (String machineType : allFlexTypes) {
+      if (!MACHINE_TYPE_PATTERN.matcher(machineType).matches()) {
+        String errorMessage = String.format(
+          "Invalid flexible VM machine type '%s'. "
+            + "Machine types should follow standard GCP format.",
+          machineType);
+        throw new DataprocRuntimeException.Builder()
+          .withErrorCategory(DataprocRuntimeException.ERROR_CATEGORY_PROVISIONING_CONFIGURATION)
+          .withErrorReason(errorMessage)
+          .withErrorMessage(errorMessage)
+          .withErrorType(ErrorType.USER)
+          .build();
+      }
+  }
 
     if (privateInstance && conf.isPreferExternalIp()) {
       // When prefer external IP is set to true it means only Dataproc external ip can be used for

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -171,6 +171,20 @@
           }
         },
         {
+          "widget-type": "multi-select",
+          "label": "Master Flexible Machine Types",
+          "name": "masterFlexVmMachineTypes",
+          "description": "Optional comma-separated list of fallback machine types in priority order if the primary master machine type is unavailable (e.g. n1, n2, n2d, e2).",
+          "widget-attributes": {
+            "options": [
+              "n1",
+              "n2",
+              "n2d",
+              "e2"
+            ]
+          }
+        },
+        {
           "widget-type": "select",
           "label": "Master Cores",
           "name": "masterCPUs",
@@ -252,6 +266,20 @@
             ],
             "default": "e2",
             "size": "medium"
+          }
+        },
+        {
+          "widget-type": "multi-select",
+          "label": "Worker Flexible Machine Types",
+          "name": "workerFlexVmMachineTypes",
+          "description": "Optional comma-separated list of fallback machine types in priority order if the primary worker machine type is unavailable (e.g. n1, n2, n2d, e2).",
+          "widget-attributes": {
+            "options": [
+              "n1",
+              "n2",
+              "n2d",
+              "e2"
+            ]
           }
         },
         {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
@@ -21,6 +21,9 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
@@ -56,6 +59,7 @@ import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -69,6 +73,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -319,6 +324,165 @@ public class DataprocClientTest {
     mockDataprocClientFactory.create(conf,
         new ErrorCategory(ErrorCategoryEnum.PROVISIONING)).createCluster("name", "2.0",
         Collections.emptyMap(), true, null);
+  }
+
+  @Test
+  public void testCreateClusterWithFlexVmConfig() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("accountKey", "{ \"type\": \"test\"}");
+    properties.put(DataprocConf.PROJECT_ID_KEY, "dummy-project");
+    properties.put("zone", "us-test1-c");
+    properties.put("masterCPUs", "2");
+    properties.put("masterMemoryMB", "8192");
+    properties.put("workerCPUs", "4");
+    properties.put("workerMemoryMB", "16384");
+    properties.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "n1, n2d");
+    properties.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n2, e2");
+    DataprocConf conf = DataprocConf.create(properties);
+
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = mock(OperationFuture.class);
+    ArgumentCaptor<Cluster> clusterCaptor = ArgumentCaptor.forClass(Cluster.class);
+    when(clusterControllerClientMock.createClusterAsync(eq(conf.getProjectId()),
+                                                        eq(conf.getRegion()),
+                                                        clusterCaptor.capture()))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = mock(ApiFuture.class);
+    ClusterOperationMetadata metadata = ClusterOperationMetadata.newBuilder().setClusterName("flex-cluster").build();
+    when(apiFuture.get()).thenReturn(metadata);
+    when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    when(operationFuture.getName()).thenReturn("projects/dummy-project/regions/us-test1/operations/myop");
+
+    ClusterOperationMetadata result = mockDataprocClientFactory.create(
+        conf, new ErrorCategory(ErrorCategoryEnum.PROVISIONING))
+      .createCluster("flex-cluster", "2.0", Collections.emptyMap(), false, null);
+
+    Assert.assertEquals(metadata, result);
+    Cluster createdCluster = clusterCaptor.getValue();
+    Assert.assertEquals("flex-cluster", createdCluster.getClusterName());
+
+    // Verify master flex VM policy
+    Assert.assertTrue(createdCluster.getConfig().getMasterConfig().hasInstanceFlexibilityPolicy());
+    List<String> masterFlexTypes = createdCluster.getConfig().getMasterConfig().getInstanceFlexibilityPolicy()
+      .getInstanceSelectionList(0).getMachineTypesList();
+    Assert.assertEquals(Arrays.asList("custom-2-8192", "n2d-custom-2-8192"), masterFlexTypes);
+
+    // Verify primary worker flex VM policy
+    Assert.assertTrue(createdCluster.getConfig().getWorkerConfig().hasInstanceFlexibilityPolicy());
+    List<String> workerFlexTypes = createdCluster.getConfig().getWorkerConfig().getInstanceFlexibilityPolicy()
+      .getInstanceSelectionList(0).getMachineTypesList();
+    Assert.assertEquals(Arrays.asList("n2-custom-4-16384", "e2-custom-4-16384"), workerFlexTypes);
+
+    // Verify secondary worker flex VM policy
+    Assert.assertTrue(createdCluster.getConfig().getSecondaryWorkerConfig().hasInstanceFlexibilityPolicy());
+    List<String> secWorkerFlexTypes = createdCluster.getConfig().getSecondaryWorkerConfig()
+      .getInstanceFlexibilityPolicy().getInstanceSelectionList(0).getMachineTypesList();
+    Assert.assertEquals(Arrays.asList("n2-custom-4-16384", "e2-custom-4-16384"), secWorkerFlexTypes);
+  }
+
+  @Test
+  public void testCreateClusterWithoutFlexVmConfig() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("accountKey", "{ \"type\": \"test\"}");
+    properties.put(DataprocConf.PROJECT_ID_KEY, "dummy-project");
+    properties.put("zone", "us-test1-c");
+    DataprocConf conf = DataprocConf.create(properties);
+
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = mock(OperationFuture.class);
+    ArgumentCaptor<Cluster> clusterCaptor = ArgumentCaptor.forClass(Cluster.class);
+    when(clusterControllerClientMock.createClusterAsync(eq(conf.getProjectId()),
+                                                        eq(conf.getRegion()),
+                                                        clusterCaptor.capture()))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = mock(ApiFuture.class);
+    ClusterOperationMetadata metadata =
+      ClusterOperationMetadata.newBuilder().setClusterName("noflex-cluster").build();
+    when(apiFuture.get()).thenReturn(metadata);
+    when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    when(operationFuture.getName()).thenReturn("projects/dummy-project/regions/us-test1/operations/myop");
+
+    ClusterOperationMetadata result = mockDataprocClientFactory.create(
+        conf, new ErrorCategory(ErrorCategoryEnum.PROVISIONING))
+      .createCluster("noflex-cluster", "2.0", Collections.emptyMap(), false, null);
+
+    Assert.assertEquals(metadata, result);
+    Cluster createdCluster = clusterCaptor.getValue();
+    Assert.assertEquals("noflex-cluster", createdCluster.getClusterName());
+
+    Assert.assertFalse(createdCluster.getConfig().getMasterConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertFalse(createdCluster.getConfig().getWorkerConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertFalse(createdCluster.getConfig().getSecondaryWorkerConfig().hasInstanceFlexibilityPolicy());
+  }
+
+  @Test
+  public void testCreateClusterWithWorkerOnlyFlexVmConfig() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("accountKey", "{ \"type\": \"test\"}");
+    properties.put(DataprocConf.PROJECT_ID_KEY, "dummy-project");
+    properties.put("zone", "us-test1-c");
+    properties.put("workerCPUs", "2");
+    properties.put("workerMemoryMB", "8192");
+    properties.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n2");
+    DataprocConf conf = DataprocConf.create(properties);
+
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = mock(OperationFuture.class);
+    ArgumentCaptor<Cluster> clusterCaptor = ArgumentCaptor.forClass(Cluster.class);
+    when(clusterControllerClientMock.createClusterAsync(eq(conf.getProjectId()),
+                                                        eq(conf.getRegion()),
+                                                        clusterCaptor.capture()))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = mock(ApiFuture.class);
+    ClusterOperationMetadata metadata =
+      ClusterOperationMetadata.newBuilder().setClusterName("worker-flex").build();
+    when(apiFuture.get()).thenReturn(metadata);
+    when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    when(operationFuture.getName()).thenReturn("projects/dummy-project/regions/us-test1/operations/myop");
+
+    mockDataprocClientFactory.create(conf, new ErrorCategory(ErrorCategoryEnum.PROVISIONING))
+      .createCluster("worker-flex", "2.0", Collections.emptyMap(), false, null);
+
+    Cluster createdCluster = clusterCaptor.getValue();
+    Assert.assertFalse(createdCluster.getConfig().getMasterConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertTrue(createdCluster.getConfig().getWorkerConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertEquals(Collections.singletonList("n2-custom-2-8192"),
+      createdCluster.getConfig().getWorkerConfig().getInstanceFlexibilityPolicy()
+        .getInstanceSelectionList(0).getMachineTypesList());
+    Assert.assertTrue(createdCluster.getConfig().getSecondaryWorkerConfig().hasInstanceFlexibilityPolicy());
+  }
+
+  @Test
+  public void testCreateClusterWithMasterOnlyFlexVmConfig() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("accountKey", "{ \"type\": \"test\"}");
+    properties.put(DataprocConf.PROJECT_ID_KEY, "dummy-project");
+    properties.put("zone", "us-test1-c");
+    properties.put("masterCPUs", "4");
+    properties.put("masterMemoryMB", "16384");
+    properties.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "e2, n2d");
+    DataprocConf conf = DataprocConf.create(properties);
+
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = mock(OperationFuture.class);
+    ArgumentCaptor<Cluster> clusterCaptor = ArgumentCaptor.forClass(Cluster.class);
+    when(clusterControllerClientMock.createClusterAsync(eq(conf.getProjectId()),
+                                                        eq(conf.getRegion()),
+                                                        clusterCaptor.capture()))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = mock(ApiFuture.class);
+    ClusterOperationMetadata metadata =
+      ClusterOperationMetadata.newBuilder().setClusterName("master-flex").build();
+    when(apiFuture.get()).thenReturn(metadata);
+    when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    when(operationFuture.getName()).thenReturn("projects/dummy-project/regions/us-test1/operations/myop");
+
+    mockDataprocClientFactory.create(conf, new ErrorCategory(ErrorCategoryEnum.PROVISIONING))
+      .createCluster("master-flex", "2.0", Collections.emptyMap(), false, null);
+
+    Cluster createdCluster = clusterCaptor.getValue();
+    Assert.assertTrue(createdCluster.getConfig().getMasterConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertEquals(Arrays.asList("e2-custom-4-16384", "n2d-custom-4-16384"),
+      createdCluster.getConfig().getMasterConfig().getInstanceFlexibilityPolicy()
+        .getInstanceSelectionList(0).getMachineTypesList());
+    Assert.assertFalse(createdCluster.getConfig().getWorkerConfig().hasInstanceFlexibilityPolicy());
+    Assert.assertFalse(createdCluster.getConfig().getSecondaryWorkerConfig().hasInstanceFlexibilityPolicy());
   }
 
   @Test

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.longrunning.Operation;
 import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.runtime.spi.MockVersionInfo;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
@@ -32,8 +33,10 @@ import io.cdap.cdap.runtime.spi.common.DataprocMetric;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -685,5 +688,226 @@ public class DataprocProvisionerTest {
     Assert.assertNotNull(genericCount);
     Assert.assertEquals(1, apiCount.intValue());
     Assert.assertEquals(1, genericCount.intValue());
+  }
+  
+  @Test
+  public void testFlexVmConfigurationParsing() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put("workerCPUs", "2");
+    props.put("workerMemoryMB", "8192");
+    props.put("masterCPUs", "2");
+    props.put("masterMemoryMB", "8192");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n2, e2");
+    props.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "n1, n2d");
+
+    DataprocConf conf = DataprocConf.create(props);
+
+    List<String> expectedWorkerTypes = Arrays.asList("n2-custom-2-8192", "e2-custom-2-8192");
+    Assert.assertEquals(expectedWorkerTypes, conf.getWorkerFlexVmMachineTypes());
+
+    List<String> expectedMasterTypes = Arrays.asList("custom-2-8192", "n2d-custom-2-8192");
+    Assert.assertEquals(expectedMasterTypes, conf.getMasterFlexVmMachineTypes());
+  }
+
+  @Test
+  public void testFlexVmDefaultEmpty() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+
+    DataprocConf conf = DataprocConf.create(props);
+
+    Assert.assertTrue(conf.getWorkerFlexVmMachineTypes().isEmpty());
+    Assert.assertTrue(conf.getMasterFlexVmMachineTypes().isEmpty());
+  }
+
+  @Test
+  public void testFlexVmValidationSuccess() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n2, e2");
+    provisioner.validateProperties(props);
+  }
+
+  @Test(expected = DataprocRuntimeException.class)
+  public void testFlexVmValidationFailureOnInvalidFormat() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "invalid@machine#name");
+
+    provisioner.validateProperties(props);
+  }
+
+  @Test
+  public void testFlexVmConfigurationParsingWithSpacesAndEmptyEntries() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put("workerCPUs", "4");
+    props.put("workerMemoryMB", "16384");
+    props.put("masterCPUs", "8");
+    props.put("masterMemoryMB", "32768");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, " , n2 , , e2 , , c2 , ");
+    props.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "  n1 , , n2d  ");
+
+    DataprocConf conf = DataprocConf.create(props);
+
+    List<String> expectedWorkerTypes = Arrays.asList(
+      "n2-custom-4-16384", "e2-custom-4-16384", "c2-custom-4-16384");
+    Assert.assertEquals(expectedWorkerTypes, conf.getWorkerFlexVmMachineTypes());
+
+    List<String> expectedMasterTypes = Arrays.asList(
+      "custom-8-32768", "n2d-custom-8-32768");
+    Assert.assertEquals(expectedMasterTypes, conf.getMasterFlexVmMachineTypes());
+  }
+
+  @Test
+  public void testFlexVmValidationMasterFailureOnInvalidFormat() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "invalid#master@type");
+
+    try {
+      provisioner.validateProperties(props);
+      Assert.fail("Expected validation to fail for invalid master flexible VM type");
+    } catch (DataprocRuntimeException e) {
+      Assert.assertEquals(ErrorType.USER, e.getErrorType());
+      Assert.assertEquals(DataprocRuntimeException.ERROR_CATEGORY_PROVISIONING_CONFIGURATION,
+                          e.getErrorCategory());
+      Assert.assertTrue(e.getMessage().contains("Invalid flexible VM machine type"));
+    }
+  }
+
+  @Test
+  public void testFlexVmValidationWorkerFailureDetails() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "invalid_type");
+
+    try {
+      provisioner.validateProperties(props);
+      Assert.fail("Expected validation to fail for invalid worker flexible VM type");
+    } catch (DataprocRuntimeException e) {
+      Assert.assertEquals(ErrorType.USER, e.getErrorType());
+      Assert.assertEquals(DataprocRuntimeException.ERROR_CATEGORY_PROVISIONING_CONFIGURATION,
+                          e.getErrorCategory());
+      Assert.assertTrue(e.getMessage().contains("Invalid flexible VM machine type"));
+    }
+  }
+
+  @Test
+  public void testFlexVmValidationBothMasterAndWorkerSuccess() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "n1, n2, n2d, e2");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n1, n2, n2d, e2");
+
+    provisioner.validateProperties(props);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testMasterFlexVmUnmodifiableList() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.MASTER_FLEX_VM_MACHINE_TYPES, "n1, n2");
+
+    DataprocConf conf = DataprocConf.create(props);
+    conf.getMasterFlexVmMachineTypes().add("e2-custom-2-8192");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testWorkerFlexVmUnmodifiableList() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.WORKER_FLEX_VM_MACHINE_TYPES, "n1, n2");
+
+    DataprocConf conf = DataprocConf.create(props);
+    conf.getWorkerFlexVmMachineTypes().add("e2-custom-2-8192");
+  }
+
+  @Test
+  public void testNetworkTagsParsing() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put("networkTags", "tag1,  tag2 , , tag3 ");
+
+    DataprocConf conf = DataprocConf.create(props);
+    Assert.assertEquals(Arrays.asList("tag1", "tag2", "tag3"), conf.getNetworkTags());
+  }
+
+  @Test
+  public void testNetworkTagsDefaultEmpty() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+
+    DataprocConf conf = DataprocConf.create(props);
+    Assert.assertTrue(conf.getNetworkTags().isEmpty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNetworkTagsExceedsMaxLimit() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    StringBuilder tags = new StringBuilder();
+    for (int i = 0; i < 65; i++) {
+      tags.append("tag").append(i).append(",");
+    }
+    props.put("networkTags", tags.toString());
+
+    DataprocConf.create(props);
+  }
+
+  @Test
+  public void testScopesDefaultContainsCloudPlatformScope() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+
+    DataprocConf conf = DataprocConf.create(props);
+    Assert.assertEquals(Collections.singletonList(DataprocConf.CLOUD_PLATFORM_SCOPE), conf.getScopes());
+  }
+
+  @Test
+  public void testScopesParsingOrderAndDeduplication() {
+    Map<String, String> props = new HashMap<>();
+    props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put("accountKey", "key");
+    props.put("region", "region1");
+    props.put(DataprocConf.SCOPES, "https://www.googleapis.com/auth/bigquery, https://www.googleapis.com/auth/drive, "
+      + "https://www.googleapis.com/auth/bigquery, " + DataprocConf.CLOUD_PLATFORM_SCOPE);
+
+    DataprocConf conf = DataprocConf.create(props);
+    List<String> expectedScopes = Arrays.asList(
+      "https://www.googleapis.com/auth/bigquery",
+      "https://www.googleapis.com/auth/drive",
+      DataprocConf.CLOUD_PLATFORM_SCOPE
+    );
+    Assert.assertEquals(expectedScopes, conf.getScopes());
   }
 }


### PR DESCRIPTION
Adds support for configuring flexible fallback machine types for Dataproc master and worker nodes. This allows clusters to automatically fall back to alternative machine types in priority order if the primary machine type is unavailable.

### Changes

* **gcp-dataproc.json:** Added masterFlexVmMachineTypes and workerFlexVmMachineTypes dropdowns to configure fallback machine types (n1, n2, n2d, e2).
* **DataprocConf.java:** Added parsing and helper methods to format fallback machine types with configured CPU and memory values.
* **DataprocClient.java:** Attached flexible machine type configuration to master, primary worker, and secondary worker node configs when present.
* **DataprocProvisioner.java:** Added validation to verify machine type naming formats.
* **DataprocProvisionerTest.java:** Added unit tests covering property parsing, validation, and cluster creation.

### Testing
* Unit tests pass locally.
* Verified successful cluster creation and fallback configuration on a live test cluster.

