### PR TITLE
Fix doc typos

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2051,7 +2051,7 @@ public final class Constants {
   public static final int DATA_LEVELDB_CACHESIZE_MAXFILES_OFFSET = 10;
 
   /**
-   * Used for upgrade and backwards compatability.
+   * Used for upgrade and backwards compatibility.
    */
   public static final String DEVELOPER_ACCOUNT = "developer";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3351,7 +3351,7 @@
     <name>provisioner.cconf.reload.interval.ms</name>
     <value>10000</value>
     <description>
-      Minimum interval in milliseconds to reload configration in provisioner
+      Minimum interval in milliseconds to reload configuration in provisioner
       operations.
     </description>
   </property>

--- a/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
@@ -68,7 +68,7 @@ public class SchemaTest {
   /**
    * Test child.
    *
-   * @param <T> Paramter.
+   * @param <T> Parameter.
    */
   public class Child<T> extends Parent<Map<String, T>> {
     private int height;


### PR DESCRIPTION
Fixes three small typos found while reading through cdap-common. No functional changes.

configration to configuration in the description for provisioner.cconf.reload.interval.ms in cdap-default.xml. compatability to compatibility in a comment on Constants.DEVELOPER_ACCOUNT. Paramter to Parameter in a Javadoc param tag in SchemaTest.