### PR TITLE
Fix duplicated word and typo in user-guide tutorials

### DIFF
--- a/cdap-docs/user-guide/source/data-preparation/concepts.rst
+++ b/cdap-docs/user-guide/source/data-preparation/concepts.rst
@@ -59,7 +59,7 @@ Record
 
 A record in this documentation will be shown as a JSON object with an
 object key representing the column names and a value shown by the plain
-representation of the the data, without any mention of types.
+representation of the data, without any mention of types.
 
 For example:
 

--- a/cdap-docs/user-guide/source/tutorials/campaign.rst
+++ b/cdap-docs/user-guide/source/tutorials/campaign.rst
@@ -108,7 +108,7 @@ The directive is in the form ``table-lookup <column> <table>``. ``column`` in th
 
 You will see a new column, ``state_abbreviation``, appear. 
 
-Directives entered into the command prompt at the bottom of the screen are applied in the same way as directives applied through each columns' drop-down menu. In fact, when you select a filter, for example, from a drop down menu, Data Preparation automatically generates and applies the equivalent directive. You can see this by selecting ``Directives`` in the right-hand sidebar. Clicking "x" next to a directive removes the corresponding transformation.
+Directives entered into the command prompt at the bottom of the screen are applied in the same way as directives applied through each column's drop-down menu. In fact, when you select a filter, for example, from a drop down menu, Data Preparation automatically generates and applies the equivalent directive. You can see this by selecting ``Directives`` in the right-hand sidebar. Clicking "x" next to a directive removes the corresponding transformation.
 
 Since you no longer need the full state name, you can delete this column. Select the caret to the left of ``state``, and choose the ``Delete Column`` option. Further, you can rename ``state_abbreviation``. Double-click the column name, and the text will become editable. Replace it with "State."
 
@@ -138,7 +138,7 @@ This task is not as simple as it may seem at first. For states, you could simply
 
 This means you cannot simply filter that requires the column to be equal to the word "Avenue." 
 
-To work around this, we will use the ``Contains`` features. Select the caret in the address column, and choose ``Filter`` and ``Keep Value if Contains``. Enter ``Avenue``. Also, choose ``ignore case``. Apply the filter. Simple!
+To work around this, we will use the ``Contains`` feature. Select the caret in the address column, and choose ``Filter`` and ``Keep Value if Contains``. Enter ``Avenue``. Also, choose ``ignore case``. Apply the filter. Simple!
 
 .. figure:: /_images/tutorials/address/address_street_type.jpeg
   :figwidth: 100%

--- a/cdap-docs/user-guide/source/tutorials/campaign.rst
+++ b/cdap-docs/user-guide/source/tutorials/campaign.rst
@@ -108,7 +108,7 @@ The directive is in the form ``table-lookup <column> <table>``. ``column`` in th
 
 You will see a new column, ``state_abbreviation``, appear. 
 
-Directives entered into the the command prompt at the bottom of the screen are applied in the same way as directives applied through each columns' drop-down menu. In fact, when you select a filter, for example, from a drop down menu, Data Preparation automatically generates and applies the equivalent directive. You can see this by selecting ``Directives`` in the right-hand sidebar. Clicking "x" next to a directive removes the correpsonding transformation.
+Directives entered into the command prompt at the bottom of the screen are applied in the same way as directives applied through each columns' drop-down menu. In fact, when you select a filter, for example, from a drop down menu, Data Preparation automatically generates and applies the equivalent directive. You can see this by selecting ``Directives`` in the right-hand sidebar. Clicking "x" next to a directive removes the corresponding transformation.
 
 Since you no longer need the full state name, you can delete this column. Select the caret to the left of ``state``, and choose the ``Delete Column`` option. Further, you can rename ``state_abbreviation``. Double-click the column name, and the text will become editable. Replace it with "State."
 
@@ -138,7 +138,7 @@ This task is not as simple as it may seem at first. For states, you could simply
 
 This means you cannot simply filter that requires the column to be equal to the word "Avenue." 
 
-To work around this, we will use the the ``Contains`` features. Select the caret in the address column, and choose ``Filter`` and ``Keep Value if Contains``. Enter ``Avenue``. Also, choose ``ignore case``. Apply the filter. Simple!
+To work around this, we will use the ``Contains`` features. Select the caret in the address column, and choose ``Filter`` and ``Keep Value if Contains``. Enter ``Avenue``. Also, choose ``ignore case``. Apply the filter. Simple!
 
 .. figure:: /_images/tutorials/address/address_street_type.jpeg
   :figwidth: 100%

--- a/cdap-docs/user-guide/source/tutorials/nytimes-xml.rst
+++ b/cdap-docs/user-guide/source/tutorials/nytimes-xml.rst
@@ -17,7 +17,7 @@ This tutorial demonstrates how to use CDAP's Data Preparation and Data Pipelines
 
 Scenario
 ---------
-Your organization, a multinational enterprise with holdings across several continents, is interested in monitoring RSS XML data feeds from many different news sites, such as the the New York Times. You want to route stories about different regions to the relevant analysts.
+Your organization, a multinational enterprise with holdings across several continents, is interested in monitoring RSS XML data feeds from many different news sites, such as the New York Times. You want to route stories about different regions to the relevant analysts.
 
 - You want stories about Brazil to be written to dataset (that is displayed via a webapp) to the Latin America analysts
 

--- a/cdap-docs/user-guide/source/tutorials/stocks.rst
+++ b/cdap-docs/user-guide/source/tutorials/stocks.rst
@@ -182,7 +182,7 @@ In the "Plugins" section, choose "Top-N."
 	:align: center
 	:class: bordered-image
 
-Deploy the Top-N application. Save your pipeline - giving it the name "StockPipeline" - and refresh the page. You will see the Top-N plugin appear in the Analytics section of the the plugin menu on the left side of your screen.
+Deploy the Top-N application. Save your pipeline - giving it the name "StockPipeline" - and refresh the page. You will see the Top-N plugin appear in the Analytics section of the plugin menu on the left side of your screen.
 
 Add a Top-N node to the canvas, as well as a Avro Time Partitioned Dataset sink.
 


### PR DESCRIPTION
Minor documentation fixes in the user guide:

- Remove repeated "the the" in the NY Times XML, stocks, and campaign tutorials, and in the data-preparation concepts page.
- Correct "correpsonding" -> "corresponding" in the campaign tutorial.

Docs-only change, no functional impact.