### PR TITLE
CDAP-21261 : Implementing Refresh Token Rotation Oauth

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthAccessToken.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthAccessToken.java
@@ -21,13 +21,32 @@ import com.google.common.base.Preconditions;
  */
 public class OAuthAccessToken {
   private final String accessToken;
+  private final long expiresAt;
+  private final String identityUrl;
 
-  public OAuthAccessToken(String accessToken) {
+  private OAuthAccessToken(String accessToken, long expiresAt, String identityUrl) {
     this.accessToken = accessToken;
+    this.expiresAt = expiresAt;
+    this.identityUrl = identityUrl;
   }
 
   public String getAccessToken() {
     return accessToken;
+  }
+
+  public long getExpiresAt() {
+    return expiresAt;
+  }
+
+  public String getIdentityUrl() {
+    return identityUrl;
+  }
+
+  public boolean isExpired(long refreshBufferMs) {
+    if (expiresAt <= 0) {
+      return false;
+    }
+    return (expiresAt - System.currentTimeMillis()) <= refreshBufferMs;
   }
 
   public static Builder newBuilder() {
@@ -39,6 +58,8 @@ public class OAuthAccessToken {
    */
   public static class Builder {
     private String accessToken;
+    private long expiresAt;
+    private String identityUrl;
 
     public Builder() {}
 
@@ -47,9 +68,19 @@ public class OAuthAccessToken {
       return this;
     }
 
+    public Builder withExpiresAt(long expiresAt) {
+      this.expiresAt = expiresAt;
+      return this;
+    }
+
+    public Builder withIdentityUrl(String identityUrl) {
+      this.identityUrl = identityUrl;
+      return this;
+    }
+
     public OAuthAccessToken build() {
       Preconditions.checkNotNull(accessToken, "OAuth access token missing");
-      return new OAuthAccessToken(accessToken);
+      return new OAuthAccessToken(accessToken, expiresAt, identityUrl);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
@@ -36,13 +36,17 @@ public class OAuthProvider {
   @Nullable
   private final AuthType authType;
 
-  public OAuthProvider(String name,
-                       String loginURL,
-                       String tokenRefreshURL,
-                       @Nullable OAuthClientCredentials clientCreds,
-                       @Nullable CredentialEncodingStrategy strategy,
-                       @Nullable String userAgent,
-                       @Nullable AuthType authType) {
+  @Nullable
+  private final RefreshType refreshType;
+
+  private OAuthProvider(String name,
+                        String loginURL,
+                        String tokenRefreshURL,
+                        @Nullable OAuthClientCredentials clientCreds,
+                        @Nullable CredentialEncodingStrategy strategy,
+                        @Nullable String userAgent,
+                        @Nullable AuthType authType,
+                        @Nullable RefreshType refreshType) {
     this.name = name;
     this.loginURL = loginURL;
     this.tokenRefreshURL = tokenRefreshURL;
@@ -50,6 +54,7 @@ public class OAuthProvider {
     this.strategy = strategy;
     this.userAgent = userAgent;
     this.authType = authType != null ? authType : AuthType.STANDARD;
+    this.refreshType = refreshType != null ? refreshType : RefreshType.STANDARD;
   }
 
   public String getName() {
@@ -83,6 +88,10 @@ public class OAuthProvider {
     return authType;
   }
 
+  public RefreshType getRefreshType() {
+    return refreshType;
+  }
+
   public enum CredentialEncodingStrategy {
     // (default) Sends client ID & secret as part of the POST request body
     FORM_BODY,
@@ -105,6 +114,7 @@ public class OAuthProvider {
     private CredentialEncodingStrategy strategy;
     private String userAgent;
     private AuthType authType;
+    private RefreshType refreshType;
 
     public Builder() {}
 
@@ -143,6 +153,11 @@ public class OAuthProvider {
       return this;
     }
 
+    public Builder withRefreshType(@Nullable RefreshType refreshType) {
+      this.refreshType = refreshType;
+      return this;
+    }
+
     public OAuthProvider build() {
       Preconditions.checkNotNull(name, "OAuth provider name missing");
       Preconditions.checkNotNull(loginURL, "Login URL missing");
@@ -151,7 +166,14 @@ public class OAuthProvider {
       if (strategy == null) {
         this.strategy = CredentialEncodingStrategy.FORM_BODY;
       }
-      return new OAuthProvider(name, loginURL, tokenRefreshURL, clientCreds, strategy, userAgent, authType);
+      if (authType == null) {
+        this.authType = AuthType.STANDARD;
+      }
+      if (refreshType == null) {
+        this.refreshType = RefreshType.STANDARD;
+      }
+      return new OAuthProvider(name, loginURL, tokenRefreshURL, clientCreds, strategy, userAgent,
+          authType, refreshType);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
@@ -19,6 +19,7 @@ import static io.cdap.cdap.datapipeline.service.OAuthHandler.PREF_PKCE_CODE_VERI
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.security.store.SecureStoreInfo;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.InvalidFieldException;
@@ -50,6 +51,7 @@ public class OAuthStore {
   private static final String CREDENTIAL_ENCODING_STRATEGY_COL = "credentialencodingstrategy";
   private static final String USER_AGENT_COL = "useragent";
   private static final String AUTH_TYPE_COL = "authtype";
+  private static final String REFRESH_TYPE_COL = "refreshtype";
   private static final String CLIENT_CREDS_KEY_PREFIX = "oauthclientcreds";
   private static final String ACCESS_TOKEN_KEY_PREFIX = "oauthaccesstoken";
   private static final String REFRESH_TOKEN_KEY_PREFIX = "oauthrefreshtoken";
@@ -68,9 +70,12 @@ public class OAuthStore {
                   Fields.stringType(TOKEN_REFRESH_URL_COL),
                   Fields.stringType(CREDENTIAL_ENCODING_STRATEGY_COL),
                   Fields.stringType(USER_AGENT_COL),
-                  Fields.stringType(AUTH_TYPE_COL))
+                  Fields.stringType(AUTH_TYPE_COL),
+                  Fields.stringType(REFRESH_TYPE_COL))
       .withPrimaryKeys(OAUTH_PROVIDER_COL)
       .build();
+
+  private volatile SecureStoreInfo secureStoreInfo;
 
   public OAuthStore(
       TransactionRunner transactionRunner,
@@ -81,6 +86,42 @@ public class OAuthStore {
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
     this.codeVerifierTTL = Long.parseLong(oauthConf.get(PREF_PKCE_CODE_VERIFIER_TTL));
+  }
+
+  public SecureStoreInfo getStoreInfo() throws OAuthStoreException {
+    if (secureStoreInfo == null) {
+      synchronized (this) {
+        if (secureStoreInfo == null) {
+          try {
+            secureStoreInfo = secureStore.getStoreInfo();
+          } catch (IOException e) {
+            throw new OAuthStoreException("Failed to get store info from secure store", e);
+          }
+        }
+      }
+    }
+    return secureStoreInfo;
+  }
+
+  public boolean acquireLease(String provider, String credentialId, long timeoutMs,
+      String leaseHolder) throws OAuthStoreException {
+    String namespace = NamespaceId.SYSTEM.getNamespace();
+    String key = getRefreshTokenKey(provider, credentialId);
+    try {
+      return secureStoreManager.acquireLease(namespace, key, timeoutMs, leaseHolder);
+    } catch (Exception e) {
+      throw new OAuthStoreException("Failed to acquire lease for credential " + credentialId, e);
+    }
+  }
+
+  public boolean releaseLease(String provider, String credentialId, String leaseHolder) throws OAuthStoreException {
+    String namespace = NamespaceId.SYSTEM.getNamespace();
+    String key = getRefreshTokenKey(provider, credentialId);
+    try {
+      return secureStoreManager.releaseLease(namespace, key, leaseHolder);
+    } catch (Exception e) {
+      throw new OAuthStoreException("Failed to release lease for credential " + credentialId, e);
+    }
   }
 
   /**
@@ -325,6 +366,7 @@ public class OAuthStore {
     String credentialEncodingStrategy = row.getString(CREDENTIAL_ENCODING_STRATEGY_COL);
     String userAgent = row.getString(USER_AGENT_COL);
     String authTypeStr = row.getString(AUTH_TYPE_COL);
+    String refreshTypeStr = row.getString(REFRESH_TYPE_COL);
 
     return OAuthProvider.newBuilder()
         .withName(name)
@@ -336,11 +378,14 @@ public class OAuthStore {
                 .map(OAuthProvider.CredentialEncodingStrategy::valueOf).orElse(null))
         .withUserAgent(userAgent)
         .withAuthType(authTypeStr != null ? AuthType.valueOf(authTypeStr) : AuthType.STANDARD)
+        .withRefreshType(
+            Optional.ofNullable(refreshTypeStr)
+                .map(RefreshType::valueOf).orElse(RefreshType.STANDARD))
         .build();
   }
 
   private static List<Field<?>> getRow(OAuthProvider oauthProvider) {
-    List<Field<?>> fields = new ArrayList<>(3);
+    List<Field<?>> fields = new ArrayList<>(7);
     fields.add(Fields.stringField(OAUTH_PROVIDER_COL, oauthProvider.getName()));
     fields.add(Fields.stringField(LOGIN_URL_COL, oauthProvider.getLoginURL()));
     fields.add(Fields.stringField(TOKEN_REFRESH_URL_COL, oauthProvider.getTokenRefreshURL()));
@@ -349,6 +394,7 @@ public class OAuthStore {
             oauthProvider.getCredentialEncodingStrategy().toString()));
     fields.add(Fields.stringField(USER_AGENT_COL, oauthProvider.getUserAgent()));
     fields.add(Fields.stringField(AUTH_TYPE_COL, oauthProvider.getAuthType().toString()));
+    fields.add(Fields.stringField(REFRESH_TYPE_COL, oauthProvider.getRefreshType().toString()));
     return fields;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthProviderRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/PutOAuthProviderRequest.java
@@ -17,33 +17,43 @@
 
 package io.cdap.cdap.datapipeline.oauth;
 
+import javax.annotation.Nullable;
+
 /**
  * OAuth REST PUT request body.
  */
 public class PutOAuthProviderRequest {
   private final String loginURL;
   private final String tokenRefreshURL;
+  @Nullable
   private final String clientId;
+  @Nullable
   private final String clientSecret;
+  @Nullable
   private final OAuthProvider.CredentialEncodingStrategy strategy;
+  @Nullable
   private final String userAgent;
+  @Nullable
   private final AuthType authType;
+  @Nullable
+  private final RefreshType refreshType;
 
-  public PutOAuthProviderRequest(
-          String loginURL,
-          String tokenRefreshURL,
-          String clientId,
-          String clientSecret,
-          OAuthProvider.CredentialEncodingStrategy strategy,
-          String userAgent,
-          AuthType authType) {
+  private PutOAuthProviderRequest(String loginURL,
+                                  String tokenRefreshURL,
+                                  @Nullable String clientId,
+                                  @Nullable String clientSecret,
+                                  @Nullable OAuthProvider.CredentialEncodingStrategy strategy,
+                                  @Nullable String userAgent,
+                                  @Nullable AuthType authType,
+                                  @Nullable RefreshType refreshType) {
     this.loginURL = loginURL;
     this.tokenRefreshURL = tokenRefreshURL;
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.strategy = strategy;
     this.userAgent = userAgent;
-    this.authType = authType;
+    this.authType = authType != null ? authType : AuthType.STANDARD;
+    this.refreshType = refreshType != null ? refreshType : RefreshType.STANDARD;
   }
 
   public String getLoginURL() {
@@ -54,23 +64,100 @@ public class PutOAuthProviderRequest {
     return tokenRefreshURL;
   }
 
+  @Nullable
   public String getClientId() {
     return clientId;
   }
 
+  @Nullable
   public String getClientSecret() {
     return clientSecret;
   }
 
+  @Nullable
   public OAuthProvider.CredentialEncodingStrategy getCredentialEncodingStrategy() {
     return strategy;
   }
 
+  @Nullable
   public String getUserAgent() {
     return userAgent;
   }
 
   public AuthType getAuthType() {
-    return authType;
+    if (authType != null) {
+      return authType;
+    }
+    return AuthType.STANDARD;
+  }
+
+  public RefreshType getRefreshType() {
+    if (refreshType != null) {
+      return refreshType;
+    }
+    return RefreshType.STANDARD;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link PutOAuthProviderRequest}.
+   */
+  public static class Builder {
+    private String loginURL;
+    private String tokenRefreshURL;
+    private String clientId;
+    private String clientSecret;
+    private OAuthProvider.CredentialEncodingStrategy strategy;
+    private String userAgent;
+    private AuthType authType;
+    private RefreshType refreshType;
+
+    public Builder loginURL(String loginURL) {
+      this.loginURL = loginURL;
+      return this;
+    }
+
+    public Builder tokenRefreshURL(String tokenRefreshURL) {
+      this.tokenRefreshURL = tokenRefreshURL;
+      return this;
+    }
+
+    public Builder clientId(@Nullable String clientId) {
+      this.clientId = clientId;
+      return this;
+    }
+
+    public Builder clientSecret(@Nullable String clientSecret) {
+      this.clientSecret = clientSecret;
+      return this;
+    }
+
+    public Builder strategy(@Nullable OAuthProvider.CredentialEncodingStrategy strategy) {
+      this.strategy = strategy;
+      return this;
+    }
+
+    public Builder userAgent(@Nullable String userAgent) {
+      this.userAgent = userAgent;
+      return this;
+    }
+
+    public Builder authType(@Nullable AuthType authType) {
+      this.authType = authType;
+      return this;
+    }
+
+    public Builder refreshType(@Nullable RefreshType refreshType) {
+      this.refreshType = refreshType;
+      return this;
+    }
+
+    public PutOAuthProviderRequest build() {
+      return new PutOAuthProviderRequest(loginURL, tokenRefreshURL, clientId,
+          clientSecret, strategy, userAgent, authType, refreshType);
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/RefreshTokenResponse.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/RefreshTokenResponse.java
@@ -36,6 +36,11 @@ public class RefreshTokenResponse {
   private final String tokenType;
   @SerializedName("issued_at")
   private final String issuedAt;
+  /**
+   * The lifetime in seconds of the access token (per RFC 6749 Section 5.1).
+   */
+  @SerializedName("expires_in")
+  private final long expiresIn;
 
   public RefreshTokenResponse(
       String accessToken,
@@ -45,7 +50,8 @@ public class RefreshTokenResponse {
       String instanceURL,
       String id,
       String tokenType,
-      String issuedAt) {
+      String issuedAt,
+      long expiresIn) {
     this.accessToken = accessToken;
     this.refreshToken = refreshToken;
     this.signature = signature;
@@ -54,6 +60,7 @@ public class RefreshTokenResponse {
     this.id = id;
     this.tokenType = tokenType;
     this.issuedAt = issuedAt;
+    this.expiresIn = expiresIn;
   }
 
   public String getAccessToken() {
@@ -88,4 +95,10 @@ public class RefreshTokenResponse {
     return issuedAt;
   }
 
+  /**
+   * Returns the lifetime in seconds of the access token.
+   */
+  public long getExpiresIn() {
+    return expiresIn;
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/RefreshType.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/RefreshType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2026 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.oauth;
+
+/**
+ * The type of OAuth 2.0 refresh flow to use.
+ */
+public enum RefreshType {
+  /**
+   * Standard OAuth 2.0 Refresh Token flow.
+   */
+  STANDARD,
+
+  /**
+   * OAuth 2.0 Refresh Token Rotation (RTR) flow.
+   * Provides enhanced security by issuing a new refresh token with every access token refresh.
+   */
+  RTR
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -17,13 +17,15 @@
 
 package io.cdap.cdap.datapipeline.service;
 
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
+import io.cdap.cdap.api.security.store.SecureStoreInfo;
 import io.cdap.cdap.api.service.http.AbstractSystemHttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
-import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.cdap.datapipeline.oauth.CredentialIsValidResponse;
 import io.cdap.cdap.datapipeline.oauth.GetAccessTokenResponse;
@@ -31,6 +33,7 @@ import io.cdap.cdap.datapipeline.oauth.OAuthAccessToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthClientCredentials;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
 import io.cdap.cdap.datapipeline.oauth.AuthType;
+import io.cdap.cdap.datapipeline.oauth.RefreshType;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider.CredentialEncodingStrategy;
 import io.cdap.cdap.datapipeline.oauth.OAuthRefreshToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthStore;
@@ -38,7 +41,6 @@ import io.cdap.cdap.datapipeline.oauth.OAuthStoreException;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthCredentialRequest;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthProviderRequest;
 import io.cdap.cdap.datapipeline.oauth.RefreshTokenResponse;
-import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
@@ -54,6 +56,7 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -84,6 +87,18 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
   private static final String OAUTH_CONF_PREFIX = "security.auth.oauth.";
   // Time To Live in seconds for PCKE based code verifier in Secure Store.
   public static final String PREF_PKCE_CODE_VERIFIER_TTL = "pkce.code.verifier.ttl.sec";
+  // Margin of safety before an access token officially expires to preemptively refresh it
+  private static final String RTR_ACCESS_TOKEN_REFRESH_BUFFER_MS = "rtr.access.token.refresh.buffer.ms";
+  // Maximum time to block and wait for another instance to complete a token refresh
+  private static final String RTR_REFRESH_WAIT_TIMEOUT_MS = "rtr.refresh.wait.timeout.ms";
+  // Interval at which to poll the token store while waiting for a concurrent refresh
+  private static final String RTR_REFRESH_POLL_INTERVAL_MS = "rtr.refresh.poll.interval.ms";
+  // The duration to hold the distributed refresh lease before it auto-expires
+  private static final String RTR_LEASE_TTL_MS = "rtr.lease.ttl.ms";
+  private long accessTokenRefreshBufferMs;
+  private long leaseTakeoverTimeoutMs;
+  private long accessTokenPollIntervalMs;
+  private long leaseExpirationTimeoutMs;
 
   private OAuthStore oauthStore;
 
@@ -92,6 +107,11 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     super.initialize(context);
     Map<String, String> oauthConf = context.getConfiguration(OAUTH_CONF_PREFIX);
     this.oauthStore = new OAuthStore(context, context, context.getAdmin(), oauthConf);
+
+    accessTokenRefreshBufferMs = Long.parseLong(oauthConf.get(RTR_ACCESS_TOKEN_REFRESH_BUFFER_MS));
+    leaseTakeoverTimeoutMs = Long.parseLong(oauthConf.get(RTR_REFRESH_WAIT_TIMEOUT_MS));
+    accessTokenPollIntervalMs = Long.parseLong(oauthConf.get(RTR_REFRESH_POLL_INTERVAL_MS));
+    leaseExpirationTimeoutMs = Long.parseLong(oauthConf.get(RTR_LEASE_TTL_MS));
   }
 
   @GET
@@ -100,7 +120,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                          @PathParam("provider") String provider,
                          @QueryParam("redirect_uri") String redirectURI,
                          @QueryParam("redirect_url") String redirectURL) {
-    try {
+    respond(responder, () -> {
       OAuthProvider oauthProvider = getProvider(provider);
 
       String formatURL = "%s";
@@ -113,32 +133,22 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
       formatURL += "client_id=%s&redirect_uri=%s";
 
       // Maintaining backward compatibility for the apps using "redirect_url" parameter.
-      if (redirectURI == null || redirectURI.isEmpty()) {
-        redirectURI = redirectURL;
-      }
+      String effectiveRedirectURI = Strings.isNullOrEmpty(redirectURI) ? redirectURL : redirectURI;
 
       String response = String.format(
-          formatURL, loginUrl, oauthProvider.getClientCredentials().getClientId(), redirectURI);
+          formatURL, loginUrl, oauthProvider.getClientCredentials().getClientId(), effectiveRedirectURI);
 
       if (oauthProvider.getAuthType() == AuthType.PKCE) {
         String state = UUID.randomUUID().toString();
         String codeVerifier = generateCodeVerifier();
         String codeChallenge = generateCodeChallenge(codeVerifier);
 
-        try {
-          oauthStore.writePKCECodeVerifier(provider, state, codeVerifier);
-        } catch (Exception e) {
-          throw new OAuthServiceException(
-              HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to store PKCE code verifier", e);
-        }
-
+        oauthStore.writePKCECodeVerifier(provider, state, codeVerifier);
         response += String.format("&state=%s&code_challenge=%s&code_challenge_method=S256", state, codeChallenge);
       }
 
       responder.sendString(response);
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
-    }
+    });
   }
 
   @PUT
@@ -147,68 +157,58 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
                                @PathParam("provider") String oauthProvider,
                                @QueryParam("reuse_client_credentials") @DefaultValue("false")
                                Boolean reuseClientCredentials) {
-    try {
-      try {
-        PutOAuthProviderRequest putOAuthProviderRequest = GSON.fromJson(
-            StandardCharsets.UTF_8.decode(request.getContent()).toString(),
-            PutOAuthProviderRequest.class);
-        CredentialEncodingStrategy strategy = putOAuthProviderRequest.getCredentialEncodingStrategy();
-        String userAgent = putOAuthProviderRequest.getUserAgent();
-        // Validate URLs
-        URL loginURL = new URL(putOAuthProviderRequest.getLoginURL());
-        URL tokenRefreshURL = new URL(putOAuthProviderRequest.getTokenRefreshURL());
+    respond(responder, () -> {
+      PutOAuthProviderRequest putOAuthProviderRequest = GSON.fromJson(
+          StandardCharsets.UTF_8.decode(request.getContent()).toString(),
+          PutOAuthProviderRequest.class);
+      CredentialEncodingStrategy strategy = putOAuthProviderRequest.getCredentialEncodingStrategy();
+      String userAgent = putOAuthProviderRequest.getUserAgent();
+      
+      // Validate URLs
+      URL loginURL = new URL(putOAuthProviderRequest.getLoginURL());
+      URL tokenRefreshURL = new URL(putOAuthProviderRequest.getTokenRefreshURL());
 
-        LOG.info("Received putOAuthProvider request with write_client_credentials = {}", reuseClientCredentials);
-        OAuthClientCredentials clientCredentials = null;
-        if (!reuseClientCredentials) {
-          clientCredentials = OAuthClientCredentials.newBuilder()
-                                                    .withClientId(putOAuthProviderRequest.getClientId())
-                                                    .withClientSecret(putOAuthProviderRequest.getClientSecret())
-                                                    .build();
-        }
-        OAuthProvider provider = OAuthProvider.newBuilder()
-                                              .withName(oauthProvider)
-                                              .withLoginURL(loginURL.toString())
-                                              .withTokenRefreshURL(tokenRefreshURL.toString())
-                                              .withClientCredentials(clientCredentials)
-                                              .withCredentialEncodingStrategy(strategy)
-                                              .withUserAgent(userAgent)
-                                              .withAuthType(putOAuthProviderRequest.getAuthType())
-                                              .build();
-        oauthStore.writeProvider(provider, reuseClientCredentials);
-        responder.sendStatus(HttpURLConnection.HTTP_OK);
-      } catch (JsonSyntaxException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid JSON: " + e.getMessage(), e);
-      } catch (NullPointerException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid provider: " + e.getMessage(), e);
-      } catch (MalformedURLException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid URL: " + e.getMessage(), e);
-      } catch (OAuthStoreException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to write to OAuth store", e);
+      LOG.info("Received putOAuthProvider request with write_client_credentials = {}", reuseClientCredentials);
+      OAuthClientCredentials clientCredentials = null;
+      if (!reuseClientCredentials) {
+        clientCredentials = OAuthClientCredentials.newBuilder()
+            .withClientId(putOAuthProviderRequest.getClientId())
+            .withClientSecret(putOAuthProviderRequest.getClientSecret())
+            .build();
       }
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
-    }
+      OAuthProvider provider = OAuthProvider.newBuilder()
+          .withName(oauthProvider)
+          .withLoginURL(loginURL.toString())
+          .withTokenRefreshURL(tokenRefreshURL.toString())
+          .withClientCredentials(clientCredentials)
+          .withCredentialEncodingStrategy(strategy)
+          .withUserAgent(userAgent)
+          .withAuthType(putOAuthProviderRequest.getAuthType())
+          .withRefreshType(putOAuthProviderRequest.getRefreshType())
+          .build();
+
+      if (provider.getRefreshType() == RefreshType.RTR) {
+        if (!oauthStore.getStoreInfo().getCapabilities().contains(SecureStoreInfo.Capability.SECRET_LEASING)) {
+          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST,
+              "The Secure Store backend does not support Refresh Token Rotation (RTR).");
+        }
+      }
+
+      oauthStore.writeProvider(provider, reuseClientCredentials);
+      responder.sendStatus(HttpURLConnection.HTTP_OK);
+    });
   }
 
   @DELETE
   @Path(API_VERSION + "/oauth/provider/{provider}")
   public void deleteOAuthProvider(HttpServiceRequest request, HttpServiceResponder responder,
-                               @PathParam("provider") String oauthProvider,
-                               @QueryParam("preserve_client_credentials") @DefaultValue("false")
-                               boolean preserveClientCredentials) {
-    try {
-      try {
-        oauthStore.deleteProvider(oauthProvider, preserveClientCredentials);
-        responder.sendStatus(HttpURLConnection.HTTP_OK);
-      } catch (NullPointerException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid provider: " + e.getMessage(), e);
-      } catch (OAuthStoreException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to delete OAuth provider.", e);
-      }
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
-    }
+                                  @PathParam("provider") String oauthProvider,
+                                  @QueryParam("preserve_client_credentials") @DefaultValue("false")
+                                  boolean preserveClientCredentials) {
+    respond(responder, () -> {
+      oauthStore.deleteProvider(oauthProvider, preserveClientCredentials);
+      responder.sendStatus(HttpURLConnection.HTTP_OK);
+    });
   }
 
   @PUT
@@ -216,41 +216,29 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
   public void putOAuthCredential(HttpServiceRequest request, HttpServiceResponder responder,
                                  @PathParam("provider") String provider,
                                  @PathParam("credential") String credentialId) {
-    try {
-      PutOAuthCredentialRequest putOAuthCredentialRequest;
-      try {
-        putOAuthCredentialRequest = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
-                PutOAuthCredentialRequest.class);
-        if (putOAuthCredentialRequest.getOneTimeCode() == null
-            || putOAuthCredentialRequest.getOneTimeCode().isEmpty()) {
-          throw new OAuthServiceException(
-              HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing one-time code");
-        }
-        if (putOAuthCredentialRequest.getRedirectURI() == null
-            || putOAuthCredentialRequest.getRedirectURI().isEmpty()) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing redirect URI");
-        }
-      } catch (JsonSyntaxException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid JSON: " + e.getMessage(), e);
+    respond(responder, () -> {
+      PutOAuthCredentialRequest putOAuthCredentialRequest = GSON.fromJson(
+          StandardCharsets.UTF_8.decode(request.getContent()).toString(),
+          PutOAuthCredentialRequest.class);
+
+      if (Strings.isNullOrEmpty(putOAuthCredentialRequest.getOneTimeCode())) {
+        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing one-time code");
+      }
+      if (Strings.isNullOrEmpty(putOAuthCredentialRequest.getRedirectURI())) {
+        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: missing redirect URI");
       }
 
       OAuthProvider oauthProvider = getProvider(provider);
-
       String state = putOAuthCredentialRequest.getState();
       String codeVerifier = null;
+      
       if (oauthProvider.getAuthType() == AuthType.PKCE) {
-        if (state == null || state.isEmpty() || !state.matches("^[a-zA-Z0-9-]+$")) {
-          throw new OAuthServiceException(
-              HttpURLConnection.HTTP_BAD_REQUEST, "State is required and must be valid for "
-              + "PKCE authentication");
+        if (Strings.isNullOrEmpty(state) || !state.matches("^[a-zA-Z0-9-]+$")) {
+          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, 
+              "State is required and must be valid for PKCE authentication");
         }
-        try {
-          codeVerifier = oauthStore.getPKCECodeVerifier(provider, state);
-          oauthStore.deletePKCECodeVerifier(provider, state);
-        } catch (OAuthStoreException e) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR,
-              "Failed to process PKCE code verifier", e);
-        }
+        codeVerifier = oauthStore.getPKCECodeVerifier(provider, state);
+        oauthStore.deletePKCECodeVerifier(provider, state);
       }
 
       HttpResponse response;
@@ -261,163 +249,252 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
             putOAuthCredentialRequest.getRedirectURI(),
             codeVerifier));
       } catch (IOException e) {
-        throw new OAuthServiceException(
-              HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
+        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
       }
 
       if (response.getResponseCode() != 200) {
-        throw new OAuthServiceException(
-          response.getResponseCode(),
-            "Request for refresh token did not return 200. Response code: "
-                + response.getResponseCode()
-                + " , response message: "
-                + response.getResponseMessage()
-                + " , response body: "
-                + response.getResponseBodyAsString());
+        throw new OAuthServiceException(response.getResponseCode(),
+            "Request for refresh token did not return 200. Response code: " + response.getResponseCode()
+            + " , response message: " + response.getResponseMessage()
+            + " , response body: " + response.getResponseBodyAsString());
       }
 
-      RefreshTokenResponse refreshTokenResponse;
-      try {
-        refreshTokenResponse = GSON.fromJson(response.getResponseBodyAsString(), RefreshTokenResponse.class);
-      } catch (JsonSyntaxException e) {
-        throw new OAuthServiceException(
-            HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to parse JSON: " + e.getMessage(), e);
-      }
+      RefreshTokenResponse refreshTokenResponse = GSON.fromJson(response.getResponseBodyAsString(),
+          RefreshTokenResponse.class);
 
-      boolean hasRefreshToken = refreshTokenResponse.getRefreshToken() != null
-          && !refreshTokenResponse.getRefreshToken().isEmpty();
-      boolean hasAccessToken = refreshTokenResponse.getAccessToken() != null
-          && !refreshTokenResponse.getAccessToken().isEmpty();
+      boolean hasRefreshToken = !Strings.isNullOrEmpty(refreshTokenResponse.getRefreshToken());
+      boolean hasAccessToken = !Strings.isNullOrEmpty(refreshTokenResponse.getAccessToken());
 
       if (!hasAccessToken && !hasRefreshToken) {
-        throw new OAuthServiceException(
-            HttpURLConnection.HTTP_BAD_REQUEST,
-            String.format(
-                "Refresh token response is missing the required access token or refresh token. " +
-                    "The actual response received: %s",
-                response.getResponseBodyAsString()));
+        throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST,
+            String.format("Refresh token response is missing the required access token or refresh token. " +
+                "The actual response received: %s", response.getResponseBodyAsString()));
       }
 
       if (hasRefreshToken) {
-        try {
-          OAuthRefreshToken refreshToken = OAuthRefreshToken.newBuilder()
-              .withRefreshToken(refreshTokenResponse.getRefreshToken())
-              .withRedirectURI(putOAuthCredentialRequest.getRedirectURI())
-              .build();
-          oauthStore.writeRefreshToken(provider, credentialId, refreshToken);
-        } catch (NullPointerException e) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, e.getMessage(), e);
-        } catch (OAuthStoreException e) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Failed to write refresh token", e);
-        }
-      } else {
-        // Refresh token call gave us an access token without a refresh token.
-        // Store the access token instead.
-
-        try {
-          OAuthAccessToken accessToken = OAuthAccessToken.newBuilder()
-              .withAccessToken(refreshTokenResponse.getAccessToken())
-              .build();
-          oauthStore.writeAccessToken(provider, credentialId, accessToken);
-        } catch (NullPointerException e) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, e.getMessage(), e);
-        } catch (OAuthStoreException e) {
-          throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST, "Failed to write access token", e);
-        }
+        writeRefreshToken(provider, credentialId, refreshTokenResponse.getRefreshToken(),
+            putOAuthCredentialRequest.getRedirectURI());
+      }
+      // For standard flow, if there no refresh token, store access token (generally long lived)
+      // For RTR, also store the initial Access Token in OAuthStore
+      if (RefreshType.RTR.equals(oauthProvider.getRefreshType()) || !hasRefreshToken) {
+        writeAccessToken(provider, credentialId, refreshTokenResponse);
       }
 
       responder.sendStatus(HttpURLConnection.HTTP_OK);
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
-    }
+    });
   }
 
-  /**
-   * If a refresh token is stored, use it to request a short-lived access token from the 3rd-party OAuth API.
-   * If a long-lived access token is stored, return it.
-   * @param request
-   * @param responder
-   * @param provider ID of OAuth provider
-   * @param credentialId ID of stored credential
-   */
   @GET
   @Path(API_VERSION + "/oauth/provider/{provider}/credential/{credential}")
   public void getOAuthCredential(HttpServiceRequest request, HttpServiceResponder responder,
                                  @PathParam("provider") String provider,
                                  @PathParam("credential") String credentialId) {
-    try {
+    respond(responder, () -> {
       OAuthProvider oauthProvider = getProvider(provider);
-      Optional<OAuthAccessToken> oAuthAccessToken = getAccessToken(provider, credentialId);
 
-      // If found, send the long-lived access token
-      if (oAuthAccessToken.isPresent()) {
-        responder.sendString(GSON.toJson(
-          new GetAccessTokenResponse(oAuthAccessToken.get().getAccessToken(), "")));
+      // 1. Check if a valid cached access token is already available
+      Optional<GetAccessTokenResponse> cachedToken = getCachedAccessTokenIfValid(
+          oauthProvider, provider, credentialId);
+      if (cachedToken.isPresent()) {
+        responder.sendString(GSON.toJson(cachedToken.get()));
         return;
       }
 
-      // If no long-lived access token was found, request a short-lived access token from the 3rd-party API using the
-      // stored refresh token
-      OAuthRefreshToken refreshToken = getRefreshToken(provider, credentialId);
-
-      HttpResponse response;
-      try {
-        response = HttpRequests.execute(createGetAccessTokenRequest(oauthProvider, refreshToken.getRefreshToken()));
-      } catch (IOException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to fetch refresh token", e);
+      // 2. Refresh token
+      GetAccessTokenResponse response;
+      if (RefreshType.RTR.equals(oauthProvider.getRefreshType())) {
+        // via RTR leasing
+        response = fetchOAuthCredentialWithRefreshTokenRotation(oauthProvider, provider, credentialId);
+      } else {
+        // via Standard refresh
+        RefreshTokenResponse tokenResponse = executeTokenRefresh(oauthProvider, provider, credentialId);
+        response = new GetAccessTokenResponse(tokenResponse.getAccessToken(), tokenResponse.getInstanceURL());
       }
+      responder.sendString(GSON.toJson(response));
+    });
+  }
 
-      if (response.getResponseCode() != 200) {
-        throw new OAuthServiceException(
-            response.getResponseCode(),
-            "Request for refresh token did not return 200. Response code: "
-                + response.getResponseCode()
-                + " , response message: "
-                + response.getResponseMessage()
-                + " , response body: "
-                + response.getResponseBodyAsString());
-      }
+  private RefreshTokenResponse executeTokenRefresh(OAuthProvider oauthProvider, String provider, String credentialId)
+      throws Exception {
+    OAuthRefreshToken refreshToken = getRefreshToken(provider, credentialId);
 
-      RefreshTokenResponse refreshTokenResponse;
-      try {
-        refreshTokenResponse = GSON.fromJson(response.getResponseBodyAsString(), RefreshTokenResponse.class);
-      } catch (JsonSyntaxException e) {
-        throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Error parsing JSON response", e);
-      }
+    HttpResponse response;
+    try {
+      response = HttpRequests.execute(createGetAccessTokenRequest(oauthProvider, refreshToken.getRefreshToken()));
+    } catch (IOException e) {
+      throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR,
+          "Failed to fetch access token from provider", e);
+    }
 
-      boolean hasRefreshToken = refreshTokenResponse.getRefreshToken() != null
-          && !refreshTokenResponse.getRefreshToken().isEmpty();
-      boolean hasAccessToken = refreshTokenResponse.getAccessToken() != null
-          && !refreshTokenResponse.getAccessToken().isEmpty();
+    if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new OAuthServiceException(response.getResponseCode(),
+          "Request for access token did not return 200. Response code: " + response.getResponseCode()
+              + " , response message: " + response.getResponseMessage()
+              + " , response body: " + response.getResponseBodyAsString());
+    }
 
-      if (!hasAccessToken) {
-        throw new OAuthServiceException(
-            HttpURLConnection.HTTP_BAD_REQUEST,
-            String.format(
-                "Access token response body does not have access token. The actual response received : %s",
-                response.getResponseBodyAsString()));
-      }
+    RefreshTokenResponse tokenResponse = GSON.fromJson(
+        response.getResponseBodyAsString(), RefreshTokenResponse.class);
 
-      // API has given us a new refresh token
-      if (hasRefreshToken && !refreshToken.getRefreshToken().equals(refreshTokenResponse.getRefreshToken())) {
-        OAuthRefreshToken newRefreshToken = OAuthRefreshToken.newBuilder()
-                .withRefreshToken(refreshTokenResponse.getRefreshToken())
-                .withRedirectURI(refreshToken.getRedirectURI())
-                .build();
+    if (Strings.isNullOrEmpty(tokenResponse.getAccessToken())) {
+      throw new OAuthServiceException(HttpURLConnection.HTTP_BAD_REQUEST,
+          "Access token response body does not have access token: " + response.getResponseBodyAsString());
+    }
+    // If provider returned a rotated refresh token, persist the updated refresh token
+    String newRefreshToken = tokenResponse.getRefreshToken();
+    if (!Strings.isNullOrEmpty(newRefreshToken) && !newRefreshToken.equals(refreshToken.getRefreshToken())) {
+      writeRefreshToken(provider, credentialId, newRefreshToken, refreshToken.getRedirectURI());
+    }
 
-        try {
-          oauthStore.writeRefreshToken(provider, credentialId, newRefreshToken);
-        } catch (OAuthStoreException e) {
-          throw new OAuthServiceException(
-              HttpURLConnection.HTTP_INTERNAL_ERROR, "An error occurred while writing the new refresh token");
+    return tokenResponse;
+  }
+
+  /**
+   * Refreshes OAuth credentials using Refresh Token Rotation (RTR) under a distributed lease.
+   * Ensures only one worker refreshes the single-use refresh token at a time while concurrent
+   * requests wait and poll for the newly published access token.
+   *
+   * @param oauthProvider the OAuth provider configuration
+   * @param provider the provider identifier
+   * @param credentialId the credential identifier
+   * @return the refreshed access token response
+   * @throws Exception if lease acquisition, token refresh, or waiting fails
+   */
+  private GetAccessTokenResponse fetchOAuthCredentialWithRefreshTokenRotation(OAuthProvider oauthProvider,
+                                                                              String provider,
+                                                                              String credentialId)
+      throws Exception {
+    // 1. Generate a unique lease holder ID for this request thread and try to acquire lease
+    String leaseHolderId = Thread.currentThread().getId() + "-" + UUID.randomUUID();
+    boolean leaseAcquired = oauthStore.acquireLease(provider, credentialId, leaseExpirationTimeoutMs, leaseHolderId);
+
+    try {
+      // 3. If Lease is held by another process -> wait for published token
+      if (!leaseAcquired) {
+        LOG.info("Lease is held by another process for provider {} credential {}. Waiting for new access token...",
+                 provider, credentialId);
+        Optional<GetAccessTokenResponse> waitedResponse = waitForNewAccessToken(oauthProvider, provider, credentialId);
+        if (waitedResponse.isPresent()) {
+          return waitedResponse.get();
+        }
+
+        // Timeout occurred while waiting for winner -> Attempt to acquire lease again!
+        leaseAcquired = oauthStore.acquireLease(provider, credentialId, leaseExpirationTimeoutMs, leaseHolderId);
+        if (!leaseAcquired) {
+          throw new OAuthServiceException(HttpURLConnection.HTTP_CLIENT_TIMEOUT,
+                                          "Timed out waiting for OAuth access token refresh for " + credentialId);
         }
       }
 
-      responder.sendString(GSON.toJson(
-          new GetAccessTokenResponse(refreshTokenResponse.getAccessToken(), refreshTokenResponse.getInstanceURL())));
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
+      // 4. Winner (either initial or fallback after timeout) executes token refresh and persistence
+      RefreshTokenResponse tokenResponse = executeTokenRefresh(oauthProvider, provider, credentialId);
+      writeAccessToken(provider, credentialId, tokenResponse);
+
+      return new GetAccessTokenResponse(tokenResponse.getAccessToken(), tokenResponse.getInstanceURL());
+    } finally {
+      if (leaseAcquired) {
+        try {
+          oauthStore.releaseLease(provider, credentialId, leaseHolderId);
+        } catch (Exception e) {
+          LOG.warn("Failed to release lease for provider {} credential {}: {}",
+                   provider, credentialId, e.getMessage());
+        }
+      }
     }
+  }
+
+  private Optional<GetAccessTokenResponse> waitForNewAccessToken(OAuthProvider oauthProvider,
+                                                                 String provider,
+                                                                 String credentialId)
+      throws OAuthServiceException {
+    long deadline = System.currentTimeMillis() + leaseTakeoverTimeoutMs;
+
+    while (System.currentTimeMillis() < deadline) {
+      Optional<GetAccessTokenResponse> accessToken = getCachedAccessTokenIfValid(
+          oauthProvider, provider, credentialId);
+      if (accessToken.isPresent()) {
+        return accessToken;
+      }
+      Uninterruptibles.sleepUninterruptibly(accessTokenPollIntervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    return Optional.empty();
+  }
+
+  private void writeRefreshToken(String provider, String credentialId,
+                                 String refreshToken, String redirectURI) throws OAuthStoreException {
+    OAuthRefreshToken token = OAuthRefreshToken.newBuilder()
+        .withRefreshToken(refreshToken)
+        .withRedirectURI(redirectURI)
+        .build();
+    oauthStore.writeRefreshToken(provider, credentialId, token);
+  }
+
+  private void writeAccessToken(String provider, String credentialId,
+                                RefreshTokenResponse tokenResponse) throws OAuthStoreException {
+    if (Strings.isNullOrEmpty(tokenResponse.getAccessToken())) {
+      return;
+    }
+
+    long expiresInSeconds = tokenResponse.getExpiresIn();
+    long expiresAt = 0L;
+    if (expiresInSeconds > 0) {
+      expiresAt = System.currentTimeMillis() + (expiresInSeconds * 1000L);
+    }
+
+    OAuthAccessToken accessToken = OAuthAccessToken.newBuilder()
+        .withAccessToken(tokenResponse.getAccessToken())
+        .withExpiresAt(expiresAt)
+        .withIdentityUrl(tokenResponse.getId())
+        .build();
+
+    oauthStore.writeAccessToken(provider, credentialId, accessToken);
+  }
+
+  private Optional<GetAccessTokenResponse> getCachedAccessTokenIfValid(OAuthProvider oauthProvider,
+      String provider,
+      String credentialId)
+      throws OAuthServiceException {
+    Optional<OAuthAccessToken> oAuthAccessToken = getAccessToken(provider, credentialId);
+    if (!oAuthAccessToken.isPresent()) {
+      return Optional.empty();
+    }
+
+    if (RefreshType.RTR.equals(oauthProvider.getRefreshType())) {
+      if (isAccessTokenValid(oAuthAccessToken.get())) {
+        LOG.debug("Returning valid cached access token for provider {} credential {}", provider, credentialId);
+        return Optional.of(new GetAccessTokenResponse(oAuthAccessToken.get().getAccessToken(), ""));
+      }
+      return Optional.empty();
+    }
+
+    // Standard flow: permanent token stored without refresh token
+    return Optional.of(new GetAccessTokenResponse(oAuthAccessToken.get().getAccessToken(), ""));
+  }
+
+  private boolean isAccessTokenValid(OAuthAccessToken token) {
+    // Rule 1: If expiresAt is present (> 0), use it with configured safety buffer
+    if (token.getExpiresAt() > 0) {
+      return !token.isExpired(accessTokenRefreshBufferMs);
+    }
+
+    // Rule 2: Else if identityUrl is present, validate against identity URL
+    if (!Strings.isNullOrEmpty(token.getIdentityUrl())) {
+      try {
+        HttpRequest request = HttpRequest.get(new URL(token.getIdentityUrl()))
+            .addHeader("Authorization", "Bearer " + token.getAccessToken())
+            .build();
+        HttpResponse response = HttpRequests.execute(request);
+        return response.getResponseCode() == HttpURLConnection.HTTP_OK;
+      } catch (Exception e) {
+        LOG.warn("Failed to validate access token via identity URL {}: {}",
+            token.getIdentityUrl(), e.getMessage());
+        return false;
+      }
+    }
+
+    return false;
   }
 
   @GET
@@ -425,44 +502,36 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
   public void getOAuthCredentialValidity(HttpServiceRequest request, HttpServiceResponder responder,
                                          @PathParam("provider") String provider,
                                          @PathParam("credential") String credentialId) {
-    try {
+    respond(responder, () -> {
       OAuthProvider oauthProvider = getProvider(provider);
-      Optional<OAuthAccessToken> oAuthAccessToken = getAccessToken(provider, credentialId);
 
-      if (oAuthAccessToken.isPresent()) {
+      // 1. Check if a valid cached access token is already available
+      Optional<GetAccessTokenResponse> cachedToken = getCachedAccessTokenIfValid(
+          oauthProvider, provider, credentialId);
+      if (cachedToken.isPresent()) {
         responder.sendString(GSON.toJson(new CredentialIsValidResponse(true)));
         return;
       }
 
-      OAuthRefreshToken refreshToken = getRefreshToken(provider, credentialId);
-
-      HttpResponse response;
-      try {
-        response = HttpRequests.execute(createGetAccessTokenRequest(oauthProvider, refreshToken.getRefreshToken()));
-      } catch (IOException e) {
-        throw new OAuthServiceException(
-              HttpURLConnection.HTTP_INTERNAL_ERROR, "Error while fetching refresh token", e);
+      // 2. For RTR providers, attempt token rotation refresh to verify validity
+      if (RefreshType.RTR.equals(oauthProvider.getRefreshType())) {
+        fetchOAuthCredentialWithRefreshTokenRotation(oauthProvider, provider, credentialId);
+        responder.sendString(GSON.toJson(new CredentialIsValidResponse(true)));
+        return;
       }
 
-      responder.sendString(GSON.toJson(new CredentialIsValidResponse(checkCredIsValid(response))));
-    } catch (OAuthServiceException e) {
-      e.respond(responder);
-    }
-  }
-
-  private boolean checkCredIsValid(HttpResponse response) throws OAuthServiceException {
-    if (response.getResponseCode() != 200) {
-      return false;
-    }
-
-    RefreshTokenResponse refreshTokenResponse;
-    try {
-      refreshTokenResponse = GSON.fromJson(response.getResponseBodyAsString(), RefreshTokenResponse.class);
-    } catch (JsonSyntaxException e) {
-      throw new OAuthServiceException(HttpURLConnection.HTTP_INTERNAL_ERROR, "Failed to parse JSON", e);
-    }
-
-    return !(refreshTokenResponse.getAccessToken() == null || refreshTokenResponse.getAccessToken().isEmpty());
+      // 3. For Standard providers, verify refresh token validity with third-party endpoint
+      OAuthRefreshToken refreshToken = getRefreshToken(provider, credentialId);
+      HttpResponse response = HttpRequests.execute(
+          createGetAccessTokenRequest(oauthProvider, refreshToken.getRefreshToken()));
+      if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+        throw new OAuthServiceException(response.getResponseCode(),
+            "Request for access token did not return 200. Response code: " + response.getResponseCode()
+                + " , response message: " + response.getResponseMessage()
+                + " , response body: " + response.getResponseBodyAsString());
+      }
+      responder.sendString(GSON.toJson(new CredentialIsValidResponse(true)));
+    });
   }
 
   /**
@@ -486,20 +555,24 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     String body;
     switch (strategy) {
       case BASIC_AUTH:
-        body = grantType.equals("authorization_code")
-                ? String.format("code=%s&redirect_uri=%s&grant_type=%s", code, redirectURI, grantType)
-                : String.format("grant_type=%s&refresh_token=%s", grantType, refreshToken);
+        if (grantType.equals("authorization_code")) {
+          body = String.format("code=%s&redirect_uri=%s&grant_type=%s", code, redirectURI, grantType);
+        } else {
+          body = String.format("grant_type=%s&refresh_token=%s", grantType, refreshToken);
+        }
         break;
       case FORM_BODY: // fall-through
       default:
-        body = grantType.equals("authorization_code")
-                ? String.format("code=%s&redirect_uri=%s&client_id=%s&client_secret=%s&grant_type=%s",
-                code, redirectURI, clientCreds.getClientId(), clientCreds.getClientSecret(), grantType)
-                : String.format("grant_type=%s&client_id=%s&client_secret=%s&refresh_token=%s",
-                grantType, clientCreds.getClientId(), clientCreds.getClientSecret(), refreshToken);
+        if (grantType.equals("authorization_code")) {
+          body = String.format("code=%s&redirect_uri=%s&client_id=%s&client_secret=%s&grant_type=%s",
+              code, redirectURI, clientCreds.getClientId(), clientCreds.getClientSecret(), grantType);
+        } else {
+          body = String.format("grant_type=%s&client_id=%s&client_secret=%s&refresh_token=%s",
+              grantType, clientCreds.getClientId(), clientCreds.getClientSecret(), refreshToken);
+        }
         break;
     }
-    if (codeVerifier != null && !codeVerifier.isEmpty()) {
+    if (!Strings.isNullOrEmpty(codeVerifier)) {
       body += "&code_verifier=" + codeVerifier;
     }
     return body;
@@ -644,7 +717,37 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
     }
   }
 
+
+  @FunctionalInterface
+  private interface EndpointRunnable {
+    void run() throws Exception;
+  }
+
+  private void respond(HttpServiceResponder responder, EndpointRunnable runnable) {
+    try {
+      runnable.run();
+    } catch (OAuthServiceException e) {
+      e.respond(responder);
+    } catch (JsonSyntaxException e) {
+      sendError(responder, HttpURLConnection.HTTP_BAD_REQUEST, "Invalid JSON: " + e.getMessage(), e);
+    } catch (MalformedURLException e) {
+      sendError(responder, HttpURLConnection.HTTP_BAD_REQUEST, "Invalid URL: " + e.getMessage(), e);
+    } catch (NullPointerException | IllegalArgumentException e) {
+      sendError(responder, HttpURLConnection.HTTP_BAD_REQUEST, "Invalid request: " + e.getMessage(), e);
+    } catch (OAuthStoreException e) {
+      sendError(responder, HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage(), e);
+    } catch (Exception e) {
+      LOG.error("An internal error has occurred", e);
+      sendError(responder, HttpURLConnection.HTTP_INTERNAL_ERROR, "Internal error", e);
+    }
+  }
+
+  private void sendError(HttpServiceResponder responder, int statusCode, String message, Throwable cause) {
+    new OAuthServiceException(statusCode, message, cause).respond(responder);
+  }
+
   private static class OAuthServiceException extends Exception {
+
     private final int status;
 
     OAuthServiceException(int status, String message, Throwable cause) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
@@ -14,22 +14,41 @@
 
 package io.cdap.cdap.datapipeline;
 
-import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.security.store.SecureStoreInfo;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
-import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
 import io.cdap.cdap.datapipeline.oauth.AuthType;
+import io.cdap.cdap.datapipeline.oauth.OAuthAccessToken;
+import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
+import io.cdap.cdap.datapipeline.oauth.OAuthRefreshToken;
 import io.cdap.cdap.datapipeline.oauth.PutOAuthProviderRequest;
+import io.cdap.cdap.datapipeline.oauth.RefreshType;
+import io.cdap.cdap.security.store.SecureStoreService;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.net.URL;
+import java.util.Collections;
+import javax.annotation.Nullable;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
 
 public class OAuthServiceTest extends DataPipelineServiceTest {
 
@@ -37,20 +56,121 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
       .setPrettyPrinting()
       .create();
 
+  private NettyHttpService mockOAuthServer;
+  private String mockTokenUrl;
+  private int mockTokenPort;
+
+  public static final class MockTokenHandler extends AbstractHttpHandler {
+    @POST
+    @Path("/token")
+    public void token(FullHttpRequest request, HttpResponder responder) {
+      responder.sendString(HttpResponseStatus.OK, "{\"access_token\":\"mock_access_token\",\"expires_in\":3600}");
+    }
+  }
+
+  @BeforeClass
+  public static void setupMockSecureStoreLeasing() {
+    for (Object inst : new Object[] {getSecureStore(), getSecureStoreManager()}) {
+      wrapSecureStoreService(inst);
+    }
+  }
+
+  private static void wrapSecureStoreService(Object inst) {
+    if (inst == null || !inst.getClass().getName().contains("DefaultSecureStoreService")) {
+      return;
+    }
+
+    try {
+      Field field = inst.getClass().getDeclaredField("secureStoreService");
+      field.setAccessible(true);
+
+      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      modifiersField.setAccessible(true);
+      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+      Object current = field.get(inst);
+      if (!(current instanceof SecureStoreService) || Proxy.isProxyClass(current.getClass())) {
+        return;
+      }
+
+      SecureStoreService delegate = (SecureStoreService) current;
+      SecureStoreService proxy = (SecureStoreService) Proxy.newProxyInstance(
+          SecureStoreService.class.getClassLoader(),
+          new Class<?>[] {SecureStoreService.class},
+          (p, method, args) -> {
+            if ("getStoreInfo".equals(method.getName())) {
+              return new SecureStoreInfo(Collections.singleton(SecureStoreInfo.Capability.SECRET_LEASING));
+            }
+            if ("acquireLease".equals(method.getName()) || "releaseLease".equals(method.getName())) {
+              return true;
+            }
+            return method.invoke(delegate, args);
+          }
+      );
+      field.set(inst, proxy);
+    } catch (Exception ignored) {
+      // Suppressed intentionally
+    }
+  }
+
+  @Before
+  public void setUpMockServer() throws Exception {
+    setupMockSecureStoreLeasing();
+    mockOAuthServer = NettyHttpService.builder("mock-oauth-server")
+        .setHost("localhost")
+        .setPort(0)
+        .setHttpHandlers(new MockTokenHandler())
+        .build();
+    mockOAuthServer.start();
+    mockTokenPort = mockOAuthServer.getBindAddress().getPort();
+    mockTokenUrl = "http://localhost:" + mockTokenPort + "/token";
+  }
+
+  @After
+  public void tearDownMockServer() throws Exception {
+    if (mockOAuthServer != null) {
+      mockOAuthServer.stop();
+    }
+  }
+
+  private static PutOAuthProviderRequest createPutRequest(String loginURL, String tokenRefreshURL,
+                                                          @Nullable String clientId, @Nullable String clientSecret,
+                                                          OAuthProvider.CredentialEncodingStrategy strategy,
+                                                          @Nullable String userAgent,
+                                                          @Nullable AuthType authType,
+                                                          @Nullable RefreshType refreshType) {
+    return PutOAuthProviderRequest.builder()
+        .loginURL(loginURL)
+        .tokenRefreshURL(tokenRefreshURL)
+        .clientId(clientId)
+        .clientSecret(clientSecret)
+        .strategy(strategy)
+        .userAgent(userAgent)
+        .authType(authType)
+        .refreshType(refreshType)
+        .build();
+  }
+
+  private static PutOAuthProviderRequest createPutRequest(String loginURL, String tokenRefreshURL,
+                                                          @Nullable String clientId, @Nullable String clientSecret,
+                                                          OAuthProvider.CredentialEncodingStrategy strategy,
+                                                          @Nullable String userAgent,
+                                                          @Nullable AuthType authType) {
+    return createPutRequest(loginURL, tokenRefreshURL, clientId, clientSecret, strategy, userAgent, authType, null);
+  }
+
+  private static PutOAuthProviderRequest createPutRequest(String loginURL, String tokenRefreshURL,
+                                                          @Nullable String clientId, @Nullable String clientSecret) {
+    return createPutRequest(loginURL, tokenRefreshURL, clientId, clientSecret,
+        OAuthProvider.CredentialEncodingStrategy.FORM_BODY, null, null, null);
+  }
+
   @Test
   public void testCreateProvider() throws IOException {
     // Attempt to create provider
     String loginURL = "http://www.example.com/login";
     String tokenRefreshURL = "http://www.example.com/token";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -66,13 +186,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider with missing client credentials should fail with 400 status code.
     String loginURL = "http://www.example.com/login";
     String tokenRefreshURL = "http://www.example.com/token";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -83,13 +197,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // param 'true' should succeed with 200 status code.
     String loginURL = "http://www.example.com/login";
     String tokenRefreshURL = "http://www.example.com/token";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider10?reuse_client_credentials=true", request);
     Assert.assertEquals(500, createResponse.getResponseCode());
   }
@@ -99,15 +207,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider with client credentials.
     String loginURL = "http://www.example.com/login20";
     String tokenRefreshURL = "http://www.example.com/token20";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
     HttpResponse createResponse = makePutCall("provider/testprovider20", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -115,13 +215,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // param 'true' should succeed with 200 status code.
     loginURL = "http://www.example.com/login21";
     tokenRefreshURL = "http://www.example.com/token21";
-    request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     createResponse = makePutCall("provider/testprovider20?reuse_client_credentials=true", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
   }
@@ -132,13 +226,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // query param 'false' should fail with 400 status code.
     String loginURL = "http://www.example.com/login30";
     String tokenRefreshURL = "http://www.example.com/token30";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider30?reuse_client_credentials=false", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -148,15 +236,8 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider
     String loginURL = "http://www.example.com/login31";
     String tokenRefreshURL = "http://www.example.com/token31";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret",
+        OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH, null, null);
     HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider31", request);
     Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
 
@@ -172,15 +253,8 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider
     String loginURL = "http://www.example.com/login32";
     String tokenRefreshURL = "http://www.example.com/token32";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH,
-            "cdap-test", null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret",
+        OAuthProvider.CredentialEncodingStrategy.BASIC_AUTH, "cdap-test", null);
     HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider32", request);
     Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
 
@@ -195,15 +269,8 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
   public void testCreateProviderWithPkceAuthType() throws IOException {
     String loginURL = "http://www.example.com/login_pkce";
     String tokenRefreshURL = "http://www.example.com/token_pkce";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, AuthType.PKCE);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret",
+        OAuthProvider.CredentialEncodingStrategy.FORM_BODY, null, AuthType.PKCE);
     HttpResponse createOauthProviderResponse = makePutCall("provider/testprovider_pkce", request);
     Assert.assertEquals(200, createOauthProviderResponse.getResponseCode());
 
@@ -211,10 +278,10 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     HttpResponse getAuthUrlResponse = makeGetCall("provider/testprovider_pkce/authurl");
     Assert.assertEquals(200, getAuthUrlResponse.getResponseCode());
     String authURL = getAuthUrlResponse.getResponseBodyAsString();
-    
+
     // Verify base URL
     Assert.assertTrue(authURL.startsWith("http://www.example.com/login_pkce?client_id=clientid&redirect_uri=null"));
-    
+
     // Verify PKCE specific query params
     Assert.assertTrue(authURL.contains("&state="));
     Assert.assertTrue(authURL.contains("&code_challenge="));
@@ -227,13 +294,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // query param 'true'.
     String loginURL = "http://www.example.com/login40";
     String tokenRefreshURL = "http://www.example.com/token40";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     HttpResponse createResponse = makePutCall("provider/testprovider40?reuse_client_credentials=false", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
 
@@ -247,15 +308,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider with client credentials.
     String loginURL = "http://www.example.com/login50";
     String tokenRefreshURL = "http://www.example.com/token50";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
     HttpResponse createResponse = makePutCall("provider/testprovider50", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -269,13 +322,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // param 'true' should succeed with 200 status code.
     loginURL = "http://www.example.com/login51";
     tokenRefreshURL = "http://www.example.com/token51";
-    request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            null,
-            null,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    request = createPutRequest(loginURL, tokenRefreshURL, null, null);
     createResponse = makePutCall("provider/testprovider50?reuse_client_credentials=true", request);
     Assert.assertEquals(200, createResponse.getResponseCode());
 
@@ -291,15 +338,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider
     String loginURL = "badurl";
     String tokenRefreshURL = "http://www.example.com/token";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -309,15 +348,7 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     // Attempt to create provider
     String loginURL = "http://www.example.com/token";
     String tokenRefreshURL = "badurl";
-    String clientId = "clientid";
-    String clientSecret = "clientsecret";
-    PutOAuthProviderRequest request = new PutOAuthProviderRequest(
-            loginURL,
-            tokenRefreshURL,
-            clientId,
-            clientSecret,
-            OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
-            null, null);
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
     HttpResponse createResponse = makePutCall("provider/testprovider", request);
     Assert.assertEquals(400, createResponse.getResponseCode());
   }
@@ -325,6 +356,130 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
   @Test
   public void testGetAuthURLProviderDoesNotExist() throws IOException {
     HttpResponse getResponse = makeGetCall("provider/nonexistantprovider/authurl");
+    Assert.assertEquals(404, getResponse.getResponseCode());
+  }
+
+  private HttpResponse makeDeleteCall(String endpoint) throws IOException {
+    URL url = serviceURI
+        .resolve(String.format("v1/oauth/%s", endpoint))
+        .toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.DELETE, url).build();
+    return HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+  }
+
+  @Test
+  public void testGetOAuthCredentialStandardLongLivedToken() throws Exception {
+    String providerName = "testGetCredLongLived";
+    String credentialName = "cred3";
+
+    // Create provider
+    PutOAuthProviderRequest request = createPutRequest("http://localhost:8080/login",
+        "http://localhost:8080/token", "clientid", "clientsecret");
+    HttpResponse createResp = makePutCall("provider/" + providerName, request);
+    Assert.assertEquals(200, createResp.getResponseCode());
+
+    // Put an access token in the store (no refresh token).
+    // Standard flow will return this directly if present.
+    OAuthAccessToken accessToken = OAuthAccessToken.newBuilder()
+        .withAccessToken("long_lived_token")
+        .withExpiresAt(0L)
+        .build();
+    getSecureStoreManager().put("system",
+        "oauthaccesstoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(accessToken), "Test", Collections.emptyMap());
+
+    // Call GET credential endpoint
+    HttpResponse response = makeGetCall("provider/" + providerName +
+        "/credential/" + credentialName);
+
+    Assert.assertEquals(200, response.getResponseCode());
+    String body = response.getResponseBodyAsString();
+    Assert.assertTrue(body.contains("long_lived_token"));
+  }
+
+  @Test
+  public void testGetOAuthCredentialStandard() throws Exception {
+    String providerName = "testGetCredStd";
+    String credentialName = "cred2";
+
+    // Create provider (default is STANDARD refresh type)
+    PutOAuthProviderRequest request = createPutRequest("http://localhost:" + mockTokenPort + "/login",
+        mockTokenUrl, "clientid", "clientsecret");
+    HttpResponse createResp = makePutCall("provider/" + providerName, request);
+    Assert.assertEquals(200, createResp.getResponseCode());
+
+    // Put a refresh token so the refresh can happen
+    OAuthRefreshToken refreshToken =
+        new OAuthRefreshToken("valid_refresh_token", "http://redirect");
+    getSecureStoreManager().put("system",
+        "oauthrefreshtoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(refreshToken), "Test", Collections.emptyMap());
+
+    // Call GET credential endpoint
+    HttpResponse response = makeGetCall("provider/" + providerName +
+        "/credential/" + credentialName);
+
+    Assert.assertEquals(200, response.getResponseCode());
+    String body = response.getResponseBodyAsString();
+    Assert.assertTrue(body.contains("mock_access_token"));
+  }
+
+  @Test
+  public void testGetOAuthCredentialValidityTokenRefresh() throws Exception {
+    String providerName = "testRefresh";
+    String credentialName = "cred1";
+
+    // Create provider
+    PutOAuthProviderRequest request = createPutRequest("http://localhost:" + mockTokenPort + "/login",
+        mockTokenUrl, "clientid", "clientsecret");
+    HttpResponse createResp = makePutCall("provider/" + providerName, request);
+    Assert.assertEquals("Create provider failed: " + createResp.getResponseBodyAsString(),
+        200, createResp.getResponseCode());
+
+    // Put EXPIRED token in SecureStore
+    // Note: we use "system" namespace and specific key formats that OAuthStore expects.
+    long expiredTime = System.currentTimeMillis() - 1000000L;
+    OAuthAccessToken expiredToken = OAuthAccessToken.newBuilder()
+        .withAccessToken("expired_token")
+        .withExpiresAt(expiredTime)
+        .build();
+
+    getSecureStoreManager().put("system",
+        "oauthaccesstoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(expiredToken), "RTR Test", Collections.emptyMap());
+
+    // Also put a refresh token so the refresh can happen
+    OAuthRefreshToken refreshToken =
+        new OAuthRefreshToken("valid_refresh_token", "http://redirect");
+    getSecureStoreManager().put("system",
+        "oauthrefreshtoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(refreshToken), "RTR Test", Collections.emptyMap());
+
+    // Call validity endpoint. This will find the expired token and try to refresh it using the tokenUrl!
+    HttpResponse response = makeGetCall("provider/" + providerName +
+        "/credential/" + credentialName + "/valid");
+
+    // Should succeed and return true
+    Assert.assertEquals(200, response.getResponseCode());
+    String body = response.getResponseBodyAsString();
+    Assert.assertTrue(body.replaceAll("\\s+", "").contains("\"isValid\":true"));
+  }
+
+  @Test
+  public void testDeleteProvider() throws IOException {
+    // Attempt to create provider
+    String loginURL = "http://www.example.com/login_del";
+    String tokenRefreshURL = "http://www.example.com/token_del";
+    PutOAuthProviderRequest request = createPutRequest(loginURL, tokenRefreshURL, "clientid", "clientsecret");
+    HttpResponse createResponse = makePutCall("provider/testprovider_del", request);
+    Assert.assertEquals(200, createResponse.getResponseCode());
+
+    // Attempt to delete provider
+    HttpResponse deleteResponse = makeDeleteCall("provider/testprovider_del");
+    Assert.assertEquals(200, deleteResponse.getResponseCode());
+
+    // Verify it's gone
+    HttpResponse getResponse = makeGetCall("provider/testprovider_del/authurl");
     Assert.assertEquals(404, getResponse.getResponseCode());
   }
 
@@ -352,4 +507,42 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
     return HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
   }
 
+  @Test
+  public void testGetOAuthCredentialRTR() throws Exception {
+    String providerName = "testGetCredRtr";
+    String credentialName = "cred1";
+
+    // Create provider with RTR refresh type
+    PutOAuthProviderRequest request = createPutRequest("http://localhost:" + mockTokenPort + "/login",
+        mockTokenUrl, "clientid", "clientsecret", OAuthProvider.CredentialEncodingStrategy.FORM_BODY,
+        null, AuthType.STANDARD, RefreshType.RTR);
+    HttpResponse createResp = makePutCall("provider/" + providerName, request);
+    Assert.assertEquals("Create provider failed: " + createResp.getResponseBodyAsString(),
+        200, createResp.getResponseCode());
+
+    // Put an EXPIRED access token so it forces a refresh
+    long expiredTime = System.currentTimeMillis() - 1000000L;
+    OAuthAccessToken expiredToken = OAuthAccessToken.newBuilder()
+        .withAccessToken("expired_token")
+        .withExpiresAt(expiredTime)
+        .build();
+    getSecureStoreManager().put("system",
+        "oauthaccesstoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(expiredToken), "RTR Test", Collections.emptyMap());
+
+    // Put a valid refresh token
+    OAuthRefreshToken refreshToken = new OAuthRefreshToken("valid_refresh_token", "http://redirect");
+    getSecureStoreManager().put("system",
+        "oauthrefreshtoken-" + providerName.toLowerCase() + "-" + credentialName.toLowerCase(),
+        GSON.toJson(refreshToken), "Test", Collections.emptyMap());
+
+    // Call GET credential endpoint
+    HttpResponse response = makeGetCall("provider/" + providerName +
+        "/credential/" + credentialName);
+
+    Assert.assertEquals("Get credential failed: " + response.getResponseBodyAsString(),
+        200, response.getResponseCode());
+    String body = response.getResponseBodyAsString();
+    Assert.assertTrue(body.contains("mock_access_token"));
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthStoreTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthStoreTest.java
@@ -25,6 +25,8 @@ import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.datapipeline.oauth.OAuthAccessToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthProvider;
+import io.cdap.cdap.datapipeline.oauth.AuthType;
+import io.cdap.cdap.datapipeline.oauth.RefreshType;
 import io.cdap.cdap.datapipeline.oauth.OAuthRefreshToken;
 import io.cdap.cdap.datapipeline.oauth.OAuthStore;
 import io.cdap.cdap.datapipeline.oauth.OAuthStoreException;
@@ -37,6 +39,7 @@ import io.cdap.cdap.spi.data.transaction.TxRunnable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
@@ -99,6 +102,39 @@ public class OAuthStoreTest {
     assertTrue(provider.isPresent());
     assertEquals(provider.get().getCredentialEncodingStrategy(),
         OAuthProvider.CredentialEncodingStrategy.FORM_BODY);
+    assertEquals(provider.get().getAuthType(), AuthType.STANDARD);
+    assertEquals(provider.get().getRefreshType(), RefreshType.STANDARD);
+  }
+
+  @Test
+  public void testGetProviderWithRefreshTokenRotationOAuthType() throws Exception {
+    String clientCredsJson = "{\"clientId\":\"test-client\",\"clientSecret\":\"test-secret\"}";
+    when(mockSecureStore.getData(any(), any())).thenReturn(
+        clientCredsJson.getBytes(StandardCharsets.UTF_8));
+
+    doAnswer(invocation -> {
+      TxRunnable runnable = invocation.getArgument(0);
+      StructuredTableContext mockContext = mock(StructuredTableContext.class);
+      when(mockContext.getTable(any())).thenReturn(mockTable);
+      runnable.run(mockContext);
+      return null;
+    }).when(mockTransactionRunner).run(any(TxRunnable.class));
+
+    when(mockRow.getString("oauthprovider")).thenReturn(PROVIDER_NAME);
+    when(mockRow.getString("loginurl")).thenReturn(LOGIN_URL);
+    when(mockRow.getString("tokenrefreshurl")).thenReturn(TOKEN_REFRESH_URL);
+    when(mockRow.getString("credentialencodingstrategy")).thenReturn("FORM_BODY");
+    when(mockRow.getString("useragent")).thenReturn(USER_AGENT);
+    when(mockRow.getString("refreshtype")).thenReturn("RTR");
+    when(mockRow.getString("authtype")).thenReturn("PKCE");
+
+    when(mockTable.read(any())).thenReturn(Optional.of(mockRow));
+
+    Optional<OAuthProvider> provider = oauthStore.getProvider(PROVIDER_NAME);
+
+    assertTrue(provider.isPresent());
+    assertEquals(provider.get().getAuthType(), AuthType.PKCE);
+    assertEquals(provider.get().getRefreshType(), RefreshType.RTR);
   }
 
   @Test
@@ -197,5 +233,16 @@ public class OAuthStoreTest {
     }
     verify(mockSecureStoreManager, times(1)).delete(any(), any());
     verify(mockTable, times(0)).delete(any());
+  }
+
+  @Test
+  public void testAcquireAndReleaseSecretLease() throws Exception {
+    when(mockSecureStoreManager.acquireLease(anyString(), anyString(), anyLong(), anyString()))
+        .thenReturn(true);
+
+    assertTrue(oauthStore.acquireLease(PROVIDER_NAME, "cred-1", 30000L, "worker-1"));
+
+    oauthStore.releaseLease(PROVIDER_NAME, "cred-1", "worker-1");
+    verify(mockSecureStoreManager, times(1)).releaseLease(anyString(), anyString(), eq("worker-1"));
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5201,6 +5201,42 @@
     </description>
   </property>
 
+  <property>
+    <name>security.auth.oauth.rtr.access.token.refresh.buffer.ms</name>
+    <value>600000</value>
+    <description>
+      Time buffer in milliseconds before an OAuth 2.0 access token's official expiration time to
+      trigger a proactive refresh. This margin of safety ensures active pipeline runs and API calls
+      do not fail due to mid-flight token expiration.
+    </description>
+  </property>
+  <property>
+    <name>security.auth.oauth.rtr.refresh.wait.timeout.ms</name>
+    <value>100000</value>
+    <description>
+      Maximum duration in milliseconds a worker thread will block and wait for a new access token
+      when a concurrent refresh is already in progress by another worker. If this timeout is exceeded,
+      the thread attempts to acquire the lease and execute the refresh itself as a fallback.
+    </description>
+  </property>
+  <property>
+    <name>security.auth.oauth.rtr.refresh.poll.interval.ms</name>
+    <value>500</value>
+    <description>
+      Time interval in milliseconds between successive polling attempts while waiting for a concurrent
+      token refresh to complete and publish a new access token into the Secure Store.
+    </description>
+  </property>
+  <property>
+    <name>security.auth.oauth.rtr.lease.ttl.ms</name>
+    <value>90000</value>
+    <description>
+      Time-To-Live (TTL) in milliseconds for the distributed token refresh lease in the Secure Store.
+      If the active lease holder fails or crashes without releasing the lease,
+      the lease automatically expires after this duration to prevent deadlocks and allow other workers to recover.
+    </description>
+  </property>
+
   <!-- UI Configuration -->
 
   <property>


### PR DESCRIPTION
This PR introduces support for **Refresh Token Rotation (RTR)** within the CDAP OAuth token management flow. To ensure safe token rotation in a distributed environment, it leverages distributed leasing/locking via `SecureStoreManager` to prevent race conditions where multiple pipeline workers might attempt to concurrently rotate the same refresh token.

**Key Changes:**
- **RTR Configuration:** Introduced `RefreshType` (with `STANDARD` and `RTR` support) to `OAuthProvider` and `PutOAuthProviderRequest`.
- **Concurrency Control:** Updated `OAuthHandler` to utilize distributed leases (`acquireLease` / `releaseLease` via `OAuthStore`) when fetching access tokens. This prevents concurrent token refreshes across multiple worker instances from invalidating each other.
- **Polling & Recovery:** Added polling mechanisms to `OAuthHandler` so instances blocked by a lock wait for the active worker to finish the refresh and then fetch the newly rotated access token.
- **State Persistence:** Updated `OAuthStore` to persist the new `RefreshType` and handle the new lease states.
- **Configurability:** Added new properties to `cdap-default.xml` for fine-tuning RTR behavior:
  - `security.auth.oauth.rtr.access.token.refresh.buffer.ms`
  - `security.auth.oauth.rtr.refresh.wait.timeout.ms`
  - `security.auth.oauth.rtr.refresh.poll.interval.ms`
  - `security.auth.oauth.rtr.lease.ttl.ms`
- **Testing:** Updated `OAuthStoreTest` to mock and validate the new leasing implementation and token deserialization logic.


Here is a clean, comprehensive **Testing Scenarios and Results** markdown block ready to copy and paste directly into your PR description:

---

## Testing Scenarios and Results

### 1. Test Summary
End-to-end verification was conducted on a live distributed Kubernetes CDAP cluster with GCP Secret Manager (`cdf-test-317207`) backing the secure store and distributed leasing. Testing covered both standard legacy OAuth 2.0 flows and Refresh Token Rotation (RTR) under concurrent load, token expiry, revocation, and failure conditions.

---

### 2. Test Matrix

| # | Test Scenario | Description / Input | Expected Behavior | Observed Result | Status |
|---|---|---|---|---|:---:|
| **1** | **Standard Flow (Backward Compatibility)** | Provider with `refreshType: STANDARD`. IdP returns new `access_token` and **omits** `refresh_token`. | Existing refresh token in GCP Secret Manager is preserved and not overwritten. | `200 OK`. GCP Secret Manager retained original `initial_v1` refresh token. | **PASSED** |
| **2** | **Standard Flow (Silent RTR)** | Provider with `refreshType: STANDARD`. IdP dynamically rotates and returns a new `refresh_token`. | CDAP automatically detects new refresh token and updates GCP Secret Manager. | `200 OK`. GCP Secret Manager was seamlessly updated to `standard_rotated_from_initial_v1`. | **PASSED** |
| **3** | **RTR Happy Path & Caching** | Provider with `refreshType: RTR`. Initial GET call followed by immediate subsequent GET call. | 1st call rotates refresh token & caches access token in Secret Manager; 2nd call serves directly from cache without hitting IdP. | `200 OK`. 1st call updated Secret Manager (`expiresAt: 1788379096207`). 2nd call served from cache; IdP received 0 additional requests. | **PASSED** |
| **4** | **Missing Expiration (`expires_in: null/0`)** | RTR refresh response does not specify `expires_in`. | Fallback validation path is executed without throwing exceptions or corrupting state. | `200 OK`. Refresh token rotated successfully and access token handled safely. | **PASSED** |
| **5** | **Revoked Refresh Token (401 Handling & Lease Release)** | IdP returns `401 Unauthorized` (`invalid_grant` / revoked token). | CDAP surfaces 401 error and releases distributed lease lock in Secret Manager cleanly. | `401 Unauthorized` returned to client. Secret Manager annotation `lease_state` cleanly reverted to `idle`. | **PASSED** |
| **6** | **Thundering Herd / High Concurrency** | 10 concurrent requests sent simultaneously during slow IdP response latency (simulated distributed race condition). | Only 1 request acquires lease and calls IdP; remaining 9 requests wait and read published token from cache. Single-use refresh token is never reused. | 10/10 requests succeeded with identical token. IdP received exactly **1 refresh request**, proving distributed synchronization. | **PASSED** |


---

